### PR TITLE
fix(indexer): improve proposal title parsing for missing H1 headers

### DIFF
--- a/apps/indexer/src/eventHandlers/voting.ts
+++ b/apps/indexer/src/eventHandlers/voting.ts
@@ -106,6 +106,41 @@ export const voteCast = async (
   });
 };
 
+const MAX_TITLE_LENGTH = 200;
+
+/**
+ * Extracts a proposal title from a markdown description.
+ *
+ * Strategy:
+ * 1. If the first non-empty line is an H1 (`# Title`), use it.
+ * 2. Otherwise, use the first non-empty line that is not a section header
+ *    (H2+), truncated to MAX_TITLE_LENGTH characters.
+ */
+function parseProposalTitle(description: string): string {
+  const lines = description.split("\n");
+
+  // Pass 1: look for an H1 among leading lines (before any content)
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (/^# /.test(trimmed)) {
+      return trimmed.replace(/^# +/, "");
+    }
+    break; // stop at first non-empty, non-H1 line
+  }
+
+  // Pass 2: no H1 found — use first non-empty, non-header line
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || /^#{1,6}\s/.test(trimmed)) continue;
+    return trimmed.length > MAX_TITLE_LENGTH
+      ? trimmed.substring(0, MAX_TITLE_LENGTH) + "..."
+      : trimmed;
+  }
+
+  return "";
+}
+
 /**
  * ### Creates:
  * - New `Account` record (for proposer if it doesn't exist)
@@ -158,7 +193,7 @@ export const proposalCreated = async (
 
   await ensureAccountExists(context, proposer);
 
-  const title = description.split("\n")[0]?.replace(/^#+\s*/, "") || "";
+  const title = parseProposalTitle(description);
   const blockDelta = parseInt(endBlock) - Number(blockNumber);
   await context.db.insert(proposalsOnchain).values({
     id: proposalId,

--- a/apps/indexer/src/eventHandlers/voting.ts
+++ b/apps/indexer/src/eventHandlers/voting.ts
@@ -112,12 +112,16 @@ const MAX_TITLE_LENGTH = 200;
  * Extracts a proposal title from a markdown description.
  *
  * Strategy:
- * 1. If the first non-empty line is an H1 (`# Title`), use it.
- * 2. Otherwise, use the first non-empty line that is not a section header
+ * 1. Normalize literal `\n` sequences to real newlines (some proposers
+ *    submit descriptions with escaped newlines).
+ * 2. If the first non-empty line is an H1 (`# Title`), use it.
+ * 3. Otherwise, use the first non-empty line that is not a section header
  *    (H2+), truncated to MAX_TITLE_LENGTH characters.
  */
 function parseProposalTitle(description: string): string {
-  const lines = description.split("\n");
+  // Normalize literal "\n" (two chars) into real newlines
+  const normalized = description.replace(/\\n/g, "\n");
+  const lines = normalized.split("\n");
 
   // Pass 1: look for an H1 among leading lines (before any content)
   for (const line of lines) {


### PR DESCRIPTION
## Summary
- Proposals without an H1 (`# Title`) header (e.g. Compound #399 which starts with `## Proposal summary`) were getting the section header as the title instead of meaningful content
- Proposals with literal `\n` text instead of real newlines (e.g. #450, #516, #553, #554) had the entire description leaking into the title
- New `parseProposalTitle()` function normalizes literal `\n`, only treats H1 as titles, falls back to first content paragraph when no H1 is present, and trims trailing whitespace
- Verified against all 161 Compound Governor proposals — 8 titles improved, 153 unchanged

| # | Old title | New title |
|---|-----------|-----------|
| 399 | `Proposal summary` | `Compound Growth Program [AlphaGrowth] proposes the deployment...` |
| 450 | `OpenZeppelin Security Partnership...\n\n\n## Background...` | `OpenZeppelin Security Partnership - Annual Renewal 2025` |
| 454 | trailing space | trimmed |
| 462 | trailing space | trimmed |
| 465 | trailing space | trimmed |
| 516 | `[Gauntlet] Rewards...\n# Simple Summary\n\n...` | `[Gauntlet] Rewards Contract Top-Up for Arbitrum and Unichain` |
| 553 | `Incentive Cuts...\n# Simple Summary\n\n...` | `Incentive Cuts on Ethereum,Linea, Optimism and Unichain` |
| 554 | `Incentive Cuts...\n# Simple Summary\n\n...` | `Incentive Cuts on Ethereum (Extension to proposal 553)` |

## Test plan
- [x] Decoded all 161 on-chain Compound ProposalCreated events and compared old vs new parser output
- [x] Indexed Compound with local reth node — verified titles are correct
- [x] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)