### PR TITLE
bug: address conversion

### DIFF
--- a/apps/indexer/src/eventHandlers/metrics/supply.ts
+++ b/apps/indexer/src/eventHandlers/metrics/supply.ts
@@ -17,7 +17,7 @@ export const updateSupplyMetric = async (
   tokenAddress: Address,
   timestamp: bigint,
 ) => {
-  const normalizedAddressList = addressList.map(getAddress);
+  const normalizedAddressList = addressList.map((a) => getAddress(a));
   const isToRelevant = normalizedAddressList.includes(getAddress(to));
   const isFromRelevant = normalizedAddressList.includes(getAddress(from));
 

--- a/apps/indexer/src/eventHandlers/metrics/total.ts
+++ b/apps/indexer/src/eventHandlers/metrics/total.ts
@@ -17,7 +17,7 @@ export const updateTotalSupply = async (
   tokenAddress: Address,
   timestamp: bigint,
 ) => {
-  const normalizedAddressList = addressList.map(getAddress);
+  const normalizedAddressList = addressList.map((a) => getAddress(a));
   const isToBurningAddress = normalizedAddressList.includes(getAddress(to));
   const isFromBurningAddress = normalizedAddressList.includes(getAddress(from));
   const isTotalSupplyTransaction =

--- a/apps/indexer/src/eventHandlers/shared.ts
+++ b/apps/indexer/src/eventHandlers/shared.ts
@@ -135,11 +135,11 @@ export const handleTransaction = async (
     timestamp,
   );
 
-  const normalizedAddresses = addresses.map(getAddress);
-  const normalizedCex = cex.map(getAddress);
-  const normalizedDex = dex.map(getAddress);
-  const normalizedLending = lending.map(getAddress);
-  const normalizedBurning = burning.map(getAddress);
+  const normalizedAddresses = addresses.map((a) => getAddress(a));
+  const normalizedCex = cex.map((a) => getAddress(a));
+  const normalizedDex = dex.map((a) => getAddress(a));
+  const normalizedLending = lending.map((a) => getAddress(a));
+  const normalizedBurning = burning.map((a) => getAddress(a));
 
   await updateTransactionFlags(
     context,

--- a/apps/indexer/src/eventHandlers/transfer.ts
+++ b/apps/indexer/src/eventHandlers/transfer.ts
@@ -119,10 +119,10 @@ export const tokenTransfer = async (
       .onConflictDoNothing();
   }
 
-  const normalizedCex = cex.map(getAddress);
-  const normalizedDex = dex.map(getAddress);
-  const normalizedLending = lending.map(getAddress);
-  const normalizedBurning = burning.map(getAddress);
+  const normalizedCex = cex.map((a) => getAddress(a));
+  const normalizedDex = dex.map((a) => getAddress(a));
+  const normalizedLending = lending.map((a) => getAddress(a));
+  const normalizedBurning = burning.map((a) => getAddress(a));
 
   await context.db
     .insert(transfer)

--- a/apps/indexer/src/eventHandlers/voting.ts
+++ b/apps/indexer/src/eventHandlers/voting.ts
@@ -129,7 +129,7 @@ export const proposalCreated = async (
     txHash,
     daoId,
     proposerAccountId: getAddress(proposer),
-    targets: targets.map(getAddress),
+    targets: targets.map((a) => getAddress(a)),
     values,
     signatures,
     calldatas,


### PR DESCRIPTION
## Summary

Fixes the indexer bug that caused `CEX_SUPPLY` (and related metrics) to be wrong or zero, and transfers to show `isCex`/`isDex`/`isLending` as `false` even when involving known CEX/DEX/Lending addresses.

## Context

In production, the `CEX_SUPPLY` metric (Token Distribution on the frontend) dropped to **0** from **2026-02-01**. We verified on-chain data via **Arkham Intelligence** (`/balances/address/{addr}?chains=ethereum`) for the same 29 CEX addresses in `constants.ts`. On Ethereum alone, Arkham shows **~90.3M UNI** in CEX wallets; our indexer showed 0 (and had already been undercounting by ~97% before that). Conclusion: the bug is in the indexer — CEX address matching was broken, so the supply accumulator never updated and transfers involving CEX had `isCex: false`.

## Root cause

Using `.map(getAddress)` in the indexer. `Array.prototype.map` invokes the callback with `(element, index, array)`. Viem’s `getAddress(address, chainId?)` treats the **second argument as chainId**. So the array **index** was passed as chainId: for index 0 it’s falsy and viem uses EIP-55 checksum; for index ≥ 1 viem uses EIP-1191 (chain-specific) checksum. The normalized list then had wrong checksums and `includes(getAddress(addr))` never matched for most addresses.

**Evidence** (from `debug-confirm-chainid.ts`): same address at index 1 and 2 gets different checksums with `.map(getAddress)`; `includes()` fails. With `.map(a => getAddress(a))`, all addresses match.

## Fix

Replace every `.map(getAddress)` with `.map((a) => getAddress(a))` so only the address is passed to `getAddress` and checksums are consistent (EIP-55).

## Files changed (indexer)

| File | Impact |
|------|--------|
| `src/eventHandlers/metrics/supply.ts` | CEX/DEX/Lending/Treasury supply accumulator |
| `src/eventHandlers/metrics/total.ts` | Total supply (burn addresses) |
| `src/eventHandlers/transfer.ts` | `isCex`, `isDex`, `isLending`, `isTotal` on transfers |
| `src/eventHandlers/shared.ts` | Transaction flags (CEX/DEX/Lending/Burning) |
| `src/eventHandlers/voting.ts` | Proposal targets (checksum consistency) |

