### PR TITLE
fix: metatag data

### DIFF
--- a/apps/dashboard/app/[daoId]/(main)/attack-profitability/page.tsx
+++ b/apps/dashboard/app/[daoId]/(main)/attack-profitability/page.tsx
@@ -19,18 +19,18 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   const canonicalPath = `/${params.daoId}/attack-profitability`;
 
   return {
-    title: `Anticapture - ${daoId} DAO Attack Profitability`,
-    description: `Analyze attack profitability and governance capture costs for ${daoId} DAO.`,
+    title: `${daoId} DAO Hostile Takeover Cost Analysis | Attack Profitability — Anticapture`,
+    description: `Calculate the economic cost of a hostile takeover of ${daoId} DAO — including token acquisition costs, governance capture thresholds, and attack profitability under different market scenarios.`,
     alternates: { canonical: canonicalPath },
     openGraph: {
       url: canonicalPath,
-      title: `Anticapture - ${daoId} DAO Attack Profitability`,
-      description: `Analyze attack profitability and governance capture costs for ${daoId} DAO.`,
+      title: `${daoId} DAO Hostile Takeover Cost Analysis | Attack Profitability — Anticapture`,
+      description: `Calculate the economic cost of a hostile takeover of ${daoId} DAO — including token acquisition costs, governance capture thresholds, and attack profitability under different market scenarios.`,
     },
     twitter: {
       card: "summary_large_image",
-      title: `Anticapture - ${daoId} DAO Attack Profitability`,
-      description: `Analyze attack profitability and governance capture costs for ${daoId} DAO.`,
+      title: `${daoId} DAO Hostile Takeover Cost Analysis | Attack Profitability — Anticapture`,
+      description: `Calculate the economic cost of a hostile takeover of ${daoId} DAO — including token acquisition costs, governance capture thresholds, and attack profitability under different market scenarios.`,
     },
   };
 }

--- a/apps/dashboard/app/[daoId]/(main)/holders-and-delegates/page.tsx
+++ b/apps/dashboard/app/[daoId]/(main)/holders-and-delegates/page.tsx
@@ -15,18 +15,18 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   const canonicalPath = `/${params.daoId}/holders-and-delegates`;
 
   return {
-    title: `Anticapture - ${daoId} DAO Holders and Delegates`,
-    description: `Explore ${daoId} DAO token holders and delegate distribution.`,
+    title: `${daoId} DAO Token Holders & Delegate Security Analysis — Anticapture`,
+    description: `Analyze token holder concentration and delegate distribution for ${daoId} DAO to identify governance capture risks, whale dominance, and delegate centralization threats.`,
     alternates: { canonical: canonicalPath },
     openGraph: {
       url: canonicalPath,
-      title: `Anticapture - ${daoId} DAO Holders and Delegates`,
-      description: `Explore ${daoId} DAO token holders and delegate distribution.`,
+      title: `${daoId} DAO Token Holders & Delegate Security Analysis — Anticapture`,
+      description: `Analyze token holder concentration and delegate distribution for ${daoId} DAO to identify governance capture risks, whale dominance, and delegate centralization threats.`,
     },
     twitter: {
       card: "summary_large_image",
-      title: `Anticapture - ${daoId} DAO Holders and Delegates`,
-      description: `Explore ${daoId} DAO token holders and delegate distribution.`,
+      title: `${daoId} DAO Token Holders & Delegate Security Analysis — Anticapture`,
+      description: `Analyze token holder concentration and delegate distribution for ${daoId} DAO to identify governance capture risks, whale dominance, and delegate centralization threats.`,
     },
   };
 }

--- a/apps/dashboard/app/[daoId]/(main)/page.tsx
+++ b/apps/dashboard/app/[daoId]/(main)/page.tsx
@@ -16,18 +16,18 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   const canonicalPath = `/${params.daoId}`;
 
   return {
-    title: `Anticapture - ${daoId} DAO`,
-    description: `Explore and mitigate governance risks in ${daoId} DAO.`,
+    title: `${daoId} DAO Governance Security | Risk Dashboard — Anticapture`,
+    description: `Monitor governance security, hostile takeover risks, token concentration, and resilience scores for ${daoId} DAO. Powered by Anticapture's open security framework.`,
     alternates: { canonical: canonicalPath },
     openGraph: {
       url: canonicalPath,
-      title: `Anticapture - ${daoId} DAO`,
-      description: `Explore and mitigate governance risks in ${daoId} DAO.`,
+      title: `${daoId} DAO Governance Security | Risk Dashboard — Anticapture`,
+      description: `Monitor governance security, hostile takeover risks, token concentration, and resilience scores for ${daoId} DAO. Powered by Anticapture's open security framework.`,
     },
     twitter: {
       card: "summary_large_image",
-      title: `Anticapture - ${daoId} DAO`,
-      description: `Explore and mitigate governance risks in ${daoId} DAO.`,
+      title: `${daoId} DAO Governance Security | Risk Dashboard — Anticapture`,
+      description: `Monitor governance security, hostile takeover risks, token concentration, and resilience scores for ${daoId} DAO. Powered by Anticapture's open security framework.`,
     },
   };
 }

--- a/apps/dashboard/app/[daoId]/(main)/resilience-stages/page.tsx
+++ b/apps/dashboard/app/[daoId]/(main)/resilience-stages/page.tsx
@@ -15,18 +15,18 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   const canonicalPath = `/${params.daoId}/resilience-stages`;
 
   return {
-    title: `Anticapture - ${daoId} DAO Resilience Stages`,
-    description: `Assess ${daoId} DAO governance resilience and security stages.`,
+    title: `${daoId} DAO Governance Resilience Score & Security Stages — Anticapture`,
+    description: `Track the governance resilience stages of ${daoId} DAO — from vulnerable to fully decentralized — with security scores, milestone assessments, and anti-capture metrics.`,
     alternates: { canonical: canonicalPath },
     openGraph: {
       url: canonicalPath,
-      title: `Anticapture - ${daoId} DAO Resilience Stages`,
-      description: `Assess ${daoId} DAO governance resilience and security stages.`,
+      title: `${daoId} DAO Governance Resilience Score & Security Stages — Anticapture`,
+      description: `Track the governance resilience stages of ${daoId} DAO — from vulnerable to fully decentralized — with security scores, milestone assessments, and anti-capture metrics.`,
     },
     twitter: {
       card: "summary_large_image",
-      title: `Anticapture - ${daoId} DAO Resilience Stages`,
-      description: `Assess ${daoId} DAO governance resilience and security stages.`,
+      title: `${daoId} DAO Governance Resilience Score & Security Stages — Anticapture`,
+      description: `Track the governance resilience stages of ${daoId} DAO — from vulnerable to fully decentralized — with security scores, milestone assessments, and anti-capture metrics.`,
     },
   };
 }

--- a/apps/dashboard/app/[daoId]/(main)/risk-analysis/page.tsx
+++ b/apps/dashboard/app/[daoId]/(main)/risk-analysis/page.tsx
@@ -19,18 +19,18 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   const canonicalPath = `/${params.daoId}/risk-analysis`;
 
   return {
-    title: `Anticapture - ${daoId} DAO Risk Analysis`,
-    description: `Analyze governance risks and security threats for ${daoId} DAO.`,
+    title: `${daoId} DAO Governance Risk Analysis | Hostile Takeover Assessment — Anticapture`,
+    description: `Deep governance risk analysis for ${daoId} DAO — quantifying hostile takeover costs, governance capture vectors, voter apathy risks, and attack profitability metrics.`,
     alternates: { canonical: canonicalPath },
     openGraph: {
       url: canonicalPath,
-      title: `Anticapture - ${daoId} DAO Risk Analysis`,
-      description: `Analyze governance risks and security threats for ${daoId} DAO.`,
+      title: `${daoId} DAO Governance Risk Analysis | Hostile Takeover Assessment — Anticapture`,
+      description: `Deep governance risk analysis for ${daoId} DAO — quantifying hostile takeover costs, governance capture vectors, voter apathy risks, and attack profitability metrics.`,
     },
     twitter: {
       card: "summary_large_image",
-      title: `Anticapture - ${daoId} DAO Risk Analysis`,
-      description: `Analyze governance risks and security threats for ${daoId} DAO.`,
+      title: `${daoId} DAO Governance Risk Analysis | Hostile Takeover Assessment — Anticapture`,
+      description: `Deep governance risk analysis for ${daoId} DAO — quantifying hostile takeover costs, governance capture vectors, voter apathy risks, and attack profitability metrics.`,
     },
   };
 }

--- a/apps/dashboard/app/[daoId]/(main)/service-providers/page.tsx
+++ b/apps/dashboard/app/[daoId]/(main)/service-providers/page.tsx
@@ -12,17 +12,21 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
   const daoId = params.daoId.toUpperCase() as DaoIdEnum;
 
+  const canonicalPath = `/${params.daoId}/service-providers`;
+
   return {
-    title: `Anticapture - ${daoId} Service Providers`,
-    description: `Monitor the publication status of quarterly reports from ${daoId} DAO-funded service providers.`,
+    title: `${daoId} DAO Service Provider Accountability | Governance Transparency — Anticapture`,
+    description: `Track quarterly report compliance and accountability of ${daoId} DAO-funded service providers. Monitor governance transparency and identify reporting gaps that create security risks.`,
+    alternates: { canonical: canonicalPath },
     openGraph: {
-      title: `Anticapture - ${daoId} Service Providers`,
-      description: `Monitor the publication status of quarterly reports from ${daoId} DAO-funded service providers.`,
+      url: canonicalPath,
+      title: `${daoId} DAO Service Provider Accountability | Governance Transparency — Anticapture`,
+      description: `Track quarterly report compliance and accountability of ${daoId} DAO-funded service providers. Monitor governance transparency and identify reporting gaps that create security risks.`,
     },
     twitter: {
       card: "summary_large_image",
-      title: `Anticapture - ${daoId} Service Providers`,
-      description: `Monitor the publication status of quarterly reports from ${daoId} DAO-funded service providers.`,
+      title: `${daoId} DAO Service Provider Accountability | Governance Transparency — Anticapture`,
+      description: `Track quarterly report compliance and accountability of ${daoId} DAO-funded service providers. Monitor governance transparency and identify reporting gaps that create security risks.`,
     },
   };
 }

--- a/apps/dashboard/app/[daoId]/(main)/token-distribution/page.tsx
+++ b/apps/dashboard/app/[daoId]/(main)/token-distribution/page.tsx
@@ -19,18 +19,18 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   const canonicalPath = `/${params.daoId}/token-distribution`;
 
   return {
-    title: `Anticapture - ${daoId} DAO Token Distribution`,
-    description: `Analyze token distribution and concentration for ${daoId} DAO.`,
+    title: `${daoId} DAO Token Distribution & Governance Concentration Risk — Anticapture`,
+    description: `Examine token distribution, concentration metrics, and Gini coefficient for ${daoId} DAO to assess governance security risks and hostile takeover susceptibility.`,
     alternates: { canonical: canonicalPath },
     openGraph: {
       url: canonicalPath,
-      title: `Anticapture - ${daoId} DAO Token Distribution`,
-      description: `Analyze token distribution and concentration for ${daoId} DAO.`,
+      title: `${daoId} DAO Token Distribution & Governance Concentration Risk — Anticapture`,
+      description: `Examine token distribution, concentration metrics, and Gini coefficient for ${daoId} DAO to assess governance security risks and hostile takeover susceptibility.`,
     },
     twitter: {
       card: "summary_large_image",
-      title: `Anticapture - ${daoId} DAO Token Distribution`,
-      description: `Analyze token distribution and concentration for ${daoId} DAO.`,
+      title: `${daoId} DAO Token Distribution & Governance Concentration Risk — Anticapture`,
+      description: `Examine token distribution, concentration metrics, and Gini coefficient for ${daoId} DAO to assess governance security risks and hostile takeover susceptibility.`,
     },
   };
 }

--- a/apps/dashboard/app/[daoId]/(secondary)/governance/page.tsx
+++ b/apps/dashboard/app/[daoId]/(secondary)/governance/page.tsx
@@ -14,24 +14,21 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
   const daoId = params.daoId.toUpperCase() as DaoIdEnum;
 
-  const ogTitle = `Anticapture - ${daoId} DAO`;
-  const ogDescription = `Explore and mitigate governance risks in ${daoId} DAO.`;
-
   const canonicalPath = `/${params.daoId}/governance`;
 
   return {
-    title: ogTitle,
-    description: ogDescription,
+    title: `${daoId} DAO Governance Proposals | Security Analysis — Anticapture`,
+    description: `Browse and analyze governance proposals for ${daoId} DAO. Track voting patterns, delegate participation, and governance capture signals across on-chain proposals.`,
     alternates: { canonical: canonicalPath },
     openGraph: {
       url: canonicalPath,
-      title: ogTitle,
-      description: ogDescription,
+      title: `${daoId} DAO Governance Proposals | Security Analysis — Anticapture`,
+      description: `Browse and analyze governance proposals for ${daoId} DAO. Track voting patterns, delegate participation, and governance capture signals across on-chain proposals.`,
     },
     twitter: {
       card: "summary_large_image",
-      title: ogTitle,
-      description: ogDescription,
+      title: `${daoId} DAO Governance Proposals | Security Analysis — Anticapture`,
+      description: `Browse and analyze governance proposals for ${daoId} DAO. Track voting patterns, delegate participation, and governance capture signals across on-chain proposals.`,
     },
   };
 }

--- a/apps/dashboard/app/[daoId]/(secondary)/governance/proposal/[proposalId]/page.tsx
+++ b/apps/dashboard/app/[daoId]/(secondary)/governance/proposal/[proposalId]/page.tsx
@@ -7,28 +7,28 @@ import { HeaderSidebar, StickyPageHeader } from "@/widgets";
 import { HeaderMobile } from "@/widgets/HeaderMobile";
 
 type Props = {
-  params: Promise<{ daoId: string }>;
+  params: Promise<{ daoId: string; proposalId: string }>;
 };
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
   const daoId = params.daoId.toUpperCase() as DaoIdEnum;
 
-  const canonicalPath = `/${params.daoId}/governance/proposal/${(params as { daoId: string; proposalId: string }).proposalId}`;
+  const canonicalPath = `/${params.daoId}/governance/proposal/${params.proposalId}`;
 
   return {
-    title: `Anticapture - ${daoId} DAO`,
-    description: `Explore and mitigate governance risks in ${daoId} DAO.`,
+    title: `${daoId} DAO Governance Proposal | Security Analysis — Anticapture`,
+    description: `Analyze the governance security implications of this proposal in ${daoId} DAO — including vote distribution, delegate participation, and potential governance capture signals.`,
     alternates: { canonical: canonicalPath },
     openGraph: {
       url: canonicalPath,
-      title: `Anticapture - ${daoId} DAO`,
-      description: `Explore and mitigate governance risks in ${daoId} DAO.`,
+      title: `${daoId} DAO Governance Proposal | Security Analysis — Anticapture`,
+      description: `Analyze the governance security implications of this proposal in ${daoId} DAO — including vote distribution, delegate participation, and potential governance capture signals.`,
     },
     twitter: {
       card: "summary_large_image",
-      title: `Anticapture - ${daoId} DAO`,
-      description: `Explore and mitigate governance risks in ${daoId} DAO.`,
+      title: `${daoId} DAO Governance Proposal | Security Analysis — Anticapture`,
+      description: `Analyze the governance security implications of this proposal in ${daoId} DAO — including vote distribution, delegate participation, and potential governance capture signals.`,
     },
   };
 }

--- a/apps/dashboard/app/alerts/page.tsx
+++ b/apps/dashboard/app/alerts/page.tsx
@@ -6,16 +6,19 @@ import { HeaderSidebar } from "@/widgets";
 import { HeaderMobile } from "@/widgets/HeaderMobile";
 
 export const metadata: Metadata = {
-  title: "Anticapture - Alerts",
-  description: "Stay updated with governance alerts and notifications.",
+  title: "DAO Governance Security Alerts | Anticapture",
+  description:
+    "Receive real-time alerts on governance security threats, hostile takeover attempts, abnormal voting patterns, and token concentration changes across monitored DAOs.",
   openGraph: {
-    title: "Anticapture - Alerts",
-    description: "Stay updated with governance alerts and notifications.",
+    title: "DAO Governance Security Alerts | Anticapture",
+    description:
+      "Receive real-time alerts on governance security threats, hostile takeover attempts, abnormal voting patterns, and token concentration changes across monitored DAOs.",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Anticapture - Alerts",
-    description: "Stay updated with governance alerts and notifications.",
+    title: "DAO Governance Security Alerts | Anticapture",
+    description:
+      "Receive real-time alerts on governance security threats, hostile takeover attempts, abnormal voting patterns, and token concentration changes across monitored DAOs.",
   },
 };
 

--- a/apps/dashboard/app/contact/page.tsx
+++ b/apps/dashboard/app/contact/page.tsx
@@ -3,16 +3,19 @@ import type { Metadata } from "next";
 import ContactPageClient from "@/app/contact/ContactPageClient";
 
 export const metadata: Metadata = {
-  title: "Anticapture - Contact",
-  description: "Get in touch with the Anticapture team.",
+  title: "Contact Anticapture | DAO Governance Security Team",
+  description:
+    "Contact the Anticapture team for governance security research partnerships, DAO integrations, or questions about hostile takeover risk analysis and the governance security framework.",
   openGraph: {
-    title: "Anticapture - Contact",
-    description: "Get in touch with the Anticapture team.",
+    title: "Contact Anticapture | DAO Governance Security Team",
+    description:
+      "Contact the Anticapture team for governance security research partnerships, DAO integrations, or questions about hostile takeover risk analysis and the governance security framework.",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Anticapture - Contact",
-    description: "Get in touch with the Anticapture team.",
+    title: "Contact Anticapture | DAO Governance Security Team",
+    description:
+      "Contact the Anticapture team for governance security research partnerships, DAO integrations, or questions about hostile takeover risk analysis and the governance security framework.",
   },
 };
 

--- a/apps/dashboard/app/donate/page.tsx
+++ b/apps/dashboard/app/donate/page.tsx
@@ -6,16 +6,19 @@ import { HeaderSidebar } from "@/widgets";
 import { HeaderMobile } from "@/widgets/HeaderMobile";
 
 export const metadata: Metadata = {
-  title: "Anticapture - Donate",
-  description: "Support DAO governance security research and development.",
+  title: "Support DAO Governance Security Research | Anticapture",
+  description:
+    "Support Anticapture's open-source research on DAO governance security, hostile takeover prevention, and governance capture detection. Help keep the security framework free and open.",
   openGraph: {
-    title: "Anticapture - Donate",
-    description: "Support DAO governance security research and development.",
+    title: "Support DAO Governance Security Research | Anticapture",
+    description:
+      "Support Anticapture's open-source research on DAO governance security, hostile takeover prevention, and governance capture detection. Help keep the security framework free and open.",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Anticapture - Donate",
-    description: "Support DAO governance security research and development.",
+    title: "Support DAO Governance Security Research | Anticapture",
+    description:
+      "Support Anticapture's open-source research on DAO governance security, hostile takeover prevention, and governance capture detection. Help keep the security framework free and open.",
   },
 };
 

--- a/apps/dashboard/app/faq/page.tsx
+++ b/apps/dashboard/app/faq/page.tsx
@@ -6,16 +6,19 @@ import { HeaderSidebar } from "@/widgets";
 import { HeaderMobile } from "@/widgets/HeaderMobile";
 
 export const metadata: Metadata = {
-  title: "Anticapture - FAQ",
-  description: "Frequently asked questions about DAO governance security.",
+  title: "DAO Governance Security FAQ | Anticapture",
+  description:
+    "Answers to common questions about DAO governance security, hostile takeover risks, governance capture, resilience metrics, and how Anticapture monitors and protects decentralized protocols.",
   openGraph: {
-    title: "Anticapture - FAQ",
-    description: "Frequently asked questions about DAO governance security.",
+    title: "DAO Governance Security FAQ | Anticapture",
+    description:
+      "Answers to common questions about DAO governance security, hostile takeover risks, governance capture, resilience metrics, and how Anticapture monitors and protects decentralized protocols.",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Anticapture - FAQ",
-    description: "Frequently asked questions about DAO governance security.",
+    title: "DAO Governance Security FAQ | Anticapture",
+    description:
+      "Answers to common questions about DAO governance security, hostile takeover risks, governance capture, resilience metrics, and how Anticapture monitors and protects decentralized protocols.",
   },
 };
 

--- a/apps/dashboard/app/glossary/page.tsx
+++ b/apps/dashboard/app/glossary/page.tsx
@@ -3,16 +3,19 @@ import type { Metadata } from "next";
 import GlossaryPageClient from "@/app/glossary/GlossaryPageClient";
 
 export const metadata: Metadata = {
-  title: "Anticapture - Glossary",
-  description: "DAO governance terminology and definitions.",
+  title: "DAO Governance Security Glossary | Anticapture",
+  description:
+    "Comprehensive glossary of DAO governance security terms — including governance capture, hostile takeover, quorum attack, delegate concentration, and resilience stages.",
   openGraph: {
-    title: "Anticapture - Glossary",
-    description: "DAO governance terminology and definitions.",
+    title: "DAO Governance Security Glossary | Anticapture",
+    description:
+      "Comprehensive glossary of DAO governance security terms — including governance capture, hostile takeover, quorum attack, delegate concentration, and resilience stages.",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Anticapture - Glossary",
-    description: "DAO governance terminology and definitions.",
+    title: "DAO Governance Security Glossary | Anticapture",
+    description:
+      "Comprehensive glossary of DAO governance security terms — including governance capture, hostile takeover, quorum attack, delegate concentration, and resilience stages.",
   },
 };
 

--- a/apps/dashboard/app/layout.tsx
+++ b/apps/dashboard/app/layout.tsx
@@ -29,23 +29,30 @@ const baseUrl =
 
 export const metadata: Metadata = {
   metadataBase: new URL(baseUrl),
-  title: "Anticapture",
+  title: "Anticapture | DAO Governance Security Dashboard",
   keywords: [
-    "governance",
-    "dao",
-    "data",
-    "risk",
-    "DAOs",
-    "governance security",
+    "DAO governance security",
+    "hostile takeover prevention",
+    "governance capture",
+    "governance risk analysis",
+    "DAO security framework",
+    "token distribution",
+    "delegate monitoring",
+    "resilience metrics",
+    "DeFi governance",
+    "on-chain governance security",
   ],
   openGraph: {
-    title: "Anticapture",
-    description: "Explore and address governance risks in top DAOs.",
+    title: "Anticapture — DAO Governance Security & Risk Analysis Platform",
+    description:
+      "Anticapture is a DAO governance security platform that quantifies hostile takeover risk, detects governance capture, and tracks resilience metrics across major DAOs.",
   },
   twitter: {
     card: "summary_large_image",
-    title: `Anticapture - DAO`,
-    description: `Explore and mitigate governance risks in DAO.`,
+    title:
+      "Anticapture | DAO Governance Security & Hostile Takeover Prevention",
+    description:
+      "Monitor governance security, hostile takeover risks, and token distribution across DAOs. Anticapture is the open security framework for decentralized governance.",
   },
 };
 

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -5,20 +5,20 @@ import { Footer } from "@/shared/components/design-system/footer/Footer";
 import { HeaderSidebar } from "@/widgets";
 import { HeaderMobile } from "@/widgets/HeaderMobile";
 
-const metadataDescription =
-  "Anticapture | Monitor DAO governance risk. Track delegation shifts, voting power concentration, and onchain risk indicators across Ethereum DAOs.";
-
 export const metadata: Metadata = {
-  title: "Anticapture - Panel",
-  description: metadataDescription,
+  title: "Anticapture | DAO Security Dashboard — Governance Risk Overview",
+  description:
+    "Explore real-time governance security metrics across major DAOs. Anticapture's dashboard tracks hostile takeover risks, token concentration, delegate activity, and resilience scores.",
   openGraph: {
-    title: "Anticapture - Panel",
-    description: metadataDescription,
+    title: "Anticapture | DAO Security Dashboard — Governance Risk Overview",
+    description:
+      "Explore real-time governance security metrics across major DAOs. Anticapture's dashboard tracks hostile takeover risks, token concentration, delegate activity, and resilience scores.",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Anticapture - Panel",
-    description: metadataDescription,
+    title: "Anticapture | DAO Security Dashboard — Governance Risk Overview",
+    description:
+      "Explore real-time governance security metrics across major DAOs. Anticapture's dashboard tracks hostile takeover risks, token concentration, delegate activity, and resilience scores.",
   },
 };
 


### PR DESCRIPTION
    - Root layout: expanded keywords, rewrote OG/Twitter copy with full value proposition                                       
    - Static pages: titles lead with keyword cluster instead of Anticapture - …
    - Dynamic DAO pages: DAO name leads title, unique descriptions per route
    - Critical cannibalization fix: /[daoId]/governance and /[daoId]/governance/proposal/[proposalId] were identical to the root
    - DAO page — both now have distinct titles/descriptions. Also fixed the missing proposalId type on the proposal page params.