### PR TITLE
fix: adjust daily bucket metrics and truncate timestamp time

### DIFF
--- a/apps/indexer/src/eventHandlers/shared.ts
+++ b/apps/indexer/src/eventHandlers/shared.ts
@@ -42,14 +42,14 @@ export const storeDailyBucket = async (
   await context.db
     .insert(daoMetricsDayBucket)
     .values({
-      date,
+      date: truncateTimestampTime(date),
       tokenId: tokenAddress,
       metricType,
       daoId,
       average: newValue,
-      open: currentValue,
-      high: max(newValue, currentValue),
-      low: min(newValue, currentValue),
+      open: newValue,
+      high: newValue,
+      low: newValue,
       close: newValue,
       volume,
       count: 1,
@@ -63,4 +63,9 @@ export const storeDailyBucket = async (
       volume: row.volume + volume,
       count: row.count + 1,
     }));
+};
+
+const truncateTimestampTime = (timestampSeconds: bigint): bigint => {
+  const SECONDS_IN_DAY = BigInt(86400); // 24 * 60 * 60
+  return (timestampSeconds / SECONDS_IN_DAY) * SECONDS_IN_DAY;
 };


### PR DESCRIPTION
## Summary                                                    
                                                              
- Fix daily bucket metrics to use correct initial values (open/high/low should all start with the new value, not previous)                                                 
- Normalize timestamps to day boundaries (00:00:00 UTC) for consistent daily buckets -> this will force conflicts and update `high`, `close`, and `average` whenever 2 metrics are collected on the same day
                                                              
## Changes                                                 
                                                              
- Added `truncateTimestampTime()` to align timestamps to start of day                                              
- Fixed OHLC initialization for new daily bucket entries  