### PR TITLE
feat(dashboard): enable governance page for Nouns

### DIFF
--- a/apps/dashboard/shared/dao-config/nouns.ts
+++ b/apps/dashboard/shared/dao-config/nouns.ts
@@ -323,4 +323,5 @@ export const NOUNS: DaoConfiguration = {
       },
     },
   },
+  governancePage: true,
 };

--- a/apps/dashboard/shared/dao-config/nouns.ts
+++ b/apps/dashboard/shared/dao-config/nouns.ts
@@ -44,7 +44,7 @@ export const NOUNS: DaoConfiguration = {
       changeVote: false,
       timelock: true,
       cancelFunction: true,
-      logic: "For",
+      logic: "For + Abstain",
       quorumCalculation: "10-15% Dynamic Quorum",
       proposalThreshold: "3 $NOUN (>0.25% Adjusted Supply)",
     },


### PR DESCRIPTION
## Summary
- Enable the proposals section for Nouns by setting `governancePage: true`
- Part of PR chain to enable governance pages for all DAOs

## On-Chain Verification (via local reth node)
- **Quorum**: `quorumVotesBPS()` = 1000 (10%) — per-proposal dynamic quorum via `quorumVotes(proposalId)`
- **API client**: Uses `proposalCount()` → `quorumVotes(lastProposalId)` — correct approach for dynamic quorum
- **Vote ABI**: `castVote(uint256,uint8)` selector `0x56781388` — compatible with ENS ABI
- **Proposal threshold**: 3 Nouns (ERC721-based governance)
- **Quorum calc**: `calculateQuorum` uses `forVotes + abstainVotes` — correct
- **950 proposals** total

## Test plan
- [ ] Verify governance page renders at `/nouns/governance`
- [ ] Verify proposal states display correctly
- [ ] Verify sidebar shows "Proposals" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**PR Chain**: UNI → COMP → GTC → NOUNS (this) → OP → OBOL → SCR → AAVE