### PR TITLE
docs(dashboard): document AAVE Governance V3 requirements

### DIFF
--- a/apps/api/src/clients/aave/index.ts
+++ b/apps/api/src/clients/aave/index.ts
@@ -75,6 +75,14 @@ export class AAVEClient<
     return 0n;
   }
 
+  async getVotingDelay(): Promise<bigint> {
+    return 0n;
+  }
+
+  async getVotingPeriod(): Promise<bigint> {
+    return 0n;
+  }
+
   calculateQuorum(votes: {
     forVotes: bigint;
     againstVotes: bigint;

--- a/apps/api/src/clients/aave/index.ts
+++ b/apps/api/src/clients/aave/index.ts
@@ -71,6 +71,10 @@ export class AAVEClient<
     // });
   }
 
+  async getProposalThreshold(): Promise<bigint> {
+    return 0n;
+  }
+
   calculateQuorum(votes: {
     forVotes: bigint;
     againstVotes: bigint;

--- a/apps/dashboard/shared/dao-config/aave.ts
+++ b/apps/dashboard/shared/dao-config/aave.ts
@@ -42,5 +42,5 @@ export const AAVE: DaoConfiguration = {
   //    getTimelockDelay(), and V3-specific getProposalStatus() override
   // 3. Dashboard: Add governor/timelock contract addresses, rules, and vote handler
   // 4. AAVE V3 uses per-access-level voting configs, not global quorum/delay
-  // See: https://github.com/blockful/anticapture/pull/XXXX for details
+  // See: https://github.com/blockful/anticapture/pull/1741 for details
 };

--- a/apps/dashboard/shared/dao-config/aave.ts
+++ b/apps/dashboard/shared/dao-config/aave.ts
@@ -35,4 +35,12 @@ export const AAVE: DaoConfiguration = {
     },
   },
   dataTables: true,
+  // TODO: Enable governancePage after implementing AAVE Governance V3 support:
+  // 1. Indexer: Add governor contract (0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7) with V3 events
+  //    (ProposalCreated, VoteEmitted, ProposalQueued, ProposalExecuted, ProposalCanceled)
+  // 2. API Client: Implement AAVEClient with real governor address, ABI, getQuorum(),
+  //    getTimelockDelay(), and V3-specific getProposalStatus() override
+  // 3. Dashboard: Add governor/timelock contract addresses, rules, and vote handler
+  // 4. AAVE V3 uses per-access-level voting configs, not global quorum/delay
+  // See: https://github.com/blockful/anticapture/pull/XXXX for details
 };

--- a/apps/dashboard/shared/dao-config/comp.ts
+++ b/apps/dashboard/shared/dao-config/comp.ts
@@ -351,4 +351,5 @@ export const COMP: DaoConfiguration = {
   tokenDistribution: true,
   dataTables: true,
   activityFeed: true,
+  governancePage: true,
 };

--- a/apps/dashboard/shared/dao-config/gtc.ts
+++ b/apps/dashboard/shared/dao-config/gtc.ts
@@ -323,4 +323,5 @@ export const GTC: DaoConfiguration = {
       },
     },
   },
+  governancePage: true,
 };

--- a/apps/dashboard/shared/dao-config/nouns.ts
+++ b/apps/dashboard/shared/dao-config/nouns.ts
@@ -323,4 +323,5 @@ export const NOUNS: DaoConfiguration = {
       },
     },
   },
+  governancePage: true,
 };

--- a/apps/dashboard/shared/dao-config/nouns.ts
+++ b/apps/dashboard/shared/dao-config/nouns.ts
@@ -44,7 +44,7 @@ export const NOUNS: DaoConfiguration = {
       changeVote: false,
       timelock: true,
       cancelFunction: true,
-      logic: "For",
+      logic: "For + Abstain",
       quorumCalculation: "10-15% Dynamic Quorum",
       proposalThreshold: "3 $NOUN (>0.25% Adjusted Supply)",
     },

--- a/apps/dashboard/shared/dao-config/obol.ts
+++ b/apps/dashboard/shared/dao-config/obol.ts
@@ -335,4 +335,5 @@ export const OBOL: DaoConfiguration = {
       },
     },
   },
+  governancePage: true,
 };

--- a/apps/dashboard/shared/dao-config/op.ts
+++ b/apps/dashboard/shared/dao-config/op.ts
@@ -345,4 +345,5 @@ export const OP: DaoConfiguration = {
   resilienceStages: true,
   tokenDistribution: true,
   dataTables: true,
+  governancePage: true,
 };

--- a/apps/dashboard/shared/dao-config/scr.ts
+++ b/apps/dashboard/shared/dao-config/scr.ts
@@ -317,4 +317,5 @@ export const SCR: DaoConfiguration = {
       },
     },
   },
+  governancePage: true,
 };

--- a/apps/dashboard/shared/dao-config/uni.ts
+++ b/apps/dashboard/shared/dao-config/uni.ts
@@ -313,4 +313,5 @@ export const UNI: DaoConfiguration = {
   resilienceStages: true,
   dataTables: true,
   activityFeed: true,
+  governancePage: true,
 };


### PR DESCRIPTION
## Summary
- Document what's needed to enable governance page for AAVE (WIP)
- AAVE uses Governance V3, which is architecturally different from OZ Governor
- **Does NOT enable governancePage** — doing so would show broken/empty data

## Why AAVE Can't Be Enabled Yet
The AAVE API client is stubbed — all methods return 0n. The indexer only indexes token events, not governor events. No proposals would appear.

## AAVE Governance V3 Architecture (confirmed on-chain)
- Core contract: 0x9AEE0B04504CeF83A65AC3f0e838D0593BCb2BC7 (459 proposals)
- Per-access-level voting configs (instead of global quorum/delay)
- Different events: VoteEmitted (not VoteCast)
- Custom state machine

## Implementation Needed
1. Indexer: Add governance contract with V3 events
2. API Client: Implement AAVEClient with real address, ABI, quorum, timelock
3. Dashboard: Add governor/timelock addresses, rules, custom vote handler
4. Dashboard config: Add governancePage: true after above is done

**PR Chain**: UNI → COMP → GTC → NOUNS → OP → OBOL → SCR → AAVE (this, WIP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)