### PR TITLE
feat(dashboard): enable governance page for Uniswap

### DIFF
--- a/apps/dashboard/shared/dao-config/uni.ts
+++ b/apps/dashboard/shared/dao-config/uni.ts
@@ -313,4 +313,5 @@ export const UNI: DaoConfiguration = {
   resilienceStages: true,
   dataTables: true,
   activityFeed: true,
+  governancePage: true,
 };


### PR DESCRIPTION
## Summary
- Enable the proposals section for Uniswap by setting `governancePage: true` in the DAO config
- Part of a PR chain to enable governance pages for all DAOs

## On-Chain Verification (via local reth node, block 24682058)
- **Quorum**: `quorumVotes()` = 40M UNI (static) — matches API client (`UNIClient.getQuorum()`)
- **Vote ABI**: `castVote(uint256,uint8)` selector `0x56781388` — compatible with ENS ABI used by dashboard
- **Proposal state**: 95 proposals, latest (#95) state = Executed — API `getProposalStatus()` logic verified
- **Timelock delay**: 2 days (172800s) via `timelock()` → `delay()` — matches `UNIClient.getTimelockDelay()`
- **Quorum calc**: `calculateQuorum` uses `forVotes` only — correct per UNI governor contract

## What this enables
- Sidebar "Proposals" navigation button
- Full governance page at `/uni/governance`
- Individual proposal pages at `/uni/governance/proposal/{id}`
- "Last Proposals" card on DAO overview
- OngoingProposalBanner on overview
- Internal proposal links in activity feed (instead of external Tally links)

## Test plan
- [ ] Verify governance page renders at `/uni/governance`
- [ ] Verify individual proposal page loads
- [ ] Verify vote modal opens and connects wallet
- [ ] Verify proposal states display correctly (Pending, Active, Executed, etc.)
- [ ] Verify sidebar shows "Proposals" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**PR Chain**: UNI (this) → COMP → GTC → NOUNS → OP → OBOL → SCR → AAVE