### PR TITLE
Feat/from end date filter on offchain proposals

### DIFF
--- a/apps/api-gateway/schema.graphql
+++ b/apps/api-gateway/schema.graphql
@@ -193,7 +193,7 @@ type Query {
   tokenMetrics(metricType: queryInput_tokenMetrics_metricType!, startDate: Float, endDate: Float, orderDirection: queryInput_tokenMetrics_orderDirection = asc, limit: NonNegativeInt = 365, skip: NonNegativeInt): tokenMetrics_200_response
 
   """Returns a list of offchain (Snapshot) proposals"""
-  offchainProposals(skip: NonNegativeInt, limit: PositiveInt = 10, orderDirection: queryInput_offchainProposals_orderDirection = desc, status: JSON, fromDate: Float): offchainProposals_200_response
+  offchainProposals(skip: NonNegativeInt, limit: PositiveInt = 10, orderDirection: queryInput_offchainProposals_orderDirection = desc, status: JSON, fromDate: Float, endDate: Float): offchainProposals_200_response
 
   """Returns a single offchain (Snapshot) proposal by its ID"""
   offchainProposalById(id: String!): offchainProposalById_200_response
@@ -1348,6 +1348,7 @@ type dao_200_response {
   votingPeriod: String!
   timelockDelay: String!
   alreadySupportCalldataReview: Boolean!
+  supportOffchainData: Boolean!
 }
 
 type tokenMetrics_200_response {

--- a/apps/api/src/controllers/proposals/offchainProposals.ts
+++ b/apps/api/src/controllers/proposals/offchainProposals.ts
@@ -34,7 +34,7 @@ export function offchainProposals(
       },
     }),
     async (context) => {
-      const { skip, limit, orderDirection, status, fromDate } =
+      const { skip, limit, orderDirection, status, fromDate, endDate } =
         context.req.valid("query");
 
       const response = await service.getProposals({
@@ -43,6 +43,7 @@ export function offchainProposals(
         orderDirection,
         status,
         fromDate,
+        endDate,
       });
 
       return context.json(OffchainProposalsResponseSchema.parse(response));

--- a/apps/api/src/mappers/proposals/offchainProposals.ts
+++ b/apps/api/src/mappers/proposals/offchainProposals.ts
@@ -68,4 +68,5 @@ export const OffchainProposalsRequestSchema = z.object({
     .union([z.string().transform((a) => [a]), z.array(z.string())])
     .optional(),
   fromDate: z.coerce.number().optional(),
+  endDate: z.coerce.number().optional(),
 });

--- a/apps/api/src/repositories/proposals/offchainProposals.ts
+++ b/apps/api/src/repositories/proposals/offchainProposals.ts
@@ -12,6 +12,7 @@ export class OffchainProposalRepository {
     orderDirection: "asc" | "desc",
     state: string[] | undefined,
     fromDate: number | undefined,
+    endDate: number | undefined,
   ): Promise<DBOffchainProposal[]> {
     const whereClauses: SQL<unknown>[] = [];
 
@@ -23,6 +24,10 @@ export class OffchainProposalRepository {
 
     if (fromDate) {
       whereClauses.push(gte(offchainProposals.created, fromDate));
+    }
+
+    if (endDate) {
+      whereClauses.push(gte(offchainProposals.end, endDate));
     }
 
     return await this.db
@@ -49,6 +54,7 @@ export class OffchainProposalRepository {
   async getProposalsCount(
     state?: string[] | undefined,
     fromDate?: number | undefined,
+    endDate?: number | undefined,
   ): Promise<number> {
     const whereClauses: SQL<unknown>[] = [];
 
@@ -59,6 +65,10 @@ export class OffchainProposalRepository {
 
     if (fromDate) {
       whereClauses.push(gte(offchainProposals.created, fromDate));
+    }
+
+    if (endDate) {
+      whereClauses.push(gte(offchainProposals.end, endDate));
     }
 
     return this.db.$count(

--- a/apps/api/src/repositories/proposals/offchainProposals.unit.test.ts
+++ b/apps/api/src/repositories/proposals/offchainProposals.unit.test.ts
@@ -69,6 +69,7 @@ describe("OffchainProposalRepository", () => {
         "desc",
         undefined,
         undefined,
+        undefined,
       );
 
       expect(result.map((p) => p.id)).toEqual(["p2", "p3", "p1"]);
@@ -79,6 +80,7 @@ describe("OffchainProposalRepository", () => {
         0,
         10,
         "desc",
+        undefined,
         undefined,
         undefined,
       );
@@ -101,6 +103,7 @@ describe("OffchainProposalRepository", () => {
         "desc",
         ["ACTIVE"],
         undefined,
+        undefined,
       );
 
       expect(result).toHaveLength(2);
@@ -122,6 +125,7 @@ describe("OffchainProposalRepository", () => {
         "desc",
         undefined,
         2000,
+        undefined,
       );
 
       expect(result).toHaveLength(2);
@@ -143,6 +147,7 @@ describe("OffchainProposalRepository", () => {
         "asc",
         undefined,
         undefined,
+        undefined,
       );
 
       expect(result.map((p) => p.id)).toEqual(["p2", "p3", "p1"]);
@@ -161,6 +166,7 @@ describe("OffchainProposalRepository", () => {
         1,
         10,
         "desc",
+        undefined,
         undefined,
         undefined,
       );
@@ -184,10 +190,34 @@ describe("OffchainProposalRepository", () => {
         "desc",
         undefined,
         undefined,
+        undefined,
       );
 
       expect(result).toHaveLength(2);
       expect(result.map((p) => p.id)).toEqual(["p1", "p2"]);
+    });
+
+    it("should filter by endDate", async () => {
+      await db
+        .insert(offchainProposals)
+        .values([
+          createProposal({ id: "p1", end: 1000 }),
+          createProposal({ id: "p2", end: 2000 }),
+          createProposal({ id: "p3", end: 3000 }),
+        ]);
+
+      const result = await repository.getProposals(
+        0,
+        10,
+        "desc",
+        undefined,
+        undefined,
+        2000,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result.map((p) => p.id)).toContain("p2");
+      expect(result.map((p) => p.id)).toContain("p3");
     });
 
     it("should combine state and fromDate filters", async () => {
@@ -205,6 +235,48 @@ describe("OffchainProposalRepository", () => {
         "desc",
         ["active"],
         2000,
+        undefined,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe("p2");
+    });
+
+    it("should combine state, fromDate and endDate filters", async () => {
+      await db.insert(offchainProposals).values([
+        createProposal({
+          id: "p1",
+          state: "active",
+          created: 1000,
+          end: 1500,
+        }),
+        createProposal({
+          id: "p2",
+          state: "active",
+          created: 3000,
+          end: 4000,
+        }),
+        createProposal({
+          id: "p3",
+          state: "closed",
+          created: 3000,
+          end: 4000,
+        }),
+        createProposal({
+          id: "p4",
+          state: "active",
+          created: 3000,
+          end: 2000,
+        }),
+      ]);
+
+      const result = await repository.getProposals(
+        0,
+        10,
+        "desc",
+        ["active"],
+        2000,
+        3000,
       );
 
       expect(result).toHaveLength(1);

--- a/apps/api/src/services/proposals/offchainProposals.ts
+++ b/apps/api/src/services/proposals/offchainProposals.ts
@@ -7,10 +7,12 @@ interface OffchainProposalsRepository {
     orderDirection: "asc" | "desc",
     state: string[] | undefined,
     fromDate: number | undefined,
+    endDate: number | undefined,
   ): Promise<DBOffchainProposal[]>;
   getProposalsCount(
     state?: string[] | undefined,
     fromDate?: number | undefined,
+    endDate?: number | undefined,
   ): Promise<number>;
   getProposalById(proposalId: string): Promise<DBOffchainProposal | undefined>;
 }
@@ -21,6 +23,7 @@ export interface OffchainProposalsRequest {
   orderDirection?: "asc" | "desc";
   status?: string[];
   fromDate?: number;
+  endDate?: number;
 }
 
 export class OffchainProposalsService {
@@ -33,11 +36,19 @@ export class OffchainProposalsService {
       orderDirection = "desc",
       status,
       fromDate,
+      endDate,
     } = params;
 
     const [items, totalCount] = await Promise.all([
-      this.repo.getProposals(skip, limit, orderDirection, status, fromDate),
-      this.repo.getProposalsCount(status, fromDate),
+      this.repo.getProposals(
+        skip,
+        limit,
+        orderDirection,
+        status,
+        fromDate,
+        endDate,
+      ),
+      this.repo.getProposalsCount(status, fromDate, endDate),
     ]);
 
     return { items, totalCount };


### PR DESCRIPTION
## Summary

Add an optional `endDate` query parameter to the offchain proposals endpoint, allowing consumers to filter proposals whose `end` timestamp is greater than or equal to the given value. This complements the existing `fromDate` filter on the `created` field.

## Changes

- Added `endDate` as an optional coerced number field to `OffchainProposalsRequestSchema` (mapper)
- Added `endDate` parameter to `getProposals` and `getProposalsCount` in `OffchainProposalRepository`, filtering with `gte` on the proposal's `end` column
- Updated `OffchainProposalsService` interface, request type, and `getProposals` method to accept and forward `endDate` to the repository
- Updated the controller to destructure `endDate` from the validated query and pass it to the service
- Added unit tests for filtering by `endDate` alone and in combination with `state` + `fromDate`
