### PR TITLE
Disable proposal log index on the API

### DIFF
--- a/apps/api/src/clients/aave/index.ts
+++ b/apps/api/src/clients/aave/index.ts
@@ -39,51 +39,9 @@ export class AAVEClient<
 
   async getQuorum(): Promise<bigint> {
     return 0n;
-    // return readContract(this.client, {
-    //   abi: this.abi,
-    //   address: this.address,
-    //   functionName: "quorum",
-    //   args: [BigInt(Math.floor(Date.now() / 1000))],
-    // });
-  }
-
-  async getVotingDelay(): Promise<bigint> {
-    return 0n;
-  }
-
-  async getVotingPeriod(): Promise<bigint> {
-    return 0n;
   }
 
   async getTimelockDelay(): Promise<bigint> {
-    return 0n;
-    // const timelockAddress = await readContract(this.client, {
-    //   abi: this.abi,
-    //   address: this.address,
-    //   functionName: "timelock",
-    // });
-    // return readContract(this.client, {
-    //   abi: [
-    //     {
-    //       inputs: [],
-    //       name: "getMinDelay",
-    //       outputs: [
-    //         {
-    //           internalType: "uint256",
-    //           name: "",
-    //           type: "uint256",
-    //         },
-    //       ],
-    //       stateMutability: "view",
-    //       type: "function",
-    //     },
-    //   ],
-    //   address: timelockAddress,
-    //   functionName: "getMinDelay",
-    // });
-  }
-
-  async getProposalThreshold(): Promise<bigint> {
     return 0n;
   }
 

--- a/apps/api/src/database/schema.ts
+++ b/apps/api/src/database/schema.ts
@@ -208,7 +208,7 @@ export const proposalsOnchain = pgTable(
     title: drizzle.text().notNull(),
     description: drizzle.text().notNull(),
     timestamp: bigint({ mode: "bigint" }).notNull(),
-    logIndex: drizzle.integer().notNull(),
+    // logIndex: drizzle.integer().notNull(),
     endTimestamp: bigint({ mode: "bigint" }).notNull(),
     status: drizzle.text().notNull(),
     forVotes: bigint({ mode: "bigint" }).default(0n).notNull(),

--- a/apps/api/src/repositories/drizzle/index.ts
+++ b/apps/api/src/repositories/drizzle/index.ts
@@ -156,9 +156,9 @@ export class DrizzleRepository {
         orderDirection === "asc"
           ? asc(proposalsOnchain.timestamp)
           : desc(proposalsOnchain.timestamp),
-        orderDirection === "asc"
-          ? asc(proposalsOnchain.logIndex)
-          : desc(proposalsOnchain.logIndex),
+        // orderDirection === "asc"
+        //   ? asc(proposalsOnchain.logIndex)
+        //   : desc(proposalsOnchain.logIndex), // TODO: enable it when all daos are indexed
       )
       .limit(limit)
       .offset(skip);

--- a/apps/api/src/repositories/proposals-activity/index.ts
+++ b/apps/api/src/repositories/proposals-activity/index.ts
@@ -139,7 +139,7 @@ export class DrizzleProposalsActivityRepository {
         orderByClause = `ORDER BY COALESCE(v.timestamp - p.timestamp, 999999999) ${orderDirection.toUpperCase()}`;
         break;
       default:
-        orderByClause = `ORDER BY p.timestamp ${orderDirection.toUpperCase()}, p.log_index ${orderDirection.toUpperCase()}`;
+        orderByClause = `ORDER BY p.timestamp ${orderDirection.toUpperCase()}`; //, p.log_index ${orderDirection.toUpperCase()}`; // TODO: enable it again when all DAOs are indexed
     }
 
     // Main query with LEFT JOIN to get proposals and their votes


### PR DESCRIPTION
This is requried for Compound governace to work without needing to wait for the full reindex.