### PR TITLE
fix: sidebar active indicator sliding throw all the items

### DIFF
--- a/apps/dashboard/shared/contexts/DaoPageInteractionContext.tsx
+++ b/apps/dashboard/shared/contexts/DaoPageInteractionContext.tsx
@@ -1,18 +1,29 @@
 "use client";
 
-import { createContext, useState, useContext, ReactNode } from "react";
+import { createContext, useState, useContext, ReactNode, useRef } from "react";
 import { RiskAreaEnum } from "@/shared/types/enums/RiskArea";
 
 interface DaoPageInteractionContextType {
   activeRisk: RiskAreaEnum;
   setActiveRisk: (risk: RiskAreaEnum) => void;
   scrollToSection: (anchorId: string) => void;
+  activeSection: string | null;
+  updateActiveSection: (
+    section: string | null,
+    options?: {
+      source?: "programmatic" | "event";
+      immediate?: boolean;
+      end?: boolean;
+    },
+  ) => void;
 }
 
 const DaoPageInteractionContext = createContext<DaoPageInteractionContextType>({
   activeRisk: RiskAreaEnum.SPAM_VULNERABLE,
   setActiveRisk: () => {},
   scrollToSection: () => {},
+  activeSection: null,
+  updateActiveSection: () => {},
 });
 
 export const useDaoPageInteraction = () =>
@@ -26,9 +37,39 @@ export const DaoPageInteractionProvider = ({
   const [activeRisk, setActiveRisk] = useState<RiskAreaEnum>(
     RiskAreaEnum.SPAM_VULNERABLE,
   );
+  const [activeSection, setActiveSectionState] = useState<string | null>(null);
+  const isProgrammaticRef = useRef<boolean>(false);
+
+  const updateActiveSection: DaoPageInteractionContextType["updateActiveSection"] =
+    (section, options) => {
+      const source = options?.source;
+      const immediate = options?.immediate === true;
+      const end = options?.end === true;
+
+      if (source === "programmatic" && end) {
+        isProgrammaticRef.current = false;
+        return;
+      }
+
+      if (source === "programmatic") {
+        isProgrammaticRef.current = true;
+        setActiveSectionState(section);
+        return;
+      }
+
+      if (immediate) {
+        setActiveSectionState(section);
+        return;
+      }
+
+      if (isProgrammaticRef.current) {
+        return;
+      }
+
+      setActiveSectionState(section);
+    };
 
   const scrollToSection = (anchorId: string) => {
-    // Scroll to the specified section
     const section = document.getElementById(anchorId);
     if (section) {
       section.scrollIntoView({ behavior: "smooth" });
@@ -37,7 +78,13 @@ export const DaoPageInteractionProvider = ({
 
   return (
     <DaoPageInteractionContext.Provider
-      value={{ activeRisk, setActiveRisk, scrollToSection }}
+      value={{
+        activeRisk,
+        setActiveRisk,
+        scrollToSection,
+        activeSection,
+        updateActiveSection,
+      }}
     >
       {children}
     </DaoPageInteractionContext.Provider>

--- a/apps/dashboard/shared/hooks/useSectionObserver.tsx
+++ b/apps/dashboard/shared/hooks/useSectionObserver.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useRef } from "react";
+import { useDaoPageInteraction } from "@/shared/contexts/DaoPageInteractionContext";
 
 interface UseSectionObserverProps {
   initialSection?: string;
@@ -9,28 +10,23 @@ interface UseSectionObserverProps {
 }
 
 export const useSectionObserver = ({
-  initialSection,
   headerOffset = 0,
   useWindowScrollTo = false,
 }: UseSectionObserverProps) => {
-  const [activeSection, setActiveSection] = useState<string | null>(
-    initialSection ?? null,
-  );
-  const isScrollingRef = useRef<boolean>(false);
+  const { activeSection, updateActiveSection } = useDaoPageInteraction();
   const hasScrolledRef = useRef<boolean>(false);
 
   useEffect(() => {
     const handleSectionChange = (event: Event) => {
-      if (isScrollingRef.current) return;
       const customEvent = event as CustomEvent<string>;
-      setActiveSection(customEvent.detail);
+      updateActiveSection(customEvent.detail, { source: "event" });
     };
 
     window.addEventListener("sectionInView", handleSectionChange);
     return () => {
       window.removeEventListener("sectionInView", handleSectionChange);
     };
-  }, []);
+  }, [updateActiveSection]);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -45,8 +41,7 @@ export const useSectionObserver = ({
   }, []);
 
   const handleSectionClick = (sectionId: string) => {
-    isScrollingRef.current = true;
-    setActiveSection(sectionId);
+    updateActiveSection(sectionId, { source: "programmatic" });
 
     const section = document.getElementById(sectionId);
     if (section) {
@@ -67,9 +62,9 @@ export const useSectionObserver = ({
     }
 
     setTimeout(() => {
-      isScrollingRef.current = false;
+      updateActiveSection(activeSection, { source: "programmatic", end: true });
       hasScrolledRef.current = true;
-    }, 500);
+    }, 1000);
   };
 
   return { activeSection, handleSectionClick };


### PR DESCRIPTION
### **Summary** 
This PR fixes the sidebar active indicator that was sliding through all intermediate items when navigating between one item to another if the user clicks on it. The indicator now transitions directly to the selected item, keeping the on scroll change.

### **Changes**
Context

- `activeSection: string | null` state to track currently active sidebar section
- `updateActiveSection` method with options parameter for granular control:
- `source: "programmatic" | "event"` for distinguishes between user clicks and scroll events
- `immediate: boolean` forces immediate state updates when needed
- `end: boolean` signals end of programmatic navigation

### **Issue**
https://github.com/blockful/anticapture/issues/729#issue-3049044501

New behavior

https://github.com/user-attachments/assets/ee2b8c43-d303-4cf0-a00d-ac5dd5638c9b



Disclaimer: I chose this approach trying to avoid overuse props on the context, but I'll be very happy to reimplement it differently if that would better suit the project's conventions! Awesome project btw 🫡
