### PR TITLE
feat: fetch provider avatars from spp-accountability

### DIFF
--- a/apps/dashboard/features/service-providers/components/ProviderNameCell.tsx
+++ b/apps/dashboard/features/service-providers/components/ProviderNameCell.tsx
@@ -5,14 +5,14 @@ import { BulletDivider } from "@/shared/components/design-system/section";
 
 interface ProviderNameCellProps {
   name: string;
-  iconUrl?: string;
+  avatarUrl?: string;
   websiteUrl?: string;
   proposalUrl?: string;
 }
 
 export const ProviderNameCell = ({
   name,
-  iconUrl,
+  avatarUrl,
   websiteUrl,
   proposalUrl,
 }: ProviderNameCellProps) => {
@@ -26,9 +26,9 @@ export const ProviderNameCell = ({
   return (
     <div className="flex items-center gap-3">
       <div className="bg-surface-contrast border-border-contrast flex size-6 shrink-0 items-center justify-center rounded-full border text-[9px] font-bold text-white">
-        {iconUrl ? (
+        {avatarUrl ? (
           <Image
-            src={iconUrl}
+            src={avatarUrl}
             alt={name}
             width={24}
             height={24}

--- a/apps/dashboard/features/service-providers/components/ServiceProvidersTable.tsx
+++ b/apps/dashboard/features/service-providers/components/ServiceProvidersTable.tsx
@@ -22,7 +22,7 @@ import { cn, formatNumberUserReadable } from "@/shared/utils";
 
 interface ProviderRow {
   name: string;
-  iconUrl?: string;
+  avatarUrl?: string;
   websiteUrl?: string;
   proposalUrl?: string;
   budget: number;
@@ -69,7 +69,7 @@ export const ServiceProvidersTable = ({
         return [
           {
             name: provider.name,
-            iconUrl: provider.iconUrl,
+            avatarUrl: provider.avatarUrl,
             websiteUrl: provider.websiteUrl,
             proposalUrl: provider.proposalUrl,
             budget: provider.budget,
@@ -100,7 +100,7 @@ export const ServiceProvidersTable = ({
         ) : (
           <ProviderNameCell
             name={row.original.name}
-            iconUrl={row.original.iconUrl}
+            avatarUrl={row.original.avatarUrl}
             websiteUrl={row.original.websiteUrl}
             proposalUrl={row.original.proposalUrl}
           />

--- a/apps/dashboard/features/service-providers/constants/ens-service-providers.ts
+++ b/apps/dashboard/features/service-providers/constants/ens-service-providers.ts
@@ -31,7 +31,6 @@ export const QUARTER_DUE_DATES: Record<
 export const ENS_SERVICE_PROVIDERS: ServiceProvider[] = [
   {
     name: "Blockful",
-    iconUrl: "/images/blockful.svg",
     websiteUrl: "https://blockful.io",
     proposalUrl:
       "https://discuss.ens.domains/t/spp2-blockful-application/20463",
@@ -41,7 +40,6 @@ export const ENS_SERVICE_PROVIDERS: ServiceProvider[] = [
   },
   {
     name: "eth.limo",
-    iconUrl: "/images/eth-limo.svg",
     websiteUrl: "https://eth.limo",
     proposalUrl:
       "https://discuss.ens.domains/t/spp2-eth-limo-application/20369",
@@ -54,14 +52,12 @@ export const ENS_SERVICE_PROVIDERS: ServiceProvider[] = [
     proposalUrl:
       "https://discuss.ens.domains/t/spp2-ethereum-identity-foundation-application/20439",
     websiteUrl: "https://ethid.org",
-    iconUrl: "/images/ethereum.svg",
     budget: 500000,
     githubSlug: "ethereum-identity-fnd",
     years: {},
   },
   {
     name: "Unruggable",
-    iconUrl: "/images/unruggable.svg",
     websiteUrl: "https://unruggable.com",
     proposalUrl:
       "https://discuss.ens.domains/t/spp2-unruggable-application/20485",
@@ -71,7 +67,6 @@ export const ENS_SERVICE_PROVIDERS: ServiceProvider[] = [
   },
   {
     name: "NameHash Labs",
-    iconUrl: "/images/namehash.svg",
     websiteUrl: "https://namehashlabs.org",
     proposalUrl:
       "https://discuss.ens.domains/t/spp2-namehash-labs-application/20502",
@@ -81,7 +76,6 @@ export const ENS_SERVICE_PROVIDERS: ServiceProvider[] = [
   },
   {
     name: "Namespace",
-    iconUrl: "/images/namespace.svg",
     websiteUrl: "https://namespace.tech",
     proposalUrl:
       "https://discuss.ens.domains/t/spp2-namespace-application/20456",
@@ -91,7 +85,6 @@ export const ENS_SERVICE_PROVIDERS: ServiceProvider[] = [
   },
   {
     name: "ZK Email",
-    iconUrl: "/images/zk-email.svg",
     websiteUrl: "https://zkemail.com",
     proposalUrl:
       "https://discuss.ens.domains/t/spp2-zk-email-application/20450",
@@ -101,7 +94,6 @@ export const ENS_SERVICE_PROVIDERS: ServiceProvider[] = [
   },
   {
     name: "JustaName",
-    iconUrl: "/images/justaname.svg",
     websiteUrl: "https://justaname.id",
     proposalUrl:
       "https://discuss.ens.domains/t/spp2-justaname-application/20430",

--- a/apps/dashboard/features/service-providers/hooks/useServiceProvidersData.ts
+++ b/apps/dashboard/features/service-providers/hooks/useServiceProvidersData.ts
@@ -4,12 +4,16 @@ import { ENS_SERVICE_PROVIDERS } from "@/features/service-providers/constants/en
 import type { ServiceProvider } from "@/features/service-providers/types";
 import {
   fetchServiceProvidersData,
-  type ServiceProvidersData,
+  type ServiceProvidersResult,
 } from "@/features/service-providers/utils/fetchServiceProvidersData";
 
-const buildProviders = (data: ServiceProvidersData): ServiceProvider[] =>
+const buildProviders = (
+  data: ServiceProvidersResult["data"],
+  avatarUrls: ServiceProvidersResult["avatarUrls"],
+): ServiceProvider[] =>
   ENS_SERVICE_PROVIDERS.map((provider) => ({
     ...provider,
+    avatarUrl: avatarUrls[provider.githubSlug],
     years: Object.fromEntries(
       Object.entries(data)
         .filter(([, slugData]) => slugData[provider.githubSlug])
@@ -23,8 +27,8 @@ export const useServiceProvidersData = () => {
   return useQuery<ServiceProvider[]>({
     queryKey: ["serviceProviders", ...slugs],
     queryFn: async () => {
-      const data = await fetchServiceProvidersData(slugs);
-      return buildProviders(data);
+      const { data, avatarUrls } = await fetchServiceProvidersData(slugs);
+      return buildProviders(data, avatarUrls);
     },
     staleTime: 3600000,
     gcTime: 3600000,

--- a/apps/dashboard/features/service-providers/types.ts
+++ b/apps/dashboard/features/service-providers/types.ts
@@ -14,7 +14,7 @@ export type YearData = {
 
 export type ServiceProvider = {
   name: string;
-  iconUrl?: string;
+  avatarUrl?: string;
   websiteUrl?: string;
   proposalUrl?: string;
   budget: number;

--- a/apps/dashboard/features/service-providers/utils/fetchServiceProvidersData.ts
+++ b/apps/dashboard/features/service-providers/utils/fetchServiceProvidersData.ts
@@ -14,6 +14,11 @@ import { extractUrlFromMarkdown } from "@/features/service-providers/utils/extra
 
 export type ServiceProvidersData = Record<number, Record<string, YearData>>;
 
+export type ServiceProvidersResult = {
+  data: ServiceProvidersData;
+  avatarUrls: Record<string, string>;
+};
+
 const fetchQuarterReport = async (
   year: number,
   slug: string,
@@ -41,12 +46,12 @@ const fetchQuarterReport = async (
 
 export const fetchServiceProvidersData = async (
   slugs: string[],
-): Promise<ServiceProvidersData> => {
+): Promise<ServiceProvidersResult> => {
   const treeResponse = await fetch(
     `${GITHUB_API_BASE}/git/trees/main?recursive=1`,
   );
 
-  if (!treeResponse.ok) return {};
+  if (!treeResponse.ok) return { data: {}, avatarUrls: {} };
 
   const { tree }: { tree: { path: string; type: string }[] } =
     await treeResponse.json();
@@ -62,6 +67,18 @@ export const fetchServiceProvidersData = async (
       )
       .map((item) => item.path.toLowerCase()),
   );
+
+  const avatarUrls: Record<string, string> = {};
+  tree
+    .filter(
+      (item) =>
+        item.type === "blob" && /^avatars\/[^/]+\.[^.]+$/.test(item.path),
+    )
+    .forEach((item) => {
+      const fileName = item.path.slice("avatars/".length);
+      const slug = fileName.slice(0, fileName.lastIndexOf("."));
+      avatarUrls[slug] = `${GITHUB_RAW_BASE}/${item.path}`;
+    });
 
   const now = new Date();
 
@@ -94,5 +111,5 @@ export const fetchServiceProvidersData = async (
     }),
   );
 
-  return Object.fromEntries(yearEntries);
+  return { data: Object.fromEntries(yearEntries), avatarUrls };
 };


### PR DESCRIPTION
Provider avatars are now sourced from the spp-accountability GitHub repo instead of being hardcoded in the dashboard.

- Add ServiceProvidersResult type wrapping data + avatarUrls
- Detect avatars/SLUG.* files from the existing recursive tree fetch (no extra network call)
- Build raw GitHub URLs and return alongside quarterly report data
- Remove hardcoded iconUrl from ENS_SERVICE_PROVIDERS constants
- Rename iconUrl → avatarUrl throughout types, table, and cell component