### PR TITLE
feat: daily bucket for `lendingSupply`

### DIFF
--- a/apps/indexer/src/lib/event-handlers.ts
+++ b/apps/indexer/src/lib/event-handlers.ts
@@ -19,7 +19,14 @@ import {
   daoMetricsDayBuckets,
   token,
 } from "ponder:schema";
-import { addressZero, LendingAddresses, MetricTypes, secondsInDay } from "./constants";
+import {
+  addressZero,
+  CEXAddresses,
+  DEXAddresses,
+  LendingAddresses,
+  MetricTypes,
+  secondsInDay,
+} from "./constants";
 
 export const delegateChanged = async (
   event: // | Event<"ENSToken:DelegateChanged">
@@ -183,7 +190,7 @@ export const tokenTransfer = async (
     daoId,
   );
 
-  const { from, to } = event.args
+  const { from, to } = event.args;
 
   //Inserting delegate account if didn't exist
   await context.db
@@ -244,32 +251,86 @@ export const tokenTransfer = async (
     .onConflictDoUpdate((current) => ({
       balance: (current.balance ?? BigInt(0)) + BigInt(value),
     }));
-  
-  const currentLendingSupply = ( await context.db
-    .find(token, { id: event.log.address }))!.lendingSupply
 
-    const lendingAddressList = Object.values(LendingAddresses);
-    const isLendingTransaction = lendingAddressList.includes(to) || lendingAddressList.includes(from);
-    
-    if (isLendingTransaction) {
-      const isToLendingPool = lendingAddressList.includes(to);
-      const newLendingSupply = (await context.db
-        .update(token, { id: event.log.address })
-        .set((row) => ({
-          lendingSupply: isToLendingPool
-            ? row.lendingSupply + value
-            : row.lendingSupply - value
-        }))).lendingSupply;
-    
-      await storeDailyBucket(
-        context,
-        event,
-        daoId,
-        MetricTypes.LENDING_SUPPLY,
-        currentLendingSupply,
-        newLendingSupply,
-      );
-    }
+  const currentLendingSupply = (await context.db.find(token, {
+    id: event.log.address,
+  }))!.lendingSupply;
+
+  const lendingAddressList = Object.values(LendingAddresses);
+  const isLendingTransaction =
+    lendingAddressList.includes(to) || lendingAddressList.includes(from);
+
+  if (isLendingTransaction) {
+    const isToLendingPool = lendingAddressList.includes(to);
+    const newLendingSupply = (
+      await context.db.update(token, { id: event.log.address }).set((row) => ({
+        lendingSupply: isToLendingPool
+          ? row.lendingSupply + value
+          : row.lendingSupply - value,
+      }))
+    ).lendingSupply;
+
+    await storeDailyBucket(
+      context,
+      event,
+      daoId,
+      MetricTypes.LENDING_SUPPLY,
+      currentLendingSupply,
+      newLendingSupply,
+    );
+  }
+
+  const currentCexSupply = (await context.db.find(token, {
+    id: event.log.address,
+  }))!.cexSupply;
+
+  const cexAddressList = Object.values(CEXAddresses);
+  const isCexTransaction =
+    cexAddressList.includes(to) || cexAddressList.includes(from);
+
+  if (isCexTransaction) {
+    const isToCex = cexAddressList.includes(to);
+    const newCexSupply = (
+      await context.db.update(token, { id: event.log.address }).set((row) => ({
+        cexSupply: isToCex ? row.cexSupply + value : row.cexSupply - value,
+      }))
+    ).cexSupply;
+
+    await storeDailyBucket(
+      context,
+      event,
+      daoId,
+      MetricTypes.CEX_SUPPLY,
+      currentCexSupply,
+      newCexSupply,
+    );
+  }
+
+  const currentDexSupply = (await context.db.find(token, {
+    id: event.log.address,
+  }))!.dexSupply;
+
+  const dexAddressList = Object.values(DEXAddresses);
+  const isDexTransaction =
+    dexAddressList.includes(to) || dexAddressList.includes(from);
+
+  if (isDexTransaction) {
+    const isToDex = dexAddressList.includes(to);
+    const newDexSupply = (
+      await context.db.update(token, { id: event.log.address }).set((row) => ({
+        dexSupply: isToDex ? row.dexSupply + value : row.dexSupply - value,
+      }))
+    ).dexSupply;
+
+    await storeDailyBucket(
+      context,
+      event,
+      daoId,
+      MetricTypes.DEX_SUPPLY,
+      currentDexSupply,
+      newDexSupply,
+    );
+  }
 };
 
 export const voteCast = async (


### PR DESCRIPTION
## Feature Request
### Feature Description
Track LENDING_SUPPLY metric in dao_metrics_day_buckets by monitoring token transfers to/from lending pool addresses.

### Implementation Details
1. Monitor Transfer events:
   - From: user → lending pool (supply increase)
   - From: lending pool → user (supply decrease)

2. Implementation:
```typescript
// Track transfer event
const newLendingSupply = isToLendingPool ? 
  currentLendingSupply + amount : 
  currentLendingSupply - amount;

await storeDailyBucket(
  context,
  event,
  daoId,
  MetricTypes.LENDING_SUPPLY,
  currentLendingSupply,
  newLendingSupply
);
```

### Testing
- Test transfers to/from lending pool addresses
- Verify daily bucket OHLC calculations
- Validate supply tracking accuracy

### Acceptance Criteria
- [ ] Track token transfers with lending pools
- [ ] Update lending supply on transfers
- [ ] Correctly calculate daily metrics
- [ ] Handle multiple lending pools if needed