### PR TITLE
fix: remove header-based DAO resolution from gateful proxy

### DIFF
--- a/apps/gateful/src/proxy/route.test.ts
+++ b/apps/gateful/src/proxy/route.test.ts
@@ -41,24 +41,12 @@ describe("proxy route", () => {
     expect(res.status).toBe(200);
   });
 
-  it("should resolve DAO from anticapture-dao-id header", async () => {
-    vi.spyOn(global, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ ok: true }), { status: 200 }),
-    );
-
-    const res = await app.request("http://localhost/", {
-      headers: { "anticapture-dao-id": "uni" },
-    });
-
-    expect(res.status).toBe(200);
-  });
-
   it("should return 400 when no DAO identifier is provided", async () => {
     const res = await app.request("/");
 
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toContain("Missing DAO identifier");
+    expect(body.error).toContain("Use /:dao/* path");
   });
 
   it("should resolve DAO case-insensitively from path", async () => {

--- a/apps/gateful/src/proxy/route.ts
+++ b/apps/gateful/src/proxy/route.ts
@@ -10,16 +10,18 @@ import { proxy as honoProxy } from "hono/proxy";
  * so it only catches unmatched requests.
  */
 export function proxy(app: OpenAPIHono, daoApis: Map<string, string>) {
-  // Two route patterns share the same handler — path-based matches first
+  // Register path-based matches before the fallback catch-alls so the DAO
+  // param is available when present in the URL.
   app.all("/:dao{[^/]+}/*", handler);
+  app.all("/", handler);
+  app.all("/*", handler);
 
   async function handler(c: Context) {
     const paramDao = c.req.param("dao");
     if (!paramDao) {
       return c.json(
         {
-          error:
-            "Missing DAO identifier. Use /:dao/* path or anticapture-dao-id header",
+          error: "Missing DAO identifier. Use /:dao/* path",
         },
         400,
       );


### PR DESCRIPTION
## Summary
- remove `anticapture-dao-id` support from the gateful proxy so DAO resolution is path-only
- keep the proxy fallback routes so requests without a DAO reach the handler and return a structured `400`
- update proxy tests to match the path-only gateway contract

## Why
The gateway should not resolve DAOs from request headers. This change restores a single routing contract based on `/:dao/*` while preserving explicit validation for requests that miss the DAO segment.

## Testing
- pnpm --filter @anticapture/gateful test
- pnpm test

## ClickUp
- No ClickUp issue was provided for this change.