### PR TITLE
feat(dashboard): enable governance page for Gitcoin

### DIFF
--- a/apps/dashboard/shared/dao-config/gtc.ts
+++ b/apps/dashboard/shared/dao-config/gtc.ts
@@ -323,4 +323,5 @@ export const GTC: DaoConfiguration = {
       },
     },
   },
+  governancePage: true,
 };


### PR DESCRIPTION
## Summary
- Enable the proposals section for Gitcoin by setting `governancePage: true`
- Part of PR chain to enable governance pages for all DAOs

## On-Chain Verification (via local reth node)
- **Quorum**: `quorum(blockNumber)` = 2.5M GTC (dynamic) — matches `GTCClient.getQuorum()`
- **Vote ABI**: `castVote(uint256,uint8)` selector `0x56781388` — compatible with ENS ABI
- **Proposal threshold**: 150K GTC
- **Quorum calc**: `calculateQuorum` uses `forVotes + abstainVotes` — correct per OZ Governor

## Test plan
- [ ] Verify governance page renders at `/gtc/governance`
- [ ] Verify proposal states display correctly
- [ ] Verify sidebar shows "Proposals" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**PR Chain**: UNI → COMP → GTC (this) → NOUNS → OP → OBOL → SCR → AAVE