### PR TITLE
hotfix: get voting power from getVotes

### DIFF
--- a/apps/petition/src/client/votingPower.ts
+++ b/apps/petition/src/client/votingPower.ts
@@ -12,8 +12,8 @@ export default class VotingPowerClient {
     })
     const calls = signers.map((signer) => ({
       address: this.getTokenAddress(daoId),
-      abi: parseAbi(["function balanceOf(address) returns (uint256)"]),
-      functionName: "balanceOf",
+      abi: parseAbi(["function getVotes(address) returns (uint256)"]),
+      functionName: "getVotes",
       args: [signer]
     }));
 


### PR DESCRIPTION
Petition voting power was being calculated from the `balanceOf` method instead of the `getVotes` from ERC20Votes