### PR TITLE
refactor: daos return type

### DIFF
--- a/apps/api-gateway/meshrc.ts
+++ b/apps/api-gateway/meshrc.ts
@@ -70,7 +70,7 @@ export default processConfig(
       }
 
       type DAOList {
-        items: [dao_200_response!]!
+        items: [DaoResponse!]!
         totalCount: Int!
       }
 


### PR DESCRIPTION
## Summary

Fix the `daos` query in the API Gateway returning a fake/empty type (`dao_200_response` with only a `_fake` field) instead of the actual DAO data. The root cause was the `DAOList` type in the Mesh additional type definitions referencing the auto-generated stub type instead of the properly resolved `DaoResponse` schema.

## Changes

- **apps/api-gateway/meshrc.ts**: Changed `DAOList.items` type from `[dao_200_response!]!` to `[DaoResponse!]!` so the GraphQL schema exposes the actual DAO fields (id, chainId, quorum, etc.) instead of a stub `_fake` field.

## Problem snapshot

<img width="1427" height="843" alt="Screenshot 2026-03-31 at 18 15 28" src="https://github.com/user-attachments/assets/39f44af6-d8f0-43f6-85df-cdeb9a57f4f0" />
