### PR TITLE
fix(spp): improve mobile UI for service providers page

### DIFF
--- a/apps/dashboard/features/service-providers/ServiceProvidersSection.tsx
+++ b/apps/dashboard/features/service-providers/ServiceProvidersSection.tsx
@@ -57,7 +57,7 @@ export const ServiceProvidersSection = () => {
           <SubSectionsContainer>
             <div className="flex flex-col gap-4">
               {programKeys.length > 1 && (
-                <div className="flex items-center justify-between gap-3">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between sm:gap-3">
                   <PillTabGroup
                     tabs={programKeys.map((key) => ({
                       label: key,
@@ -67,7 +67,7 @@ export const ServiceProvidersSection = () => {
                     onTabChange={(value) => setSelectedProgram(value)}
                   />
                   {activeProgramDef && (
-                    <div className="flex items-center gap-1.5">
+                    <div className="mt-3 flex items-center gap-1.5 sm:mt-0">
                       <DefaultLink
                         size="sm"
                         openInNewTab
@@ -89,7 +89,7 @@ export const ServiceProvidersSection = () => {
                         openInNewTab
                         href={activeProgramDef.selectionProposal.forumUrl}
                       >
-                        {activeProgramDef.selectionProposal.title.toUpperCase()}
+                        PROVIDER SELECTION
                       </DefaultLink>
                     </div>
                   )}

--- a/apps/dashboard/features/service-providers/components/ProviderNameCell.tsx
+++ b/apps/dashboard/features/service-providers/components/ProviderNameCell.tsx
@@ -24,7 +24,7 @@ export const ProviderNameCell = ({
     .toUpperCase();
 
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex min-w-0 items-center gap-3 overflow-hidden">
       <div className="bg-surface-contrast border-border-contrast flex size-6 shrink-0 items-center justify-center rounded-full border text-[9px] font-bold text-white">
         {avatarUrl ? (
           <Image
@@ -43,7 +43,7 @@ export const ProviderNameCell = ({
         <span className="text-primary truncate text-sm font-medium">
           {name}
         </span>
-        <div className="flex items-center gap-1.5">
+        <div className="hidden items-center gap-1.5 sm:flex">
           {websiteUrl && (
             <DefaultLink size="sm" openInNewTab href={websiteUrl}>
               WEBSITE

--- a/apps/dashboard/features/service-providers/components/ServiceProvidersTable.tsx
+++ b/apps/dashboard/features/service-providers/components/ServiceProvidersTable.tsx
@@ -184,7 +184,7 @@ export const ServiceProvidersTable = ({
         ),
       meta: {
         columnClassName: cn(
-          "w-[260px] px-2 sticky left-0 z-20 [&:is(th)]:bg-surface-contrast bg-surface-background lg:bg-surface-default",
+          "w-[130px] sm:w-[260px] px-2 sticky left-0 z-20 [&:is(th)]:bg-surface-contrast bg-surface-background lg:bg-surface-default",
           hasYear2 &&
             "after:absolute after:right-0 after:top-0 after:bottom-0 after:w-px after:content-[''] after:bg-border-default",
         ),
@@ -260,6 +260,7 @@ export const ServiceProvidersTable = ({
       wrapperClassName="overflow-x-auto overflow-y-visible"
       withDownloadCSV={true}
       withSorting={true}
+      mobileTableFixed
       fillHeight
     />
   );


### PR DESCRIPTION
- Stack tabs and links into separate rows on mobile
- Hide website/proposal links in name cell on mobile
- Reduce name column width on mobile with truncation + ellipsis
- Enforce table-fixed layout on mobile for column widths
- Rename selection proposal link label to "PROVIDER SELECTION"