### PR TITLE
feat: daily bucket for `circulatingsupply`

### DIFF
--- a/apps/indexer/src/lib/event-handlers.ts
+++ b/apps/indexer/src/lib/event-handlers.ts
@@ -380,6 +380,29 @@ export const tokenTransfer = async (
       newTotalSupply,
     );
   }
+
+  const currentCirculatingSupply = (await context.db.find(token, {
+    id: event.log.address,
+  }))!.circulatingSupply;
+
+  const isCirculatingSupplyTransaction = isTotalSupplyTransaction || isTreasuryTransaction
+
+  if (isCirculatingSupplyTransaction) {
+    const newCirculatingSupply = (
+      await context.db.update(token, { id: event.log.address }).set((row) => ({
+        circulatingSupply: row.totalSupply - row.treasury,
+      }))
+    ).circulatingSupply;
+
+    await storeDailyBucket(
+      context,
+      event,
+      daoId,
+      MetricTypesEnum.CIRCULATING_SUPPLY,
+      currentCirculatingSupply,
+      newCirculatingSupply,
+    );
+  }
 };
 
 export const voteCast = async (


### PR DESCRIPTION
## Feature Request
### Feature Description
Track CIRCULATING_SUPPLY metric in dao_metrics_day_buckets by calculating available tokens in circulation, excluding treasury and inaccessible tokens.

### Implementation Details
1. Calculate Circulating Supply:
   ```
   Circulating Supply = Total Supply - Treasury Holdings
   ```

2. Implementation:
```typescript
const newCirculatingSupply = (await context.db
  .update(token, { id: event.log.address })
  .set((row) => ({
    circulatingSupply: row.totalSupply - row.treasury
  }))).circulatingSupply;

await storeDailyBucket(
  context,
  event,
  daoId,
  MetricTypes.CIRCULATING_SUPPLY,
  currentCirculatingSupply,
  newCirculatingSupply
);
```

3. Update on:
   - Total Supply changes (mints/burns)
   - Treasury balance changes

### Testing
- Test calculation on mint events
- Test calculation on burn events
- Test calculation on treasury transfers
- Verify daily bucket calculations

### Acceptance Criteria
- [ ] Update when Total Supply changes
- [ ] Update when Treasury balance changes
- [ ] Calculate correct daily metrics
- [ ] Handle boundary conditions (totalSupply < treasury)