### PR TITLE
feat(dashboard): enable governance page for Scroll

### DIFF
--- a/apps/dashboard/shared/dao-config/scr.ts
+++ b/apps/dashboard/shared/dao-config/scr.ts
@@ -317,4 +317,5 @@ export const SCR: DaoConfiguration = {
       },
     },
   },
+  governancePage: true,
 };


### PR DESCRIPTION
## Summary
- Enable the proposals section for Scroll by setting `governancePage: true`
- Part of PR chain to enable governance pages for all DAOs

## Verification Notes
SCR Governor is on Scroll L2 — not verifiable on local mainnet reth node. Verified via **code review** of `SCRClient`:
- **Quorum**: Hardcoded 2.1M SCR — correct per governance config
- **Quorum calc**: `calculateQuorum` uses `forVotes + abstainVotes + againstVotes` (all votes)
- **Timelock**: `getTimelockDelay()` uses `getMinDelay()` on TimelockController — correct
- **Vote ABI**: Standard OZ `castVote(uint256,uint8)` — compatible

## Test plan
- [ ] Verify governance page renders at `/scr/governance`
- [ ] Verify proposal states display correctly
- [ ] Verify sidebar shows "Proposals" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**PR Chain**: UNI → COMP → GTC → NOUNS → OP → OBOL → SCR (this) → AAVE