### PR TITLE
fix(dashboard): canceled status, 404 for invalid DAOs, NounsClient daoId

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -1,26 +1,16 @@
-directive @resolveRoot(subgraph: String) on FIELD_DEFINITION
-
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
-
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
-
 directive @enum(subgraph: String, value: String) on ENUM_VALUE
+
+directive @resolveRoot(subgraph: String) on FIELD_DEFINITION
 
 directive @typescript(subgraph: String, type: String) on SCALAR | ENUM
 
 directive @example(subgraph: String, value: ObjMap) repeatable on FIELD_DEFINITION | OBJECT | INPUT_OBJECT | ENUM | SCALAR
 
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
+
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
+
 type Query {
-  """
-  Returns label information from Arkham, ENS data, and whether the address is an EOA or contract. Arkham data is stored permanently. ENS data is cached with a configurable TTL.
-  """
-  getAddress(address: String!): getAddress_200_response
-
-  """
-  Returns label information from Arkham, ENS data, and address type for multiple addresses. Maximum 100 addresses per request. Arkham data is stored permanently. ENS data is cached with a configurable TTL.
-  """
-  getAddresses(addresses: JSON!): getAddresses_200_response
-
   """
   Get historical delegations for an account, with optional filtering and sorting
   """
@@ -244,69 +234,6 @@ type Query {
   daos: DAOList!
 }
 
-type getAddress_200_response {
-  address: String!
-  isContract: Boolean!
-  arkham: query_getAddress_arkham
-  ens: query_getAddress_ens
-}
-
-type query_getAddress_arkham {
-  entity: String
-  entityType: String
-  label: String
-  twitter: String
-}
-
-type query_getAddress_ens {
-  name: String
-  avatar: String
-  banner: String
-}
-
-type getAddresses_200_response {
-  results: [query_getAddresses_results_items]!
-}
-
-type query_getAddresses_results_items {
-  address: String!
-  isContract: Boolean!
-  arkham: query_getAddresses_results_items_arkham
-  ens: query_getAddresses_results_items_ens
-}
-
-type query_getAddresses_results_items_arkham {
-  entity: String
-  entityType: String
-  label: String
-  twitter: String
-}
-
-type query_getAddresses_results_items_ens {
-  name: String
-  avatar: String
-  banner: String
-}
-
-"""
-The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
-"""
-scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
-
-enum HTTPMethod {
-  GET
-  HEAD
-  POST
-  PUT
-  DELETE
-  CONNECT
-  OPTIONS
-  TRACE
-  PATCH
-}
-
-scalar ObjMap
-
 type historicalDelegations_200_response {
   items: [query_historicalDelegations_items_items]!
   totalCount: Float!
@@ -319,6 +246,11 @@ type query_historicalDelegations_items_items {
   timestamp: String!
   transactionHash: String!
 }
+
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
 """Integers that will have a value of 0 or more."""
 scalar NonNegativeInt
@@ -464,6 +396,7 @@ type token_200_response {
   dexSupply: String!
   lendingSupply: String!
   circulatingSupply: String!
+  nonCirculatingSupply: String!
   treasury: String!
   price: String!
 }
@@ -1473,6 +1406,20 @@ enum queryInput_votesOffchainByProposalId_orderBy {
 enum queryInput_votesOffchainByProposalId_orderDirection {
   asc
   desc
+}
+
+scalar ObjMap
+
+enum HTTPMethod {
+  GET
+  HEAD
+  POST
+  PUT
+  DELETE
+  CONNECT
+  OPTIONS
+  TRACE
+  PATCH
 }
 
 type AverageDelegationPercentageItem {

--- a/apps/api/src/clients/nouns/index.ts
+++ b/apps/api/src/clients/nouns/index.ts
@@ -1,6 +1,7 @@
 import { Account, Address, Chain, Client as vClient, Transport } from "viem";
 
 import { DAOClient } from "@/clients";
+import { DaoIdEnum } from "@/lib/enums";
 
 import { GovernorBase } from "../governor.base";
 
@@ -16,15 +17,21 @@ export class Client<
 {
   protected abi: typeof GovernorAbi;
   protected address: Address;
+  private daoId: DaoIdEnum;
 
-  constructor(client: vClient<TTransport, TChain, TAccount>, address: Address) {
+  constructor(
+    client: vClient<TTransport, TChain, TAccount>,
+    address: Address,
+    daoId: DaoIdEnum,
+  ) {
     super(client, 5); // 5 minutes of cache for quorum
     this.address = address;
+    this.daoId = daoId;
     this.abi = GovernorAbi;
   }
 
   getDaoId(): string {
-    return "NOUNS";
+    return this.daoId;
   }
 
   async getQuorum(): Promise<bigint> {

--- a/apps/api/src/lib/client.ts
+++ b/apps/api/src/lib/client.ts
@@ -45,11 +45,11 @@ export function getClient<
     }
     case DaoIdEnum.LIL_NOUNS: {
       const { governor } = CONTRACT_ADDRESSES[daoId];
-      return new NounsClient(client, governor.address);
+      return new NounsClient(client, governor.address, DaoIdEnum.LIL_NOUNS);
     }
     case DaoIdEnum.NOUNS: {
       const { governor } = CONTRACT_ADDRESSES[daoId];
-      return new NounsClient(client, governor.address);
+      return new NounsClient(client, governor.address, DaoIdEnum.NOUNS);
     }
     case DaoIdEnum.SCR: {
       const { governor } = CONTRACT_ADDRESSES[daoId];

--- a/apps/dashboard/app/[daoId]/(main)/layout.tsx
+++ b/apps/dashboard/app/[daoId]/(main)/layout.tsx
@@ -1,32 +1,17 @@
 import type { ReactNode } from "react";
 
-import NotFound from "@/app/not-found";
 import { Footer } from "@/shared/components/design-system/footer/Footer";
-import type { DaoIdEnum } from "@/shared/types/daos";
-import { ALL_DAOS } from "@/shared/types/daos";
 import { HeaderDAOSidebar, HeaderSidebar, StickyPageHeader } from "@/widgets";
 import { HeaderMobile } from "@/widgets/HeaderMobile";
-// import { BaseHeaderLayoutSidebar } from "@/shared/components";
-
-type DaoParams = {
-  daoId: string;
-};
 
 interface DaoLayoutProps {
   children: ReactNode;
-  params: Promise<DaoParams>;
+  params: Promise<{ daoId: string }>;
 }
 
 export default async function DaoLayout({ children, params }: DaoLayoutProps) {
-  const { daoId } = await params;
-  const daoIdEnum = daoId.toUpperCase() as DaoIdEnum;
+  await params;
 
-  // Check if DAO exists and handle support stages
-  if (!ALL_DAOS.includes(daoIdEnum)) {
-    return <NotFound />;
-  }
-
-  // For FULL, IN_ANALYSIS and ELECTION stages, render the layout with appropriate providers
   return (
     <div className="bg-surface-background dark relative mx-auto flex h-screen max-w-screen-2xl">
       <div className="active relative hidden h-screen lg:flex">

--- a/apps/dashboard/app/[daoId]/layout.tsx
+++ b/apps/dashboard/app/[daoId]/layout.tsx
@@ -1,7 +1,9 @@
+import { notFound } from "next/navigation";
 import type { ReactNode } from "react";
 
 import { DaoApolloProvider } from "@/shared/providers/DaoApolloProvider";
 import type { DaoIdEnum } from "@/shared/types/daos";
+import { ALL_DAOS } from "@/shared/types/daos";
 
 interface DaoRootLayoutProps {
   children: ReactNode;
@@ -13,10 +15,11 @@ export default async function DaoRootLayout({
   params,
 }: DaoRootLayoutProps) {
   const { daoId } = await params;
+  const daoIdEnum = daoId.toUpperCase() as DaoIdEnum;
 
-  return (
-    <DaoApolloProvider daoId={daoId.toUpperCase() as DaoIdEnum}>
-      {children}
-    </DaoApolloProvider>
-  );
+  if (!ALL_DAOS.includes(daoIdEnum)) {
+    notFound();
+  }
+
+  return <DaoApolloProvider daoId={daoIdEnum}>{children}</DaoApolloProvider>;
 }

--- a/apps/dashboard/features/governance/components/proposal-overview/ProposalItem.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/ProposalItem.tsx
@@ -27,7 +27,7 @@ export const getTextStatusColor = (status: ProposalStatus) => {
       return "text-success";
     case ProposalStatus.DEFEATED:
       return "text-error";
-    case ProposalStatus.CANCELLED:
+    case ProposalStatus.CANCELED:
       return "text-error";
     case ProposalStatus.QUEUED:
       return "text-success";
@@ -54,7 +54,7 @@ export const getStatusColorBar = (status: ProposalStatus) => {
       return "bg-success";
     case ProposalStatus.DEFEATED:
       return "bg-error";
-    case ProposalStatus.CANCELLED:
+    case ProposalStatus.CANCELED:
       return "bg-error";
     case ProposalStatus.QUEUED:
       return "bg-success";
@@ -81,7 +81,7 @@ export const getBackgroundStatusColor = (status: ProposalStatus) => {
       return "bg-surface-opacity-success";
     case ProposalStatus.DEFEATED:
       return "bg-surface-opacity-error";
-    case ProposalStatus.CANCELLED:
+    case ProposalStatus.CANCELED:
       return "bg-surface-opacity-error";
     case ProposalStatus.QUEUED:
       return "bg-surface-opacity-success";
@@ -108,7 +108,7 @@ export const getStatusText = (status: ProposalStatus) => {
       return "Executed";
     case ProposalStatus.DEFEATED:
       return "Defeated";
-    case ProposalStatus.CANCELLED:
+    case ProposalStatus.CANCELED:
       return "Cancelled";
     case ProposalStatus.QUEUED:
       return "Queued";

--- a/apps/dashboard/features/governance/types/index.ts
+++ b/apps/dashboard/features/governance/types/index.ts
@@ -5,7 +5,7 @@ export enum ProposalStatus {
   ONGOING = "ongoing",
   EXECUTED = "executed",
   DEFEATED = "defeated",
-  CANCELLED = "cancelled",
+  CANCELED = "canceled",
   QUEUED = "queued",
   PENDING_EXECUTION = "pending_execution",
   SUCCEEDED = "succeeded",

--- a/apps/dashboard/features/governance/utils/getProposalState.ts
+++ b/apps/dashboard/features/governance/utils/getProposalState.ts
@@ -10,6 +10,7 @@ export const getProposalState = (status: string): ProposalState => {
     case "executed":
     case "defeated":
     case "pending_execution":
+    case "canceled":
     case "cancelled":
     case "queued":
     case "no_quorum":

--- a/apps/dashboard/features/governance/utils/getProposalStatus.ts
+++ b/apps/dashboard/features/governance/utils/getProposalStatus.ts
@@ -13,8 +13,9 @@ export const getProposalStatus = (status: string): ProposalStatus => {
       return ProposalStatus.EXECUTED;
     case "defeated":
       return ProposalStatus.DEFEATED;
+    case "canceled":
     case "cancelled":
-      return ProposalStatus.CANCELLED;
+      return ProposalStatus.CANCELED;
     case "pending":
       return ProposalStatus.PENDING;
     case "no_quorum":

--- a/apps/dashboard/features/holders-and-delegates/utils/proposalsTableUtils.tsx
+++ b/apps/dashboard/features/holders-and-delegates/utils/proposalsTableUtils.tsx
@@ -67,8 +67,8 @@ export const proposalsFinalResultMapping = {
     icon: <XCircle className="text-error size-4" />,
   },
   CANCELED: {
-    text: "Cancel",
-    icon: <CircleMinus className="text-secondary size-4" />,
+    text: "Canceled",
+    icon: <CircleMinus className="text-error size-4" />,
   },
   QUEUED: {
     text: "Queued",

--- a/turbo.json
+++ b/turbo.json
@@ -62,7 +62,8 @@
       "outputs": ["drizzle/**"]
     },
     "@anticapture/api#dev": {
-      "dependsOn": ["@anticapture/observability#build"]
+      "dependsOn": ["@anticapture/observability#build"],
+      "passThroughEnv": ["*"]
     },
     "dev": {
       "persistent": true,


### PR DESCRIPTION
## Summary
- Fix canceled proposal status not displaying correctly — API returns `CANCELED` (one L) but dashboard only matched `CANCELLED` (two L's), causing canceled proposals to show as "Pending"
- Return proper 404 for invalid DAO routes (e.g. `/SOMETHING_WRONG/governance`) by moving validation to root `[daoId]/layout.tsx` using `notFound()`
- Pass `daoId` to `NounsClient` constructor for Lil Nouns / Nouns differentiation
- Update GraphQL schema and turbo config

## Test plan
- [ ] Navigate to `/lil_nouns/governance` and verify canceled proposals show "Canceled" status with red styling
- [ ] Navigate to `/INVALID_DAO/governance` and verify 404 page is shown
- [ ] Verify Lil Nouns and Nouns proposals load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)