### PR TITLE
feat(dashboard): enable governance page for Optimism

### DIFF
--- a/apps/dashboard/shared/dao-config/op.ts
+++ b/apps/dashboard/shared/dao-config/op.ts
@@ -345,4 +345,5 @@ export const OP: DaoConfiguration = {
   resilienceStages: true,
   tokenDistribution: true,
   dataTables: true,
+  governancePage: true,
 };


### PR DESCRIPTION
## Summary
- Enable the proposals section for Optimism by setting `governancePage: true`
- Part of PR chain to enable governance pages for all DAOs

## Verification Notes
OP Governor is on Optimism L2 — not verifiable on local mainnet reth node. Verified via **code review** of `OPClient`:
- **Quorum**: `quorum(proposalId)` — per-proposal dynamic quorum
- **Quorum calc**: `calculateQuorum` uses `forVotes + againstVotes + abstainVotes` (all votes)
- **Timelock**: `getTimelockDelay()` returns `0n` — no timelock on OP
- **Foundation-only**: proposals restricted to Foundation/Manager addresses
- **Vote ABI**: Standard OZ `castVote(uint256,uint8)` — compatible

## Test plan
- [ ] Verify governance page renders at `/op/governance`
- [ ] Verify proposal states display correctly
- [ ] Verify sidebar shows "Proposals" button
- [ ] Note: OP has Foundation-only proposals — verify propose UI handles this gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**PR Chain**: UNI → COMP → GTC → NOUNS → OP (this) → OBOL → SCR → AAVE