### PR TITLE
add: chainId on dao structure

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -122,6 +122,7 @@ type dao {
   votingDelay: BigInt!
   votingPeriod: BigInt!
   timelockDelay: BigInt!
+  chainId: Int!
 }
 
 type daoPage {

--- a/apps/indexer/ponder.schema.ts
+++ b/apps/indexer/ponder.schema.ts
@@ -15,6 +15,7 @@ export const dao = onchainTable("dao", (drizzle) => ({
   votingDelay: drizzle.bigint("voting_delay").notNull().default(0n),
   votingPeriod: drizzle.bigint("voting_period").notNull().default(0n),
   timelockDelay: drizzle.bigint("timelock_delay").notNull().default(0n),
+  chainId: drizzle.integer("chain_id").notNull(),
 }));
 
 export const token = onchainTable("token", (drizzle) => ({

--- a/apps/indexer/src/indexer/ens/governor.ts
+++ b/apps/indexer/src/indexer/ens/governor.ts
@@ -9,6 +9,7 @@ import { DaoIdEnum } from "@/lib/enums";
 import { DAOClient } from "@/interfaces/client";
 import { dao } from "ponder:schema";
 import { ProposalStatus } from "@/lib/constants";
+import { env } from "@/env";
 
 export function GovernorIndexer(client: DAOClient, blockTime: number) {
   const daoId = DaoIdEnum.ENS;
@@ -35,6 +36,7 @@ export function GovernorIndexer(client: DAOClient, blockTime: number) {
       votingDelay,
       timelockDelay,
       proposalThreshold,
+      chainId: env.CHAIN_ID,
     });
   });
 

--- a/apps/indexer/src/indexer/gtc/governor.ts
+++ b/apps/indexer/src/indexer/gtc/governor.ts
@@ -9,6 +9,7 @@ import { DaoIdEnum } from "@/lib/enums";
 import { DAOClient } from "@/interfaces/client";
 import { dao } from "ponder:schema";
 import { ProposalStatus } from "@/lib/constants";
+import { env } from "@/env";
 
 export function GovernorIndexer(client: DAOClient, blockTime: number) {
   const daoId = DaoIdEnum.GTC;
@@ -35,6 +36,7 @@ export function GovernorIndexer(client: DAOClient, blockTime: number) {
       votingDelay,
       timelockDelay,
       proposalThreshold,
+      chainId: env.CHAIN_ID,
     });
   });
 
@@ -42,7 +44,7 @@ export function GovernorIndexer(client: DAOClient, blockTime: number) {
     await voteCast(context, daoId, {
       proposalId: event.args.proposalId.toString(),
       voter: event.args.voter,
-      reason: event.reason,
+      reason: event.args.reason,
       support: event.args.support ? 1 : 0,
       timestamp: event.block.timestamp,
       txHash: event.transaction.hash,

--- a/apps/indexer/src/indexer/op/governor.ts
+++ b/apps/indexer/src/indexer/op/governor.ts
@@ -9,6 +9,7 @@ import { DaoIdEnum } from "@/lib/enums";
 import { DAOClient } from "@/interfaces/client";
 import { dao } from "ponder:schema";
 import { ProposalStatus } from "@/lib/constants";
+import { env } from "@/env";
 
 export function GovernorIndexer(client: DAOClient, blockTime: number) {
   const daoId = DaoIdEnum.OP;
@@ -35,6 +36,7 @@ export function GovernorIndexer(client: DAOClient, blockTime: number) {
       votingDelay,
       timelockDelay,
       proposalThreshold,
+      chainId: env.CHAIN_ID,
     });
   });
 

--- a/apps/indexer/src/indexer/uni/governor.ts
+++ b/apps/indexer/src/indexer/uni/governor.ts
@@ -9,6 +9,7 @@ import {
 import { DaoIdEnum } from "@/lib/enums";
 import { DAOClient } from "@/interfaces/client";
 import { ProposalStatus } from "@/lib/constants";
+import { env } from "@/env";
 
 export function GovernorIndexer(client: DAOClient, blockTime: number) {
   const daoId = DaoIdEnum.UNI;
@@ -35,6 +36,7 @@ export function GovernorIndexer(client: DAOClient, blockTime: number) {
       votingDelay,
       timelockDelay,
       proposalThreshold,
+      chainId: env.CHAIN_ID,
     });
   });
 


### PR DESCRIPTION
### Description
This PR adds a `chainId` field to the DAO GraphQL type, enabling the notification system and other consumers to construct proper blockchain explorer URLs based on the DAO's chain.

### Problem
The notification system currently sends messages containing transaction hashes when voting power changes occur, but lacks the ability to generate clickable blockchain explorer links. This is because each DAO operates on a different blockchain (Ethereum, Optimism, Arbitrum), and without knowing which chain a DAO is deployed on, it's impossible to construct the correct explorer URL.

### Solution
We've added a `chainId` field to the DAO schema that leverages the existing `env.CHAIN_ID` configuration from each indexer deployment. This provides a standardized way to identify the blockchain for each DAO. Ethereum-based DAOs (UNI, ENS, GTC) will return chainId 1, Optimism (OP) returns chainId 10, and Arbitrum (ARB) returns chainId 42161.

### Changes
- **Schema**: Added `chainId: integer` to DAO table schema
- **Indexers**: Updated all governor indexers to populate `chainId` from `env.CHAIN_ID`
- **ARB Special Case**: Created DAO record for Arbitrum (which lacks a governor contract)
- **API Gateway**: Updated GraphQL schema to expose the new field

### Testing
The changes have been tested locally using the ENS indexer with a local PostgreSQL instance. GraphQL queries successfully return the chainId field with the correct value, and TypeScript compilation passes without errors.