### PR TITLE
feat(dashboard): enable governance page for Compound

### DIFF
--- a/apps/dashboard/shared/dao-config/comp.ts
+++ b/apps/dashboard/shared/dao-config/comp.ts
@@ -351,4 +351,5 @@ export const COMP: DaoConfiguration = {
   tokenDistribution: true,
   dataTables: true,
   activityFeed: true,
+  governancePage: true,
 };


### PR DESCRIPTION
## Summary
- Enable the proposals section for Compound by setting `governancePage: true` in the DAO config
- Part of a PR chain to enable governance pages for all DAOs

## On-Chain Verification (via local reth node, block 24682058)
- **Quorum**: `quorum(blockNumber)` = 400K COMP (dynamic, block-based) — matches API client (`COMPClient.getQuorum()` which uses `blockNumber - 10`)
- **Vote ABI**: `castVote(uint256,uint8)` selector `0x56781388` — compatible with ENS ABI used by dashboard
- **Proposal state**: 552 proposals, latest (#552) state = Active — API `getProposalStatus()` logic verified
- **Timelock delay**: 2 days (172800s) via `timelock()` → `delay()` — matches `COMPClient.getTimelockDelay()`
- **Quorum calc**: `calculateQuorum` uses `forVotes` only — correct per COMP governor contract

## Test plan
- [ ] Verify governance page renders at `/comp/governance`
- [ ] Verify individual proposal page loads
- [ ] Verify vote modal opens and connects wallet
- [ ] Verify proposal states display correctly
- [ ] Verify sidebar shows "Proposals" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**PR Chain**: UNI → COMP (this) → GTC → NOUNS → OP → OBOL → SCR → AAVE