### PR TITLE
Grafana "Anticapture V2" data visualization Dashboard

### DIFF
--- a/apps/api-gateway/src/index.ts
+++ b/apps/api-gateway/src/index.ts
@@ -9,6 +9,13 @@ import "./_dev-reload";
 import config from "../meshrc";
 import { exporter } from "./instrumentation";
 import { validateAuthToken } from "./auth";
+import { httpRequestDuration, httpRequestTotal } from "./metrics";
+
+function resolveClientSource(header: string | undefined): string {
+  if (header === "notification-system") return "notification-system";
+  if (header === "anticapture-frontend") return "anticapture-frontend";
+  return "other";
+}
 
 const bootstrap = async () => {
   const mesh = await getMesh(await config);
@@ -38,6 +45,24 @@ const bootstrap = async () => {
       return;
     }
     if (!validateAuthToken(req, res)) return;
+
+    const start = performance.now();
+    const clientSource = resolveClientSource(
+      req.headers["x-client-source"] as string | undefined,
+    );
+
+    res.on("finish", () => {
+      const duration = (performance.now() - start) / 1000;
+      const labels = {
+        http_request_method: req.method ?? "UNKNOWN",
+        http_route: req.url ?? "/",
+        http_response_status_code: res.statusCode,
+        client_source: clientSource,
+      };
+      httpRequestDuration.record(duration, labels);
+      httpRequestTotal.add(1, labels);
+    });
+
     handler(req, res);
   });
 

--- a/apps/api-gateway/src/index.ts
+++ b/apps/api-gateway/src/index.ts
@@ -55,7 +55,7 @@ const bootstrap = async () => {
       const duration = (performance.now() - start) / 1000;
       const labels = {
         http_request_method: req.method ?? "UNKNOWN",
-        http_route: req.url ?? "/",
+        http_route: req.url ? new URL(req.url, "http://localhost").pathname : "/",
         http_response_status_code: res.statusCode,
         client_source: clientSource,
       };

--- a/apps/api-gateway/src/index.ts
+++ b/apps/api-gateway/src/index.ts
@@ -9,7 +9,7 @@ import "./_dev-reload";
 import config from "../meshrc";
 import { exporter } from "./instrumentation";
 import { validateAuthToken } from "./auth";
-import { httpRequestDuration, httpRequestTotal } from "./metrics";
+import { httpRequestDuration } from "./metrics";
 
 function resolveClientSource(header: string | undefined): string {
   if (header === "notification-system") return "notification-system";
@@ -60,7 +60,6 @@ const bootstrap = async () => {
         client_source: clientSource,
       };
       httpRequestDuration.record(duration, labels);
-      httpRequestTotal.add(1, labels);
     });
 
     handler(req, res);

--- a/apps/api-gateway/src/metrics.ts
+++ b/apps/api-gateway/src/metrics.ts
@@ -1,0 +1,22 @@
+import { meterProvider } from "./instrumentation";
+
+const meter = meterProvider.getMeter("anticapture-gateway");
+
+export const httpRequestDuration = meter.createHistogram(
+  "http_server_request_duration_seconds",
+  {
+    description: "Duration of HTTP requests in seconds",
+    advice: {
+      explicitBucketBoundaries: [
+        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5,
+      ],
+    },
+  },
+);
+
+export const httpRequestTotal = meter.createCounter(
+  "http_server_requests_total",
+  {
+    description: "Total number of HTTP requests",
+  },
+);

--- a/apps/api-gateway/src/metrics.ts
+++ b/apps/api-gateway/src/metrics.ts
@@ -8,15 +8,8 @@ export const httpRequestDuration = meter.createHistogram(
     description: "Duration of HTTP requests in seconds",
     advice: {
       explicitBucketBoundaries: [
-        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5,
+        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
       ],
     },
-  },
-);
-
-export const httpRequestTotal = meter.createCounter(
-  "http_server_requests_total",
-  {
-    description: "Total number of HTTP requests",
   },
 );

--- a/apps/dashboard/app/api/gateful/[...path]/route.ts
+++ b/apps/dashboard/app/api/gateful/[...path]/route.ts
@@ -29,10 +29,7 @@ const getForwardHeaders = (request: NextRequest) => {
     headers.set("content-type", contentType);
   }
 
-  const clientSource = request.headers.get("x-client-source");
-  if (clientSource) {
-    headers.set("x-client-source", clientSource);
-  }
+  headers.set("x-client-source", "anticapture-frontend");
 
   return headers;
 };

--- a/apps/dashboard/app/api/gateful/[...path]/route.ts
+++ b/apps/dashboard/app/api/gateful/[...path]/route.ts
@@ -29,6 +29,11 @@ const getForwardHeaders = (request: NextRequest) => {
     headers.set("content-type", contentType);
   }
 
+  const clientSource = request.headers.get("x-client-source");
+  if (clientSource) {
+    headers.set("x-client-source", clientSource);
+  }
+
   return headers;
 };
 

--- a/apps/gateful/src/metrics.ts
+++ b/apps/gateful/src/metrics.ts
@@ -1,0 +1,8 @@
+import { meterProvider } from "./instrumentation.js";
+
+const meter = meterProvider.getMeter("anticapture-gateful");
+
+export const cacheRequestTotal = meter.createCounter("cache_requests_total", {
+  description:
+    "Total number of cache lookups, labelled by result (hit/miss) and route",
+});

--- a/apps/gateful/src/middlewares/cache.ts
+++ b/apps/gateful/src/middlewares/cache.ts
@@ -44,7 +44,7 @@ export function cacheMiddleware(redis: CacheStore) {
     // DAO segment (useful for per-DAO cache panels) while collapsing all
     // sub-resource segments so each DAO produces exactly one time-series.
     const [, dao] = c.req.path.split("/");
-    const route = dao ? `/${dao}/*` : "/";
+    const route = dao ? `/${dao.toLowerCase()}/*` : "/";
 
     // --- Request phase: check for a cached response ---
     // Fail open: if Redis is unavailable, .catch returns null and we proceed normally.

--- a/apps/gateful/src/middlewares/cache.ts
+++ b/apps/gateful/src/middlewares/cache.ts
@@ -40,16 +40,22 @@ export function cacheMiddleware(redis: CacheStore) {
 
     const key = c.req.url;
 
+    // Normalize the path to a fixed-cardinality label: "/<dao>/*" keeps the
+    // DAO segment (useful for per-DAO cache panels) while collapsing all
+    // sub-resource segments so each DAO produces exactly one time-series.
+    const [, dao] = c.req.path.split("/");
+    const route = dao ? `/${dao}/*` : "/";
+
     // --- Request phase: check for a cached response ---
     // Fail open: if Redis is unavailable, .catch returns null and we proceed normally.
     const raw = await redis.get(key).catch(() => null);
     if (raw) {
       const entry = safeParse<CachedEntry>(raw);
       if (!entry) {
-        cacheRequestTotal.add(1, { result: "corrupt", route: c.req.path });
+        cacheRequestTotal.add(1, { result: "corrupt", route });
         return next();
       }
-      cacheRequestTotal.add(1, { result: "hit", route: c.req.path });
+      cacheRequestTotal.add(1, { result: "hit", route });
       return new Response(entry.body, {
         status: entry.status,
         headers: {
@@ -60,7 +66,7 @@ export function cacheMiddleware(redis: CacheStore) {
       });
     }
 
-    cacheRequestTotal.add(1, { result: "miss", route: c.req.path });
+    cacheRequestTotal.add(1, { result: "miss", route });
     await next();
 
     // --- Response phase: store the response if eligible ---

--- a/apps/gateful/src/middlewares/cache.ts
+++ b/apps/gateful/src/middlewares/cache.ts
@@ -45,7 +45,10 @@ export function cacheMiddleware(redis: CacheStore) {
     const raw = await redis.get(key).catch(() => null);
     if (raw) {
       const entry = safeParse<CachedEntry>(raw);
-      if (!entry) return next();
+      if (!entry) {
+        cacheRequestTotal.add(1, { result: "corrupt", route: c.req.path });
+        return next();
+      }
       cacheRequestTotal.add(1, { result: "hit", route: c.req.path });
       return new Response(entry.body, {
         status: entry.status,

--- a/apps/gateful/src/middlewares/cache.ts
+++ b/apps/gateful/src/middlewares/cache.ts
@@ -1,5 +1,7 @@
 import type { Context, Next } from "hono";
 
+import { cacheRequestTotal } from "../metrics.js";
+
 /** Minimal interface the middleware actually needs */
 export interface CacheStore {
   get(key: string): Promise<string | null>;
@@ -44,6 +46,7 @@ export function cacheMiddleware(redis: CacheStore) {
     if (raw) {
       const entry = safeParse<CachedEntry>(raw);
       if (!entry) return next();
+      cacheRequestTotal.add(1, { result: "hit", route: c.req.path });
       return new Response(entry.body, {
         status: entry.status,
         headers: {
@@ -54,6 +57,7 @@ export function cacheMiddleware(redis: CacheStore) {
       });
     }
 
+    cacheRequestTotal.add(1, { result: "miss", route: c.req.path });
     await next();
 
     // --- Response phase: store the response if eligible ---

--- a/infra/monitoring/Dockerfile.alertmanager
+++ b/infra/monitoring/Dockerfile.alertmanager
@@ -1,5 +1,4 @@
 FROM prom/alertmanager:latest
-ARG CACHEBUST=1
 COPY alertmanager.yml /etc/alertmanager/config.yml.tmpl
 COPY slack.tmpl /etc/alertmanager/slack.tmpl
 COPY entrypoint.alertmanager.sh /entrypoint.sh

--- a/infra/monitoring/Dockerfile.alertmanager
+++ b/infra/monitoring/Dockerfile.alertmanager
@@ -1,4 +1,5 @@
 FROM prom/alertmanager:latest
+ARG CACHEBUST=1
 COPY alertmanager.yml /etc/alertmanager/config.yml.tmpl
 COPY slack.tmpl /etc/alertmanager/slack.tmpl
 COPY entrypoint.alertmanager.sh /entrypoint.sh

--- a/infra/monitoring/Dockerfile.alertmanager
+++ b/infra/monitoring/Dockerfile.alertmanager
@@ -1,5 +1,6 @@
 FROM prom/alertmanager:latest
 COPY alertmanager.yml /etc/alertmanager/config.yml.tmpl
+COPY slack.tmpl /etc/alertmanager/slack.tmpl
 COPY entrypoint.alertmanager.sh /entrypoint.sh
 USER root
 RUN chmod +x /entrypoint.sh

--- a/infra/monitoring/Dockerfile.prometheus
+++ b/infra/monitoring/Dockerfile.prometheus
@@ -1,7 +1,6 @@
 FROM prom/prometheus:latest AS prometheus
 
 FROM alpine:3.19
-ARG CACHEBUST=1
 RUN apk add --no-cache gettext
 COPY --from=prometheus /bin/prometheus /bin/prometheus
 COPY --from=prometheus /bin/promtool /bin/promtool

--- a/infra/monitoring/Dockerfile.prometheus
+++ b/infra/monitoring/Dockerfile.prometheus
@@ -1,6 +1,7 @@
 FROM prom/prometheus:latest AS prometheus
 
 FROM alpine:3.19
+ARG CACHEBUST=1
 RUN apk add --no-cache gettext
 COPY --from=prometheus /bin/prometheus /bin/prometheus
 COPY --from=prometheus /bin/promtool /bin/promtool

--- a/infra/monitoring/alertmanager.yml
+++ b/infra/monitoring/alertmanager.yml
@@ -1,3 +1,6 @@
+templates:
+  - /etc/alertmanager/slack.tmpl
+
 route:
   receiver: default
   group_by: [alertname, job]
@@ -10,5 +13,7 @@ receivers:
     slack_configs:
       - api_url: "${SLACK_WEBHOOK_URL}"
         channel: "${SLACK_CHANNEL}"
-        title: "[{{ .Status | toUpper }}] {{ .CommonAnnotations.summary }}"
-        text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
+        color: '{{ template "slack.anticapture.color" . }}'
+        title: '{{ template "slack.anticapture.title" . }}'
+        text: '{{ template "slack.anticapture.text" . }}'
+        send_resolved: true

--- a/infra/monitoring/alertmanager.yml
+++ b/infra/monitoring/alertmanager.yml
@@ -1,6 +1,9 @@
 templates:
   - /etc/alertmanager/slack.tmpl
 
+global:
+  resolve_timeout: 5m
+
 route:
   receiver: default
   group_by: [alertname, job]

--- a/infra/monitoring/alerts.yml
+++ b/infra/monitoring/alerts.yml
@@ -4,7 +4,7 @@ groups:
     rules:
       # Service is not responding (no scrape data for 1 minute)
       - alert: ServiceDown
-        expr: up == 0 and on(job) group_left() (group by(job) ({job!~".*-indexer"}))
+        expr: up{job!~".*-indexer"} == 0
         for: 1m
         labels:
           severity: critical
@@ -17,7 +17,7 @@ groups:
 
       # Indexer is not responding — longer window to account for slow startup
       - alert: IndexerDown
-        expr: up == 0 and on(job) group_left() (group by(job) ({job=~".*-indexer"}))
+        expr: up{job=~".*-indexer"} == 0
         for: 10m
         labels:
           severity: critical

--- a/infra/monitoring/alerts.yml
+++ b/infra/monitoring/alerts.yml
@@ -9,8 +9,11 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: "Service {{ $labels.job }} is down"
-          description: "Prometheus cannot scrape {{ $labels.job }} at {{ $labels.instance }}"
+          summary: "[CRITICAL] {{ $labels.job }} is unreachable"
+          description: >
+            Prometheus has been unable to scrape {{ $labels.job }} at {{ $labels.instance }}
+            for more than 1 minute. The service may be crashed, OOM-killed, or misconfigured.
+            Check container/process status and recent logs immediately.
 
       # Indexer is not responding — longer window to account for slow startup
       - alert: IndexerDown
@@ -19,8 +22,12 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: "Indexer {{ $labels.job }} is down"
-          description: "Prometheus cannot scrape {{ $labels.job }} at {{ $labels.instance }}"
+          summary: "[CRITICAL] {{ $labels.job }} is unreachable"
+          description: >
+            Prometheus has been unable to scrape {{ $labels.job }} at {{ $labels.instance }}
+            for more than 10 minutes. Note: indexers take time to bind their HTTP server on
+            cold start, so this alert has an extended window. If the indexer was not recently
+            deployed, check container/process status and recent logs.
 
       # CPU usage above 80% for 5 minutes
       - alert: HighCPUUsage
@@ -29,8 +36,11 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: "High CPU on {{ $labels.job }}"
-          description: '{{ $labels.job }} CPU at {{ printf "%.1f" $value }}% for 5 minutes'
+          summary: "[WARNING] High CPU usage on {{ $labels.job }}"
+          description: >
+            {{ $labels.job }} has been using {{ printf "%.1f" $value }}% CPU for more than
+            5 minutes. This may indicate a processing backlog, tight indexing loop, or a
+            runaway query. Review process metrics and recent workload.
 
       # p99 HTTP latency above 2s for 5 minutes
       - alert: HighLatency
@@ -42,8 +52,11 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: "High p99 latency"
-          description: 'p99 latency is {{ printf "%.2f" $value }}s'
+          summary: "[WARNING] High p99 HTTP latency"
+          description: >
+            The p99 HTTP response time has been {{ printf "%.2f" $value }}s for more than
+            5 minutes (threshold: 2s). This may indicate slow database queries, resource
+            contention, or downstream bottlenecks. Check slow query logs and DB connection pool.
 
       # 5xx error rate above 1% for 2 minutes
       - alert: HighErrorRate
@@ -56,5 +69,9 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: "High 5xx error rate"
-          description: '5xx rate is {{ printf "%.2f" $value }}%'
+          summary: "[CRITICAL] Elevated 5xx error rate"
+          description: >
+            The 5xx error rate has been {{ printf "%.2f" $value }}% for more than 2 minutes
+            (threshold: 1%). Users are experiencing server errors. Check application logs for
+            stack traces, database connectivity, and any recent deployments that may have
+            introduced regressions.

--- a/infra/monitoring/alerts.yml
+++ b/infra/monitoring/alerts.yml
@@ -4,12 +4,22 @@ groups:
     rules:
       # Service is not responding (no scrape data for 1 minute)
       - alert: ServiceDown
-        expr: up == 0
+        expr: up == 0 and on(job) group_left() (group by(job) ({job!~".*-indexer"}))
         for: 1m
         labels:
           severity: critical
         annotations:
           summary: "Service {{ $labels.job }} is down"
+          description: "Prometheus cannot scrape {{ $labels.job }} at {{ $labels.instance }}"
+
+      # Indexer is not responding — longer window to account for slow startup
+      - alert: IndexerDown
+        expr: up == 0 and on(job) group_left() (group by(job) ({job=~".*-indexer"}))
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Indexer {{ $labels.job }} is down"
           description: "Prometheus cannot scrape {{ $labels.job }} at {{ $labels.instance }}"
 
       # CPU usage above 80% for 5 minutes

--- a/infra/monitoring/entrypoint.prometheus.sh
+++ b/infra/monitoring/entrypoint.prometheus.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 envsubst < /etc/prometheus/prometheus.yml.tmpl > /etc/prometheus/prometheus.yml
-rm -rf /prometheus/*
+if [ ! -f /prometheus/.initialized ]; then
+  rm -rf /prometheus/*
+  touch /prometheus/.initialized
+fi
 exec /bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.enable-lifecycle --web.enable-remote-write-receiver "$@"

--- a/infra/monitoring/entrypoint.prometheus.sh
+++ b/infra/monitoring/entrypoint.prometheus.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 envsubst < /etc/prometheus/prometheus.yml.tmpl > /etc/prometheus/prometheus.yml
+rm -rf /prometheus/*
 exec /bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.enable-lifecycle --web.enable-remote-write-receiver "$@"

--- a/infra/monitoring/entrypoint.prometheus.sh
+++ b/infra/monitoring/entrypoint.prometheus.sh
@@ -1,7 +1,4 @@
 #!/bin/sh
 envsubst < /etc/prometheus/prometheus.yml.tmpl > /etc/prometheus/prometheus.yml
-if [ ! -f /prometheus/.initialized ]; then
-  rm -rf /prometheus/*
-  touch /prometheus/.initialized
-fi
+rm -rf /prometheus/*
 exec /bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.enable-lifecycle --web.enable-remote-write-receiver "$@"

--- a/infra/monitoring/grafana/dashboards/anticapture-v2.json
+++ b/infra/monitoring/grafana/dashboards/anticapture-v2.json
@@ -1,0 +1,296 @@
+{
+  "title": "Anticapture V2",
+  "uid": "anticapture-v2",
+  "editable": true,
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "15s",
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 100,
+      "type": "row",
+      "title": "Service Health",
+      "collapsed": false,
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 }
+    },
+    {
+      "id": 1,
+      "title": "API Health",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 1, "w": 12, "h": 5 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": { "1": { "text": "UP", "color": "green" } }
+            },
+            {
+              "type": "value",
+              "options": { "0": { "text": "DOWN", "color": "red" } }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "up{job=~\"anticapture-.*-api\"}",
+          "legendFormat": "{{job}}",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Indexer Health",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 1, "w": 12, "h": 5 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": { "1": { "text": "UP", "color": "green" } }
+            },
+            {
+              "type": "value",
+              "options": { "0": { "text": "DOWN", "color": "red" } }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "up{job=~\"anticapture-.*-indexer\"}",
+          "legendFormat": "{{job}}",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 101,
+      "type": "row",
+      "title": "Requests per Route per DAO",
+      "collapsed": false,
+      "gridPos": { "x": 0, "y": 6, "w": 24, "h": 1 }
+    },
+    {
+      "id": 3,
+      "title": "Request Rate by DAO & Route (req/s)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 7, "w": 24, "h": 9 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean", "max"]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[1m])) by (job, http_route)",
+          "legendFormat": "{{job}} — {{http_route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "p99 Latency by DAO & Route",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 16, "w": 24, "h": 9 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean", "max"]
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=~\"anticapture-.*-api\"}[5m])) by (le, job, http_route))",
+          "legendFormat": "p99 {{job}} — {{http_route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 102,
+      "type": "row",
+      "title": "Error Rates per Route per DAO",
+      "collapsed": false,
+      "gridPos": { "x": 0, "y": 25, "w": 24, "h": 1 }
+    },
+    {
+      "id": 5,
+      "title": "5xx Error Rate by DAO & Route (req/s)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 26, "w": 16, "h": 9 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean", "max"]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\", http_response_status_code=~\"5..\"}[1m])) by (job, http_route)",
+          "legendFormat": "{{job}} — {{http_route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Error Ratio by DAO (5xx / total)",
+      "type": "timeseries",
+      "gridPos": { "x": 16, "y": 26, "w": 8, "h": 9 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\", http_response_status_code=~\"5..\"}[5m])) by (job) / sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[5m])) by (job)",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/monitoring/grafana/dashboards/anticapture-v2.json
+++ b/infra/monitoring/grafana/dashboards/anticapture-v2.json
@@ -251,7 +251,7 @@
       "options": { "tooltip": { "mode": "multi" } },
       "targets": [
         {
-          "expr": "sum(rate(http_server_request_duration_seconds_count[1m])) by (http_route, http_request_method)",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[1m])) by (http_route, http_request_method)",
           "legendFormat": "{{http_request_method}} {{http_route}}",
           "refId": "A"
         }
@@ -273,7 +273,7 @@
       "options": { "tooltip": { "mode": "multi" } },
       "targets": [
         {
-          "expr": "sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~\"5..\"}[1m])) by (http_route)",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\", http_response_status_code=~\"5..\"}[1m])) by (http_route)",
           "legendFormat": "5xx {{http_route}}",
           "refId": "A"
         }
@@ -292,17 +292,17 @@
       "options": { "tooltip": { "mode": "multi" } },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=~\"anticapture-.*-api\"}[5m])) by (le))",
           "legendFormat": "p99",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{job=~\"anticapture-.*-api\"}[5m])) by (le))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket{job=~\"anticapture-.*-api\"}[5m])) by (le))",
           "legendFormat": "p50",
           "refId": "C"
         }
@@ -321,7 +321,7 @@
       "options": { "tooltip": { "mode": "multi" } },
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le, http_route))",
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=~\"anticapture-.*-api\"}[5m])) by (le, http_route))",
           "legendFormat": "p99 {{http_route}}",
           "refId": "A"
         }
@@ -344,7 +344,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(http_server_request_duration_seconds_count[5m])) by (http_response_status_code)",
+          "expr": "sum(increase(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[5m])) by (http_response_status_code)",
           "legendFormat": "{{http_response_status_code}}",
           "refId": "A"
         }
@@ -523,7 +523,7 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(http_server_request_duration_seconds_count{job=\"anticapture-gateway\"}[$__range])) by (client_source)",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=\"anticapture-gateway\"}[5m])) by (client_source)",
           "legendFormat": "{{client_source}}",
           "instant": true,
           "refId": "A"
@@ -824,7 +824,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(erpc_network_successful_request_total{job=\"anticapture-erpc\"}[1m])) by (network, vendor, category)",
+              "expr": "sum(rate(erpc_network_successful_request_total{job=\"anticapture-erpc\"}[$__rate_interval])) by (network, vendor, category)",
               "legendFormat": "{{network}} / {{vendor}} / {{category}}",
               "refId": "A"
             }
@@ -854,7 +854,7 @@
           },
           "targets": [
             {
-              "expr": "sum(increase(erpc_network_failed_request_total{job=\"anticapture-erpc\", severity=\"critical\"}[1m])) by (network, category, error) > 0",
+              "expr": "sum(increase(erpc_network_failed_request_total{job=\"anticapture-erpc\", severity=\"critical\"}[$__rate_interval])) by (network, category, error) > 0",
               "legendFormat": "{{network}} / {{error}}",
               "refId": "A"
             }
@@ -884,7 +884,7 @@
           },
           "targets": [
             {
-              "expr": "sum(increase(erpc_upstream_request_errors_total{job=\"anticapture-erpc\", severity=\"critical\", composite=\"none\"}[1m])) by (upstream, network, error) > 0",
+              "expr": "sum(increase(erpc_upstream_request_errors_total{job=\"anticapture-erpc\", severity=\"critical\", composite=\"none\"}[$__rate_interval])) by (upstream, network, error) > 0",
               "legendFormat": "{{upstream}} / {{error}}",
               "refId": "A"
             }
@@ -910,7 +910,7 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(erpc_upstream_request_duration_seconds_bucket{job=\"anticapture-erpc\", composite=\"none\"}[1m])) by (le, vendor, category))",
+              "expr": "histogram_quantile(0.99, sum(rate(erpc_upstream_request_duration_seconds_bucket{job=\"anticapture-erpc\", composite=\"none\"}[$__rate_interval])) by (le, vendor, category))",
               "legendFormat": "p99 {{vendor}} / {{category}}",
               "refId": "A"
             }
@@ -936,7 +936,7 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(erpc_upstream_request_duration_seconds_bucket{job=\"anticapture-erpc\", composite=\"none\"}[1m])) by (le, upstream, category))",
+              "expr": "histogram_quantile(0.99, sum(rate(erpc_upstream_request_duration_seconds_bucket{job=\"anticapture-erpc\", composite=\"none\"}[$__rate_interval])) by (le, upstream, category))",
               "legendFormat": "p99 {{upstream}} / {{category}}",
               "refId": "A"
             }

--- a/infra/monitoring/grafana/dashboards/anticapture-v2.json
+++ b/infra/monitoring/grafana/dashboards/anticapture-v2.json
@@ -120,151 +120,133 @@
     {
       "id": 101,
       "type": "row",
-      "title": "Requests per Route per DAO",
+      "title": "Traffic Overview — Table View",
       "collapsed": false,
       "gridPos": { "x": 0, "y": 6, "w": 24, "h": 1 }
     },
     {
       "id": 3,
-      "title": "Request Rate by DAO & Route (req/s)",
-      "type": "timeseries",
-      "gridPos": { "x": 0, "y": 7, "w": 24, "h": 9 },
+      "title": "DAO × Route — Request Rate / Latency / Error Rate (Table)",
+      "description": "One row per (DAO, route). Columns: req/s (5m avg), p99 latency, error ratio. Error ratio cell is threshold-colored: green <1%, yellow <5%, red ≥5%.",
+      "type": "table",
+      "gridPos": { "x": 0, "y": 7, "w": 24, "h": 12 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "unit": "reqps",
-          "color": { "mode": "palette-classic" },
           "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "lineInterpolation": "linear",
-            "showPoints": "never"
+            "align": "auto",
+            "cellOptions": { "type": "auto" },
+            "filterable": true
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "req/s" },
+            "properties": [
+              { "id": "unit", "value": "reqps" },
+              { "id": "decimals", "value": 3 },
+              { "id": "custom.width", "value": 100 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "p99 latency" },
+            "properties": [
+              { "id": "unit", "value": "s" },
+              { "id": "decimals", "value": 3 },
+              { "id": "custom.width", "value": 120 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "error ratio" },
+            "properties": [
+              { "id": "unit", "value": "percentunit" },
+              { "id": "decimals", "value": 2 },
+              { "id": "custom.width", "value": 120 },
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-background" }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "green", "value": null },
+                    { "color": "yellow", "value": 0.01 },
+                    { "color": "red", "value": 0.05 }
+                  ]
+                }
+              },
+              { "id": "color", "value": { "mode": "thresholds" } }
+            ]
+          }
+        ]
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true,
-          "calcs": ["mean", "max"]
-        }
+        "sortBy": [{ "displayName": "error ratio", "desc": true }],
+        "footer": { "show": false },
+        "frameIndex": 0,
+        "showHeader": true
       },
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Value #A": "req/s",
+              "Value #B": "p99 latency",
+              "Value #C": "error ratio",
+              "job": "DAO",
+              "http_route": "route"
+            }
+          }
+        }
+      ],
       "targets": [
         {
-          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[1m])) by (job, http_route)",
-          "legendFormat": "{{job}} — {{http_route}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "id": 4,
-      "title": "p99 Latency by DAO & Route",
-      "type": "timeseries",
-      "gridPos": { "x": 0, "y": 16, "w": 24, "h": 9 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "lineInterpolation": "linear",
-            "showPoints": "never"
-          }
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[5m])) by (job, http_route)",
+          "legendFormat": "{{job}}|{{http_route}}",
+          "instant": true,
+          "refId": "A",
+          "format": "table"
         },
-        "overrides": []
-      },
-      "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true,
-          "calcs": ["mean", "max"]
-        }
-      },
-      "targets": [
         {
           "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=~\"anticapture-.*-api\"}[5m])) by (le, job, http_route))",
-          "legendFormat": "p99 {{job}} — {{http_route}}",
-          "refId": "A"
+          "legendFormat": "{{job}}|{{http_route}}",
+          "instant": true,
+          "refId": "B",
+          "format": "table"
+        },
+        {
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\",http_response_status_code=~\"5..\"}[5m])) by (job, http_route) / sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[5m])) by (job, http_route)",
+          "legendFormat": "{{job}}|{{http_route}}",
+          "instant": true,
+          "refId": "C",
+          "format": "table"
         }
       ]
     },
     {
       "id": 102,
       "type": "row",
-      "title": "Error Rates per Route per DAO",
+      "title": "Traffic Overview — Heatmap View",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 25, "w": 24, "h": 1 }
+      "gridPos": { "x": 0, "y": 19, "w": 24, "h": 1 }
     },
     {
-      "id": 5,
-      "title": "5xx Error Rate by DAO & Route (req/s)",
-      "type": "timeseries",
-      "gridPos": { "x": 0, "y": 26, "w": 16, "h": 9 },
+      "id": 4,
+      "title": "Error Ratio Heatmap — DAO × Route (color = error %)",
+      "description": "Each cell is a (DAO, route) pair colored by its 5xx error ratio. Tooltip shows req/s and p99 latency via additional series. Uses xy-chart to render a categorical DAO (Y) × route (X) matrix.",
+      "type": "xychart",
+      "gridPos": { "x": 0, "y": 20, "w": 24, "h": 12 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "unit": "reqps",
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "lineInterpolation": "linear",
-            "showPoints": "never"
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true,
-          "calcs": ["mean", "max"]
-        }
-      },
-      "targets": [
-        {
-          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\", http_response_status_code=~\"5..\"}[1m])) by (job, http_route)",
-          "legendFormat": "{{job}} — {{http_route}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "id": 6,
-      "title": "Error Ratio by DAO (5xx / total)",
-      "type": "timeseries",
-      "gridPos": { "x": 16, "y": 26, "w": 8, "h": 9 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percentunit",
-          "min": 0,
-          "max": 1,
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "lineInterpolation": "linear",
-            "showPoints": "never"
-          },
+          "color": { "mode": "thresholds" },
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -272,23 +254,149 @@
               { "color": "yellow", "value": 0.01 },
               { "color": "red", "value": 0.05 }
             ]
+          },
+          "custom": {
+            "pointSize": { "fixed": 40 },
+            "fillOpacity": 80,
+            "show": "points"
           }
         },
         "overrides": []
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
+        "mapping": "auto",
+        "series": [],
+        "tooltip": { "mode": "single" },
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
         }
       },
+      "transformations": [
+        { "id": "merge", "options": {} },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Value #A": "error ratio",
+              "job": "DAO",
+              "http_route": "route"
+            }
+          }
+        }
+      ],
       "targets": [
         {
-          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\", http_response_status_code=~\"5..\"}[5m])) by (job) / sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[5m])) by (job)",
-          "legendFormat": "{{job}}",
-          "refId": "A"
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\",http_response_status_code=~\"5..\"}[5m])) by (job, http_route) / sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[5m])) by (job, http_route)",
+          "legendFormat": "{{job}} | {{http_route}}",
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Request Rate Heatmap — DAO × Route (color = req/s)",
+      "description": "Same DAO × route matrix, colored by request rate instead of error ratio.",
+      "type": "xychart",
+      "gridPos": { "x": 0, "y": 32, "w": 12, "h": 10 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "continuous-BlYlRd" },
+          "custom": {
+            "pointSize": { "fixed": 40 },
+            "fillOpacity": 80,
+            "show": "points"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "mapping": "auto",
+        "series": [],
+        "tooltip": { "mode": "single" },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "transformations": [
+        { "id": "merge", "options": {} },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Value #A": "req/s",
+              "job": "DAO",
+              "http_route": "route"
+            }
+          }
+        }
+      ],
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[5m])) by (job, http_route)",
+          "legendFormat": "{{job}} | {{http_route}}",
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "p99 Latency Heatmap — DAO × Route (color = latency)",
+      "description": "Same DAO × route matrix, colored by p99 latency.",
+      "type": "xychart",
+      "gridPos": { "x": 12, "y": 32, "w": 12, "h": 10 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "continuous-BlYlRd" },
+          "custom": {
+            "pointSize": { "fixed": 40 },
+            "fillOpacity": 80,
+            "show": "points"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "mapping": "auto",
+        "series": [],
+        "tooltip": { "mode": "single" },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "transformations": [
+        { "id": "merge", "options": {} },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Value #A": "p99 latency",
+              "job": "DAO",
+              "http_route": "route"
+            }
+          }
+        }
+      ],
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=~\"anticapture-.*-api\"}[5m])) by (le, job, http_route))",
+          "legendFormat": "{{job}} | {{http_route}}",
+          "instant": true,
+          "refId": "A",
+          "format": "table"
         }
       ]
     }

--- a/infra/monitoring/grafana/dashboards/anticapture-v2.json
+++ b/infra/monitoring/grafana/dashboards/anticapture-v2.json
@@ -763,6 +763,185 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "id": 130,
+      "type": "row",
+      "title": "eRPC",
+      "collapsed": true,
+      "gridPos": { "x": 0, "y": 88, "w": 24, "h": 1 },
+      "panels": [
+        {
+          "id": 1301,
+          "title": "Incoming RPS",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 89, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "color": { "mode": "palette-classic" }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": { "mode": "multi", "sort": "desc" },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(erpc_network_request_received_total{job=\"anticapture-erpc\"}[$__rate_interval])) by (network, category)",
+              "legendFormat": "{{network}} / {{category}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "title": "Successful Responses RPS",
+          "type": "timeseries",
+          "gridPos": { "x": 12, "y": 89, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps",
+              "color": { "mode": "palette-classic" }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": { "mode": "multi", "sort": "desc" },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(erpc_network_successful_request_total{job=\"anticapture-erpc\"}[1m])) by (network, vendor, category)",
+              "legendFormat": "{{network}} / {{vendor}} / {{category}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1303,
+          "title": "Network-level Critical Errors",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 97, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": { "mode": "palette-classic" },
+              "custom": { "fillOpacity": 10 }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": { "mode": "multi", "sort": "desc" },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(increase(erpc_network_failed_request_total{job=\"anticapture-erpc\", severity=\"critical\"}[1m])) by (network, category, error) > 0",
+              "legendFormat": "{{network}} / {{error}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1304,
+          "title": "Upstream-level Critical Errors",
+          "type": "timeseries",
+          "gridPos": { "x": 12, "y": 97, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "color": { "mode": "palette-classic" },
+              "custom": { "fillOpacity": 10 }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": { "mode": "multi", "sort": "desc" },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(increase(erpc_upstream_request_errors_total{job=\"anticapture-erpc\", severity=\"critical\", composite=\"none\"}[1m])) by (upstream, network, error) > 0",
+              "legendFormat": "{{upstream}} / {{error}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1305,
+          "title": "Vendor P99 Response Time",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 105, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": { "unit": "s", "color": { "mode": "palette-classic" } },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": { "mode": "multi", "sort": "desc" },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(erpc_upstream_request_duration_seconds_bucket{job=\"anticapture-erpc\", composite=\"none\"}[1m])) by (le, vendor, category))",
+              "legendFormat": "p99 {{vendor}} / {{category}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1306,
+          "title": "Upstream P99 Response Time",
+          "type": "timeseries",
+          "gridPos": { "x": 12, "y": 105, "w": 12, "h": 8 },
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "fieldConfig": {
+            "defaults": { "unit": "s", "color": { "mode": "palette-classic" } },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": { "mode": "multi", "sort": "desc" },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(erpc_upstream_request_duration_seconds_bucket{job=\"anticapture-erpc\", composite=\"none\"}[1m])) by (le, upstream, category))",
+              "legendFormat": "p99 {{upstream}} / {{category}}",
+              "refId": "A"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/infra/monitoring/grafana/dashboards/anticapture-v2.json
+++ b/infra/monitoring/grafana/dashboards/anticapture-v2.json
@@ -5,75 +5,41 @@
   "schemaVersion": 38,
   "version": 1,
   "refresh": "15s",
-  "time": {
-    "from": "now-30m",
-    "to": "now"
-  },
+  "time": { "from": "now-30m", "to": "now" },
   "panels": [
     {
       "id": 100,
       "type": "row",
       "title": "Service Health",
       "collapsed": false,
-      "gridPos": {
-        "x": 0,
-        "y": 0,
-        "w": 24,
-        "h": 1
-      }
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 }
     },
     {
       "id": 1,
       "title": "API Health",
       "type": "stat",
-      "gridPos": {
-        "x": 0,
-        "y": 1,
-        "w": 12,
-        "h": 10
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "gridPos": { "x": 0, "y": 1, "w": 12, "h": 10 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "mappings": [
             {
               "type": "value",
-              "options": {
-                "1": {
-                  "text": "UP",
-                  "color": "green"
-                }
-              }
+              "options": { "1": { "text": "UP", "color": "green" } }
             },
             {
               "type": "value",
-              "options": {
-                "0": {
-                  "text": "DOWN",
-                  "color": "red"
-                }
-              }
+              "options": { "0": { "text": "DOWN", "color": "red" } }
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
             ]
           },
-          "color": {
-            "mode": "thresholds"
-          }
+          "color": { "mode": "thresholds" }
         },
         "overrides": []
       },
@@ -102,54 +68,28 @@
       "id": 2,
       "title": "Indexer Health",
       "type": "stat",
-      "gridPos": {
-        "x": 12,
-        "y": 1,
-        "w": 12,
-        "h": 10
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "gridPos": { "x": 12, "y": 1, "w": 12, "h": 10 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "mappings": [
             {
               "type": "value",
-              "options": {
-                "1": {
-                  "text": "UP",
-                  "color": "green"
-                }
-              }
+              "options": { "1": { "text": "UP", "color": "green" } }
             },
             {
               "type": "value",
-              "options": {
-                "0": {
-                  "text": "DOWN",
-                  "color": "red"
-                }
-              }
+              "options": { "0": { "text": "DOWN", "color": "red" } }
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
             ]
           },
-          "color": {
-            "mode": "thresholds"
-          }
+          "color": { "mode": "thresholds" }
         },
         "overrides": []
       },
@@ -179,151 +119,74 @@
       "type": "row",
       "title": "Traffic Overview",
       "collapsed": false,
-      "gridPos": {
-        "x": 0,
-        "y": 11,
-        "w": 24,
-        "h": 1
-      }
+      "gridPos": { "x": 0, "y": 11, "w": 24, "h": 1 }
     },
     {
       "id": 3,
       "title": "DAO × Route — Request Rate / Latency / Error Rate",
       "description": "One row per (DAO, route). Columns: req/s (5m avg), p99 latency, error ratio. Error ratio cell is threshold-colored: green <1%, yellow <5%, red ≥5%.",
       "type": "table",
-      "gridPos": {
-        "x": 0,
-        "y": 12,
-        "w": 24,
-        "h": 12
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "gridPos": { "x": 0, "y": 12, "w": 24, "h": 12 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "custom": {
             "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
+            "cellOptions": { "type": "auto" },
             "filterable": true
           }
         },
         "overrides": [
           {
-            "matcher": {
-              "id": "byName",
-              "options": "req/s"
-            },
+            "matcher": { "id": "byName", "options": "req/s" },
             "properties": [
-              {
-                "id": "unit",
-                "value": "reqps"
-              },
-              {
-                "id": "decimals",
-                "value": 3
-              },
-              {
-                "id": "custom.width",
-                "value": 100
-              }
+              { "id": "unit", "value": "reqps" },
+              { "id": "decimals", "value": 3 },
+              { "id": "custom.width", "value": 100 }
             ]
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "p99 latency"
-            },
+            "matcher": { "id": "byName", "options": "p99 latency" },
             "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              },
-              {
-                "id": "decimals",
-                "value": 3
-              },
-              {
-                "id": "custom.width",
-                "value": 120
-              }
+              { "id": "unit", "value": "s" },
+              { "id": "decimals", "value": 3 },
+              { "id": "custom.width", "value": 120 }
             ]
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "error ratio"
-            },
+            "matcher": { "id": "byName", "options": "error ratio" },
             "properties": [
-              {
-                "id": "unit",
-                "value": "percentunit"
-              },
-              {
-                "id": "decimals",
-                "value": 2
-              },
-              {
-                "id": "custom.width",
-                "value": 120
-              },
+              { "id": "unit", "value": "percentunit" },
+              { "id": "decimals", "value": 2 },
+              { "id": "custom.width", "value": 120 },
               {
                 "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
+                "value": { "type": "color-background" }
               },
               {
                 "id": "thresholds",
                 "value": {
                   "mode": "absolute",
                   "steps": [
-                    {
-                      "color": "green",
-                      "value": null
-                    },
-                    {
-                      "color": "yellow",
-                      "value": 0.01
-                    },
-                    {
-                      "color": "red",
-                      "value": 0.05
-                    }
+                    { "color": "green", "value": null },
+                    { "color": "yellow", "value": 0.01 },
+                    { "color": "red", "value": 0.05 }
                   ]
                 }
               },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "thresholds"
-                }
-              }
+              { "id": "color", "value": { "mode": "thresholds" } }
             ]
           }
         ]
       },
       "options": {
-        "sortBy": [
-          {
-            "displayName": "error ratio",
-            "desc": true
-          }
-        ],
-        "footer": {
-          "show": false
-        },
+        "sortBy": [{ "displayName": "error ratio", "desc": true }],
+        "footer": { "show": false },
         "frameIndex": 0,
         "showHeader": true
       },
       "transformations": [
-        {
-          "id": "merge",
-          "options": {}
-        },
+        { "id": "merge", "options": {} },
         {
           "id": "organize",
           "options": {
@@ -372,41 +235,19 @@
       "type": "row",
       "title": "Traffic Detail",
       "collapsed": false,
-      "gridPos": {
-        "x": 0,
-        "y": 11,
-        "w": 24,
-        "h": 1
-      }
+      "gridPos": { "x": 0, "y": 24, "w": 24, "h": 1 }
     },
     {
       "id": 1101,
       "title": "Request Rate (req/s)",
       "type": "timeseries",
-      "gridPos": {
-        "x": 0,
-        "y": 0,
-        "w": 8,
-        "h": 8
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "gridPos": { "x": 0, "y": 25, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
-        "defaults": {
-          "unit": "reqps",
-          "color": {
-            "mode": "palette-classic"
-          }
-        },
+        "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" } },
         "overrides": []
       },
-      "options": {
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
+      "options": { "tooltip": { "mode": "multi" } },
       "targets": [
         {
           "expr": "sum(rate(http_server_request_duration_seconds_count[1m])) by (http_route, http_request_method)",
@@ -419,31 +260,16 @@
       "id": 1102,
       "title": "Error Rate (5xx)",
       "type": "timeseries",
-      "gridPos": {
-        "x": 8,
-        "y": 0,
-        "w": 8,
-        "h": 8
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "gridPos": { "x": 8, "y": 25, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "unit": "reqps",
-          "color": {
-            "mode": "fixed",
-            "fixedColor": "red"
-          }
+          "color": { "mode": "fixed", "fixedColor": "red" }
         },
         "overrides": []
       },
-      "options": {
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
+      "options": { "tooltip": { "mode": "multi" } },
       "targets": [
         {
           "expr": "sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~\"5..\"}[1m])) by (http_route)",
@@ -456,30 +282,13 @@
       "id": 1103,
       "title": "P99 / P95 / P50 Latency",
       "type": "timeseries",
-      "gridPos": {
-        "x": 16,
-        "y": 0,
-        "w": 8,
-        "h": 8
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "gridPos": { "x": 16, "y": 25, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "color": {
-            "mode": "palette-classic"
-          }
-        },
+        "defaults": { "unit": "s", "color": { "mode": "palette-classic" } },
         "overrides": []
       },
-      "options": {
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
+      "options": { "tooltip": { "mode": "multi" } },
       "targets": [
         {
           "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))",
@@ -502,30 +311,13 @@
       "id": 1104,
       "title": "Latency by Route (p99)",
       "type": "timeseries",
-      "gridPos": {
-        "x": 0,
-        "y": 8,
-        "w": 16,
-        "h": 8
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "gridPos": { "x": 0, "y": 33, "w": 16, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "color": {
-            "mode": "palette-classic"
-          }
-        },
+        "defaults": { "unit": "s", "color": { "mode": "palette-classic" } },
         "overrides": []
       },
-      "options": {
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
+      "options": { "tooltip": { "mode": "multi" } },
       "targets": [
         {
           "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le, http_route))",
@@ -538,33 +330,16 @@
       "id": 1105,
       "title": "Status Code Breakdown",
       "type": "piechart",
-      "gridPos": {
-        "x": 16,
-        "y": 8,
-        "w": 8,
-        "h": 8
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "gridPos": { "x": 16, "y": 33, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          }
-        },
+        "defaults": { "color": { "mode": "palette-classic" } },
         "overrides": []
       },
       "options": {
         "pieType": "donut",
-        "tooltip": {
-          "mode": "multi"
-        },
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom"
-        }
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
       },
       "targets": [
         {
@@ -579,36 +354,21 @@
       "type": "row",
       "title": "Gateful Cache",
       "collapsed": false,
-      "gridPos": {
-        "x": 0,
-        "y": 24,
-        "w": 24,
-        "h": 1
-      }
+      "gridPos": { "x": 0, "y": 41, "w": 24, "h": 1 }
     },
     {
       "id": 6,
       "title": "Cache Hit Rate (gateful)",
       "description": "hits / (hits + misses) per route over time. A healthy cache stays well above 50%.",
       "type": "timeseries",
-      "gridPos": {
-        "x": 0,
-        "y": 25,
-        "w": 16,
-        "h": 10
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "gridPos": { "x": 0, "y": 42, "w": 16, "h": 10 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "unit": "percentunit",
           "min": 0,
           "max": 1,
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "custom": {
             "drawStyle": "line",
             "lineWidth": 1,
@@ -620,28 +380,16 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.5
-              },
-              {
-                "color": "green",
-                "value": 0.8
-              }
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "green", "value": 0.8 }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        },
+        "tooltip": { "mode": "multi", "sort": "desc" },
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
@@ -661,72 +409,44 @@
       "title": "Cache Hits vs Misses (gateful)",
       "description": "Absolute hit and miss rate in req/s.",
       "type": "timeseries",
-      "gridPos": {
-        "x": 16,
-        "y": 25,
-        "w": 8,
-        "h": 10
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "gridPos": { "x": 16, "y": 42, "w": 8, "h": 10 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "unit": "reqps",
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "custom": {
             "drawStyle": "bars",
             "lineWidth": 1,
             "fillOpacity": 60,
             "gradientMode": "none",
             "showPoints": "never",
-            "stacking": {
-              "mode": "normal",
-              "group": "A"
-            }
+            "stacking": { "mode": "normal", "group": "A" }
           }
         },
         "overrides": [
           {
-            "matcher": {
-              "id": "byName",
-              "options": "hit"
-            },
+            "matcher": { "id": "byName", "options": "hit" },
             "properties": [
               {
                 "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
+                "value": { "fixedColor": "green", "mode": "fixed" }
               }
             ]
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "miss"
-            },
+            "matcher": { "id": "byName", "options": "miss" },
             "properties": [
               {
                 "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
+                "value": { "fixedColor": "red", "mode": "fixed" }
               }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        },
+        "tooltip": { "mode": "multi", "sort": "desc" },
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
@@ -746,78 +466,45 @@
       "type": "row",
       "title": "Client Traffic",
       "collapsed": false,
-      "gridPos": {
-        "x": 0,
-        "y": 35,
-        "w": 24,
-        "h": 1
-      }
+      "gridPos": { "x": 0, "y": 52, "w": 24, "h": 1 }
     },
     {
       "id": 4,
       "title": "Requests by Client Source — Share (donut)",
       "description": "Split by x-client-source header from the API gateway. Three values: 'anticapture-frontend' (dashboard), 'notification-system' (bot), 'other' (unidentified callers).",
       "type": "piechart",
-      "gridPos": {
-        "x": 0,
-        "y": 36,
-        "w": 8,
-        "h": 10
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "gridPos": { "x": 0, "y": 53, "w": 8, "h": 10 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "unit": "percentunit"
         },
         "overrides": [
           {
-            "matcher": {
-              "id": "byName",
-              "options": "notification-system"
-            },
+            "matcher": { "id": "byName", "options": "notification-system" },
             "properties": [
               {
                 "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
+                "value": { "fixedColor": "orange", "mode": "fixed" }
               }
             ]
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "anticapture-frontend"
-            },
+            "matcher": { "id": "byName", "options": "anticapture-frontend" },
             "properties": [
               {
                 "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
+                "value": { "fixedColor": "blue", "mode": "fixed" }
               }
             ]
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "other"
-            },
+            "matcher": { "id": "byName", "options": "other" },
             "properties": [
               {
                 "id": "color",
-                "value": {
-                  "fixedColor": "gray",
-                  "mode": "fixed"
-                }
+                "value": { "fixedColor": "gray", "mode": "fixed" }
               }
             ]
           }
@@ -825,9 +512,7 @@
       },
       "options": {
         "pieType": "donut",
-        "tooltip": {
-          "mode": "single"
-        },
+        "tooltip": { "mode": "single" },
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
@@ -849,22 +534,12 @@
       "title": "Requests by Client Source — Rate over time",
       "description": "req/s per client source at the gateway level, useful for spotting bot spikes vs normal dashboard load.",
       "type": "timeseries",
-      "gridPos": {
-        "x": 8,
-        "y": 36,
-        "w": 16,
-        "h": 10
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "gridPos": { "x": 8, "y": 53, "w": 16, "h": 10 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
           "unit": "reqps",
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "custom": {
             "drawStyle": "line",
             "lineWidth": 1,
@@ -876,57 +551,36 @@
         },
         "overrides": [
           {
-            "matcher": {
-              "id": "byName",
-              "options": "notification-system"
-            },
+            "matcher": { "id": "byName", "options": "notification-system" },
             "properties": [
               {
                 "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
+                "value": { "fixedColor": "orange", "mode": "fixed" }
               }
             ]
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "anticapture-frontend"
-            },
+            "matcher": { "id": "byName", "options": "anticapture-frontend" },
             "properties": [
               {
                 "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
+                "value": { "fixedColor": "blue", "mode": "fixed" }
               }
             ]
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "other"
-            },
+            "matcher": { "id": "byName", "options": "other" },
             "properties": [
               {
                 "id": "color",
-                "value": {
-                  "fixedColor": "gray",
-                  "mode": "fixed"
-                }
+                "value": { "fixedColor": "gray", "mode": "fixed" }
               }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        },
+        "tooltip": { "mode": "multi", "sort": "desc" },
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
@@ -946,39 +600,104 @@
       "type": "row",
       "title": "System Metrics",
       "collapsed": false,
-      "gridPos": {
-        "x": 0,
-        "y": 35,
-        "w": 24,
-        "h": 1
-      }
+      "gridPos": { "x": 0, "y": 63, "w": 24, "h": 1 }
+    },
+    {
+      "id": 1209,
+      "title": "Process CPU Usage %",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 64, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum(process_cpu_utilization) by (job, process_cpu_state)",
+          "legendFormat": "{{job}} - {{process_cpu_state}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12010,
+      "title": "Process Memory Usage",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 64, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "bytes", "color": { "mode": "palette-classic" } },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum(process_memory_usage) by (job, process_memory_type)",
+          "legendFormat": "{{job}} - {{process_memory_type}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12011,
+      "title": "System CPU Usage %",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 72, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum(system_cpu_utilization) by (system_cpu_state)",
+          "legendFormat": "{{system_cpu_state}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12012,
+      "title": "System Memory Usage",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 72, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "unit": "bytes", "color": { "mode": "palette-classic" } },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "expr": "sum(system_memory_usage) by (system_memory_state)",
+          "legendFormat": "{{system_memory_state}}",
+          "refId": "A"
+        }
+      ]
     },
     {
       "id": 1207,
+      "title": "RPC Request Rate",
       "type": "timeseries",
-      "title": "RPC request rate",
-      "gridPos": {
-        "h": 8,
-        "w": 16,
-        "x": 0,
-        "y": 43
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "expr": "sum by (method) (rate(rpc_requests_total[5m]))",
-          "legendFormat": "{{method}}",
-          "refId": "A"
-        }
-      ],
+      "gridPos": { "x": 0, "y": 80, "w": 16, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" },
           "custom": {
             "drawStyle": "line",
             "lineWidth": 1,
@@ -986,85 +705,40 @@
             "gradientMode": "none",
             "lineInterpolation": "linear",
             "pointSize": 5,
-            "showPoints": "never",
-            "axisPlacement": "auto",
-            "axisLabel": "",
-            "axisColorMode": "text",
-            "axisCenteredZero": false,
-            "barAlignment": 0,
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "unit": "reqps",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
+            "showPoints": "never"
           }
         },
         "overrides": []
       },
       "options": {
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        },
+        "tooltip": { "mode": "multi", "sort": "none" },
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
         }
-      }
-    },
-    {
-      "id": 1208,
-      "type": "stat",
-      "title": "RPC requests total",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 43
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
       },
       "targets": [
         {
-          "expr": "sum by (method) (rpc_requests_total)",
+          "expr": "sum by (method) (rate(rpc_requests_total[5m]))",
           "legendFormat": "{{method}}",
-          "instant": true,
           "refId": "A"
         }
-      ],
+      ]
+    },
+    {
+      "id": 1208,
+      "title": "RPC Requests Total",
+      "type": "stat",
+      "gridPos": { "x": 16, "y": 80, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "color": { "mode": "thresholds" },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
+            "steps": [{ "color": "green", "value": null }]
           }
         },
         "overrides": []
@@ -1081,230 +755,12 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.0"
-    },
-    {
-      "id": 1209,
-      "title": "Process CPU Usage %",
-      "type": "timeseries",
-      "gridPos": {
-        "x": 0,
-        "y": 19,
-        "w": 12,
-        "h": 8
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percentunit",
-          "min": 0,
-          "max": 1,
-          "color": {
-            "mode": "palette-classic"
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
       "targets": [
         {
-          "expr": "sum(process_cpu_utilization) by (job, process_cpu_state)",
-          "legendFormat": "{{job}} - {{process_cpu_state}}",
+          "expr": "sum by (method) (rpc_requests_total)",
+          "legendFormat": "{{method}}",
+          "instant": true,
           "refId": "A"
-        }
-      ]
-    },
-    {
-      "id": 12010,
-      "title": "Process Memory Usage",
-      "type": "timeseries",
-      "gridPos": {
-        "x": 12,
-        "y": 19,
-        "w": 12,
-        "h": 8
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes",
-          "color": {
-            "mode": "palette-classic"
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "targets": [
-        {
-          "expr": "sum(process_memory_usage) by (job, process_memory_type)",
-          "legendFormat": "{{job}} - {{process_memory_type}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "id": 12011,
-      "title": "System CPU Usage %",
-      "type": "timeseries",
-      "gridPos": {
-        "x": 0,
-        "y": 27,
-        "w": 12,
-        "h": 8
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percentunit",
-          "min": 0,
-          "max": 1,
-          "color": {
-            "mode": "palette-classic"
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "targets": [
-        {
-          "expr": "sum(system_cpu_utilization) by (system_cpu_state)",
-          "legendFormat": "{{system_cpu_state}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "id": 12012,
-      "title": "System Memory Usage",
-      "type": "timeseries",
-      "gridPos": {
-        "x": 12,
-        "y": 27,
-        "w": 12,
-        "h": 8
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes",
-          "color": {
-            "mode": "palette-classic"
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "targets": [
-        {
-          "expr": "sum(system_memory_usage) by (system_memory_state)",
-          "legendFormat": "{{system_memory_state}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "id": 12013,
-      "title": "Network I/O",
-      "type": "timeseries",
-      "gridPos": {
-        "x": 0,
-        "y": 35,
-        "w": 12,
-        "h": 8
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "Bps",
-          "color": {
-            "mode": "palette-classic"
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "targets": [
-        {
-          "expr": "sum(rate(system_network_io_total[1m])) by (network_io_direction)",
-          "legendFormat": "{{network_io_direction}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "id": 12014,
-      "title": "Network Errors & Drops",
-      "type": "timeseries",
-      "gridPos": {
-        "x": 12,
-        "y": 35,
-        "w": 12,
-        "h": 8
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "color": {
-            "mode": "palette-classic"
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "tooltip": {
-          "mode": "multi"
-        }
-      },
-      "targets": [
-        {
-          "expr": "sum(rate(system_network_errors_total[1m])) by (network_io_direction)",
-          "legendFormat": "errors {{network_io_direction}}",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(rate(system_network_dropped_total[1m])) by (network_io_direction)",
-          "legendFormat": "drops {{network_io_direction}}",
-          "refId": "B"
         }
       ]
     }

--- a/infra/monitoring/grafana/dashboards/anticapture-v2.json
+++ b/infra/monitoring/grafana/dashboards/anticapture-v2.json
@@ -21,7 +21,7 @@
       "id": 1,
       "title": "API Health",
       "type": "stat",
-      "gridPos": { "x": 0, "y": 1, "w": 12, "h": 5 },
+      "gridPos": { "x": 0, "y": 1, "w": 12, "h": 10 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -71,7 +71,7 @@
       "id": 2,
       "title": "Indexer Health",
       "type": "stat",
-      "gridPos": { "x": 12, "y": 1, "w": 12, "h": 5 },
+      "gridPos": { "x": 12, "y": 1, "w": 12, "h": 10 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -120,16 +120,16 @@
     {
       "id": 101,
       "type": "row",
-      "title": "Traffic Overview — Table View",
+      "title": "Traffic Overview",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 6, "w": 24, "h": 1 }
+      "gridPos": { "x": 0, "y": 11, "w": 24, "h": 1 }
     },
     {
       "id": 3,
-      "title": "DAO × Route — Request Rate / Latency / Error Rate (Table)",
+      "title": "DAO × Route — Request Rate / Latency / Error Rate",
       "description": "One row per (DAO, route). Columns: req/s (5m avg), p99 latency, error ratio. Error ratio cell is threshold-colored: green <1%, yellow <5%, red ≥5%.",
       "type": "table",
-      "gridPos": { "x": 0, "y": 7, "w": 24, "h": 12 },
+      "gridPos": { "x": 0, "y": 12, "w": 24, "h": 12 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
@@ -226,176 +226,6 @@
           "legendFormat": "{{job}}|{{http_route}}",
           "instant": true,
           "refId": "C",
-          "format": "table"
-        }
-      ]
-    },
-    {
-      "id": 102,
-      "type": "row",
-      "title": "Traffic Overview — Heatmap View",
-      "collapsed": false,
-      "gridPos": { "x": 0, "y": 19, "w": 24, "h": 1 }
-    },
-    {
-      "id": 4,
-      "title": "Error Ratio Heatmap — DAO × Route (color = error %)",
-      "description": "Each cell is a (DAO, route) pair colored by its 5xx error ratio. Tooltip shows req/s and p99 latency via additional series. Uses xy-chart to render a categorical DAO (Y) × route (X) matrix.",
-      "type": "xychart",
-      "gridPos": { "x": 0, "y": 20, "w": 24, "h": 12 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.01 },
-              { "color": "red", "value": 0.05 }
-            ]
-          },
-          "custom": {
-            "pointSize": { "fixed": 40 },
-            "fillOpacity": 80,
-            "show": "points"
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "mapping": "auto",
-        "series": [],
-        "tooltip": { "mode": "single" },
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        }
-      },
-      "transformations": [
-        { "id": "merge", "options": {} },
-        {
-          "id": "organize",
-          "options": {
-            "renameByName": {
-              "Value #A": "error ratio",
-              "job": "DAO",
-              "http_route": "route"
-            }
-          }
-        }
-      ],
-      "targets": [
-        {
-          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\",http_response_status_code=~\"5..\"}[5m])) by (job, http_route) / sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[5m])) by (job, http_route)",
-          "legendFormat": "{{job}} | {{http_route}}",
-          "instant": true,
-          "refId": "A",
-          "format": "table"
-        }
-      ]
-    },
-    {
-      "id": 5,
-      "title": "Request Rate Heatmap — DAO × Route (color = req/s)",
-      "description": "Same DAO × route matrix, colored by request rate instead of error ratio.",
-      "type": "xychart",
-      "gridPos": { "x": 0, "y": 32, "w": 12, "h": 10 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "reqps",
-          "color": { "mode": "continuous-BlYlRd" },
-          "custom": {
-            "pointSize": { "fixed": 40 },
-            "fillOpacity": 80,
-            "show": "points"
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "mapping": "auto",
-        "series": [],
-        "tooltip": { "mode": "single" },
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        }
-      },
-      "transformations": [
-        { "id": "merge", "options": {} },
-        {
-          "id": "organize",
-          "options": {
-            "renameByName": {
-              "Value #A": "req/s",
-              "job": "DAO",
-              "http_route": "route"
-            }
-          }
-        }
-      ],
-      "targets": [
-        {
-          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[5m])) by (job, http_route)",
-          "legendFormat": "{{job}} | {{http_route}}",
-          "instant": true,
-          "refId": "A",
-          "format": "table"
-        }
-      ]
-    },
-    {
-      "id": 6,
-      "title": "p99 Latency Heatmap — DAO × Route (color = latency)",
-      "description": "Same DAO × route matrix, colored by p99 latency.",
-      "type": "xychart",
-      "gridPos": { "x": 12, "y": 32, "w": 12, "h": 10 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "color": { "mode": "continuous-BlYlRd" },
-          "custom": {
-            "pointSize": { "fixed": 40 },
-            "fillOpacity": 80,
-            "show": "points"
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "mapping": "auto",
-        "series": [],
-        "tooltip": { "mode": "single" },
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        }
-      },
-      "transformations": [
-        { "id": "merge", "options": {} },
-        {
-          "id": "organize",
-          "options": {
-            "renameByName": {
-              "Value #A": "p99 latency",
-              "job": "DAO",
-              "http_route": "route"
-            }
-          }
-        }
-      ],
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=~\"anticapture-.*-api\"}[5m])) by (le, job, http_route))",
-          "legendFormat": "{{job}} | {{http_route}}",
-          "instant": true,
-          "refId": "A",
           "format": "table"
         }
       ]

--- a/infra/monitoring/grafana/dashboards/anticapture-v2.json
+++ b/infra/monitoring/grafana/dashboards/anticapture-v2.json
@@ -15,34 +15,65 @@
       "type": "row",
       "title": "Service Health",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 1 }
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 1
+      }
     },
     {
       "id": 1,
       "title": "API Health",
       "type": "stat",
-      "gridPos": { "x": 0, "y": 1, "w": 12, "h": 10 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 12,
+        "h": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "mappings": [
             {
               "type": "value",
-              "options": { "1": { "text": "UP", "color": "green" } }
+              "options": {
+                "1": {
+                  "text": "UP",
+                  "color": "green"
+                }
+              }
             },
             {
               "type": "value",
-              "options": { "0": { "text": "DOWN", "color": "red" } }
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red"
+                }
+              }
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
             ]
           },
-          "color": { "mode": "thresholds" }
+          "color": {
+            "mode": "thresholds"
+          }
         },
         "overrides": []
       },
@@ -71,28 +102,54 @@
       "id": 2,
       "title": "Indexer Health",
       "type": "stat",
-      "gridPos": { "x": 12, "y": 1, "w": 12, "h": 10 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "x": 12,
+        "y": 1,
+        "w": 12,
+        "h": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "mappings": [
             {
               "type": "value",
-              "options": { "1": { "text": "UP", "color": "green" } }
+              "options": {
+                "1": {
+                  "text": "UP",
+                  "color": "green"
+                }
+              }
             },
             {
               "type": "value",
-              "options": { "0": { "text": "DOWN", "color": "red" } }
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red"
+                }
+              }
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
             ]
           },
-          "color": { "mode": "thresholds" }
+          "color": {
+            "mode": "thresholds"
+          }
         },
         "overrides": []
       },
@@ -122,69 +179,143 @@
       "type": "row",
       "title": "Traffic Overview",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 11, "w": 24, "h": 1 }
+      "gridPos": {
+        "x": 0,
+        "y": 11,
+        "w": 24,
+        "h": 1
+      }
     },
     {
       "id": 3,
       "title": "DAO × Route — Request Rate / Latency / Error Rate",
       "description": "One row per (DAO, route). Columns: req/s (5m avg), p99 latency, error ratio. Error ratio cell is threshold-colored: green <1%, yellow <5%, red ≥5%.",
       "type": "table",
-      "gridPos": { "x": 0, "y": 12, "w": 24, "h": 12 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "x": 0,
+        "y": 12,
+        "w": 24,
+        "h": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "custom": {
             "align": "auto",
-            "cellOptions": { "type": "auto" },
+            "cellOptions": {
+              "type": "auto"
+            },
             "filterable": true
           }
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "req/s" },
+            "matcher": {
+              "id": "byName",
+              "options": "req/s"
+            },
             "properties": [
-              { "id": "unit", "value": "reqps" },
-              { "id": "decimals", "value": 3 },
-              { "id": "custom.width", "value": 100 }
+              {
+                "id": "unit",
+                "value": "reqps"
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "p99 latency" },
+            "matcher": {
+              "id": "byName",
+              "options": "p99 latency"
+            },
             "properties": [
-              { "id": "unit", "value": "s" },
-              { "id": "decimals", "value": 3 },
-              { "id": "custom.width", "value": 120 }
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              },
+              {
+                "id": "custom.width",
+                "value": 120
+              }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "error ratio" },
+            "matcher": {
+              "id": "byName",
+              "options": "error ratio"
+            },
             "properties": [
-              { "id": "unit", "value": "percentunit" },
-              { "id": "decimals", "value": 2 },
-              { "id": "custom.width", "value": 120 },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.width",
+                "value": 120
+              },
               {
                 "id": "custom.cellOptions",
-                "value": { "type": "color-background" }
+                "value": {
+                  "type": "color-background"
+                }
               },
               {
                 "id": "thresholds",
                 "value": {
                   "mode": "absolute",
                   "steps": [
-                    { "color": "green", "value": null },
-                    { "color": "yellow", "value": 0.01 },
-                    { "color": "red", "value": 0.05 }
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.01
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.05
+                    }
                   ]
                 }
               },
-              { "id": "color", "value": { "mode": "thresholds" } }
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              }
             ]
           }
         ]
       },
       "options": {
-        "sortBy": [{ "displayName": "error ratio", "desc": true }],
-        "footer": { "show": false },
+        "sortBy": [
+          {
+            "displayName": "error ratio",
+            "desc": true
+          }
+        ],
+        "footer": {
+          "show": false
+        },
         "frameIndex": 0,
         "showHeader": true
       },
@@ -237,25 +368,247 @@
       ]
     },
     {
+      "id": 110,
+      "type": "row",
+      "title": "Traffic Detail",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 11,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "id": 1101,
+      "title": "Request Rate (req/s)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_request_duration_seconds_count[1m])) by (http_route, http_request_method)",
+          "legendFormat": "{{http_request_method}} {{http_route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 1102,
+      "title": "Error Rate (5xx)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 8,
+        "y": 0,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "red"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~\"5..\"}[1m])) by (http_route)",
+          "legendFormat": "5xx {{http_route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 1103,
+      "title": "P99 / P95 / P50 Latency",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 16,
+        "y": 0,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 1104,
+      "title": "Latency by Route (p99)",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 16,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le, http_route))",
+          "legendFormat": "p99 {{http_route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 1105,
+      "title": "Status Code Breakdown",
+      "type": "piechart",
+      "gridPos": {
+        "x": 16,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "pieType": "donut",
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(http_server_request_duration_seconds_count[5m])) by (http_response_status_code)",
+          "legendFormat": "{{http_response_status_code}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
       "id": 103,
       "type": "row",
       "title": "Gateful Cache",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 24, "w": 24, "h": 1 }
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 24,
+        "h": 1
+      }
     },
     {
       "id": 6,
       "title": "Cache Hit Rate (gateful)",
       "description": "hits / (hits + misses) per route over time. A healthy cache stays well above 50%.",
       "type": "timeseries",
-      "gridPos": { "x": 0, "y": 25, "w": 16, "h": 10 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "x": 0,
+        "y": 25,
+        "w": 16,
+        "h": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "percentunit",
           "min": 0,
           "max": 1,
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "lineWidth": 1,
@@ -267,16 +620,28 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "yellow", "value": 0.5 },
-              { "color": "green", "value": 0.8 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 0.8
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
@@ -296,44 +661,72 @@
       "title": "Cache Hits vs Misses (gateful)",
       "description": "Absolute hit and miss rate in req/s.",
       "type": "timeseries",
-      "gridPos": { "x": 16, "y": 25, "w": 8, "h": 10 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "x": 16,
+        "y": 25,
+        "w": 8,
+        "h": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "reqps",
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "bars",
             "lineWidth": 1,
             "fillOpacity": 60,
             "gradientMode": "none",
             "showPoints": "never",
-            "stacking": { "mode": "normal", "group": "A" }
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
           }
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "hit" },
+            "matcher": {
+              "id": "byName",
+              "options": "hit"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "green", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "miss" },
+            "matcher": {
+              "id": "byName",
+              "options": "miss"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "red", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
@@ -353,45 +746,78 @@
       "type": "row",
       "title": "Client Traffic",
       "collapsed": false,
-      "gridPos": { "x": 0, "y": 35, "w": 24, "h": 1 }
+      "gridPos": {
+        "x": 0,
+        "y": 35,
+        "w": 24,
+        "h": 1
+      }
     },
     {
       "id": 4,
       "title": "Requests by Client Source — Share (donut)",
       "description": "Split by x-client-source header from the API gateway. Three values: 'anticapture-frontend' (dashboard), 'notification-system' (bot), 'other' (unidentified callers).",
       "type": "piechart",
-      "gridPos": { "x": 0, "y": 36, "w": 8, "h": 10 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "x": 0,
+        "y": 36,
+        "w": 8,
+        "h": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "percentunit"
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "notification-system" },
+            "matcher": {
+              "id": "byName",
+              "options": "notification-system"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "orange", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "anticapture-frontend" },
+            "matcher": {
+              "id": "byName",
+              "options": "anticapture-frontend"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "blue", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "other" },
+            "matcher": {
+              "id": "byName",
+              "options": "other"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "gray", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "gray",
+                  "mode": "fixed"
+                }
               }
             ]
           }
@@ -399,7 +825,9 @@
       },
       "options": {
         "pieType": "donut",
-        "tooltip": { "mode": "single" },
+        "tooltip": {
+          "mode": "single"
+        },
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
@@ -421,12 +849,22 @@
       "title": "Requests by Client Source — Rate over time",
       "description": "req/s per client source at the gateway level, useful for spotting bot spikes vs normal dashboard load.",
       "type": "timeseries",
-      "gridPos": { "x": 8, "y": 36, "w": 16, "h": 10 },
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": {
+        "x": 8,
+        "y": 36,
+        "w": 16,
+        "h": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "reqps",
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "drawStyle": "line",
             "lineWidth": 1,
@@ -438,36 +876,57 @@
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "notification-system" },
+            "matcher": {
+              "id": "byName",
+              "options": "notification-system"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "orange", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "anticapture-frontend" },
+            "matcher": {
+              "id": "byName",
+              "options": "anticapture-frontend"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "blue", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
-            "matcher": { "id": "byName", "options": "other" },
+            "matcher": {
+              "id": "byName",
+              "options": "other"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "gray", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "gray",
+                  "mode": "fixed"
+                }
               }
             ]
           }
         ]
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
@@ -479,6 +938,373 @@
           "expr": "sum(rate(http_server_request_duration_seconds_count{job=\"anticapture-gateway\"}[5m])) by (client_source)",
           "legendFormat": "{{client_source}}",
           "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 120,
+      "type": "row",
+      "title": "System Metrics",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 35,
+        "w": 24,
+        "h": 1
+      }
+    },
+    {
+      "id": 1207,
+      "type": "timeseries",
+      "title": "RPC request rate",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 43
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (method) (rate(rpc_requests_total[5m]))",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "pointSize": 5,
+            "showPoints": "never",
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "axisCenteredZero": false,
+            "barAlignment": 0,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      }
+    },
+    {
+      "id": 1208,
+      "type": "stat",
+      "title": "RPC requests total",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 43
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "sum by (method) (rpc_requests_total)",
+          "legendFormat": "{{method}}",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 1209,
+      "title": "Process CPU Usage %",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 19,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(process_cpu_utilization) by (job, process_cpu_state)",
+          "legendFormat": "{{job}} - {{process_cpu_state}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12010,
+      "title": "Process Memory Usage",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 19,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(process_memory_usage) by (job, process_memory_type)",
+          "legendFormat": "{{job}} - {{process_memory_type}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12011,
+      "title": "System CPU Usage %",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 27,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(system_cpu_utilization) by (system_cpu_state)",
+          "legendFormat": "{{system_cpu_state}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12012,
+      "title": "System Memory Usage",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 27,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(system_memory_usage) by (system_memory_state)",
+          "legendFormat": "{{system_memory_state}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12013,
+      "title": "Network I/O",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 35,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(system_network_io_total[1m])) by (network_io_direction)",
+          "legendFormat": "{{network_io_direction}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12014,
+      "title": "Network Errors & Drops",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 12,
+        "y": 35,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(system_network_errors_total[1m])) by (network_io_direction)",
+          "legendFormat": "errors {{network_io_direction}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(system_network_dropped_total[1m])) by (network_io_direction)",
+          "legendFormat": "drops {{network_io_direction}}",
+          "refId": "B"
         }
       ]
     }

--- a/infra/monitoring/grafana/dashboards/anticapture-v2.json
+++ b/infra/monitoring/grafana/dashboards/anticapture-v2.json
@@ -60,8 +60,8 @@
       },
       "targets": [
         {
-          "expr": "up{job=~\"anticapture-.*-api\"}",
-          "legendFormat": "{{job}}",
+          "expr": "label_replace(label_replace(up{job=~\"anticapture-.*-api\"}, \"dao\", \"$1\", \"job\", \".*\"), \"dao\", \"$1\", \"job\", \"anticapture-(.*)-api\")",
+          "legendFormat": "{{dao}}",
           "instant": true,
           "refId": "A"
         }
@@ -110,8 +110,8 @@
       },
       "targets": [
         {
-          "expr": "up{job=~\"anticapture-.*-indexer\"}",
-          "legendFormat": "{{job}}",
+          "expr": "label_replace(label_replace(up{job=~\"anticapture-.*-indexer\"}, \"dao\", \"$1\", \"job\", \".*\"), \"dao\", \"$1\", \"job\", \"anticapture-(.*)-indexer\")",
+          "legendFormat": "{{dao}}",
           "instant": true,
           "refId": "A"
         }
@@ -196,6 +196,12 @@
         {
           "id": "organize",
           "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true
+            },
             "renameByName": {
               "Value #A": "req/s",
               "Value #B": "p99 latency",
@@ -227,6 +233,252 @@
           "instant": true,
           "refId": "C",
           "format": "table"
+        }
+      ]
+    },
+    {
+      "id": 103,
+      "type": "row",
+      "title": "Gateful Cache",
+      "collapsed": false,
+      "gridPos": { "x": 0, "y": 24, "w": 24, "h": 1 }
+    },
+    {
+      "id": 6,
+      "title": "Cache Hit Rate (gateful)",
+      "description": "hits / (hits + misses) per route over time. A healthy cache stays well above 50%.",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 25, "w": 16, "h": 10 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "green", "value": 0.8 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(cache_requests_total{job=\"anticapture-gateful\", result=\"hit\"}[5m])) by (route) / sum(rate(cache_requests_total{job=\"anticapture-gateful\"}[5m])) by (route)",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Cache Hits vs Misses (gateful)",
+      "description": "Absolute hit and miss rate in req/s.",
+      "type": "timeseries",
+      "gridPos": { "x": 16, "y": 25, "w": 8, "h": 10 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 60,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "stacking": { "mode": "normal", "group": "A" }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "hit" },
+            "properties": [
+              {
+                "id": "color",
+                "value": { "fixedColor": "green", "mode": "fixed" }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "miss" },
+            "properties": [
+              {
+                "id": "color",
+                "value": { "fixedColor": "red", "mode": "fixed" }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(cache_requests_total{job=\"anticapture-gateful\"}[5m])) by (result)",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 102,
+      "type": "row",
+      "title": "Client Traffic",
+      "collapsed": false,
+      "gridPos": { "x": 0, "y": 35, "w": 24, "h": 1 }
+    },
+    {
+      "id": 4,
+      "title": "Requests by Client Source — Share (donut)",
+      "description": "Split by x-client-source header from the API gateway. Three values: 'anticapture-frontend' (dashboard), 'notification-system' (bot), 'other' (unidentified callers).",
+      "type": "piechart",
+      "gridPos": { "x": 0, "y": 36, "w": 8, "h": 10 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "notification-system" },
+            "properties": [
+              {
+                "id": "color",
+                "value": { "fixedColor": "orange", "mode": "fixed" }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "anticapture-frontend" },
+            "properties": [
+              {
+                "id": "color",
+                "value": { "fixedColor": "blue", "mode": "fixed" }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "other" },
+            "properties": [
+              {
+                "id": "color",
+                "value": { "fixedColor": "gray", "mode": "fixed" }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "pieType": "donut",
+        "tooltip": { "mode": "single" },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "displayLabels": ["percent"]
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(http_server_request_duration_seconds_count{job=\"anticapture-gateway\"}[$__range])) by (client_source)",
+          "legendFormat": "{{client_source}}",
+          "instant": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Requests by Client Source — Rate over time",
+      "description": "req/s per client source at the gateway level, useful for spotting bot spikes vs normal dashboard load.",
+      "type": "timeseries",
+      "gridPos": { "x": 8, "y": 36, "w": 16, "h": 10 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "showPoints": "never"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "notification-system" },
+            "properties": [
+              {
+                "id": "color",
+                "value": { "fixedColor": "orange", "mode": "fixed" }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "anticapture-frontend" },
+            "properties": [
+              {
+                "id": "color",
+                "value": { "fixedColor": "blue", "mode": "fixed" }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "other" },
+            "properties": [
+              {
+                "id": "color",
+                "value": { "fixedColor": "gray", "mode": "fixed" }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=\"anticapture-gateway\"}[5m])) by (client_source)",
+          "legendFormat": "{{client_source}}",
+          "refId": "A"
         }
       ]
     }

--- a/infra/monitoring/grafana/dashboards/anticapture-v2.json
+++ b/infra/monitoring/grafana/dashboards/anticapture-v2.json
@@ -194,13 +194,14 @@
               "Time": true,
               "Time 1": true,
               "Time 2": true,
-              "Time 3": true
+              "Time 3": true,
+              "job": true
             },
             "renameByName": {
               "Value #A": "req/s",
               "Value #B": "p99 latency",
               "Value #C": "error ratio",
-              "job": "DAO",
+              "dao": "DAO",
               "http_route": "route"
             }
           }
@@ -208,22 +209,22 @@
       ],
       "targets": [
         {
-          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[5m])) by (job, http_route)",
-          "legendFormat": "{{job}}|{{http_route}}",
+          "expr": "label_replace(label_replace(sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[5m])) by (job, http_route), \"dao\", \"$1\", \"job\", \".*\"), \"dao\", \"$1\", \"job\", \"anticapture-(.*)-api\")",
+          "legendFormat": "{{dao}}|{{http_route}}",
           "instant": true,
           "refId": "A",
           "format": "table"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=~\"anticapture-.*-api\"}[5m])) by (le, job, http_route))",
-          "legendFormat": "{{job}}|{{http_route}}",
+          "expr": "label_replace(label_replace(histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=~\"anticapture-.*-api\"}[5m])) by (le, job, http_route)), \"dao\", \"$1\", \"job\", \".*\"), \"dao\", \"$1\", \"job\", \"anticapture-(.*)-api\")",
+          "legendFormat": "{{dao}}|{{http_route}}",
           "instant": true,
           "refId": "B",
           "format": "table"
         },
         {
-          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\",http_response_status_code=~\"5..\"}[5m])) by (job, http_route) / sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[5m])) by (job, http_route)",
-          "legendFormat": "{{job}}|{{http_route}}",
+          "expr": "label_replace(label_replace(sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\",http_response_status_code=~\"5..\"}[5m])) by (job, http_route) / sum(rate(http_server_request_duration_seconds_count{job=~\"anticapture-.*-api\"}[5m])) by (job, http_route), \"dao\", \"$1\", \"job\", \".*\"), \"dao\", \"$1\", \"job\", \"anticapture-(.*)-api\")",
+          "legendFormat": "{{dao}}|{{http_route}}",
           "instant": true,
           "refId": "C",
           "format": "table"

--- a/infra/monitoring/slack.tmpl
+++ b/infra/monitoring/slack.tmpl
@@ -1,0 +1,27 @@
+{{ define "slack.anticapture.color" -}}
+  {{- if eq .Status "firing" -}}
+    {{- if eq (index .Alerts 0).Labels.severity "critical" -}}danger{{- else -}}warning{{- end -}}
+  {{- else -}}good{{- end -}}
+{{- end }}
+
+{{ define "slack.anticapture.icon" -}}
+  {{- if eq .Status "firing" -}}
+    {{- if eq (index .Alerts 0).Labels.severity "critical" -}}:red_circle:{{- else -}}:large_yellow_circle:{{- end -}}
+  {{- else -}}:large_green_circle:{{- end -}}
+{{- end }}
+
+{{ define "slack.anticapture.title" -}}
+  {{ template "slack.anticapture.icon" . }} *{{ if eq .Status "firing" }}{{ (index .Alerts 0).Labels.severity | toUpper }}{{ else }}RESOLVED{{ end }}* — {{ .CommonAnnotations.summary }}
+{{- end }}
+
+{{ define "slack.anticapture.text" -}}
+  {{- range .Alerts }}
+*Description:* {{ .Annotations.description }}
+
+*Details:*
+• *Alert:* `{{ .Labels.alertname }}`
+• *Job:* `{{ .Labels.job }}`{{ if .Labels.instance }}
+• *Instance:* `{{ .Labels.instance }}`{{ end }}
+• *Since:* {{ .StartsAt.Format "2006-01-02 15:04:05 UTC" }}
+  {{- end }}
+{{- end }}

--- a/packages/anticapture-client/kubb.config.ts
+++ b/packages/anticapture-client/kubb.config.ts
@@ -15,8 +15,8 @@ export default defineConfig(({ watch }) => ({
     path: gatefulOpenApiSpecPath,
   },
   output: {
-    path: "./generated",
     clean: !watch,
+    path: "./generated",
   },
   plugins: [
     pluginOas({

--- a/packages/anticapture-client/src/client.ts
+++ b/packages/anticapture-client/src/client.ts
@@ -109,6 +109,8 @@ const getHeaders = (
 ) => {
   const resolvedHeaders = new Headers(headers);
 
+  resolvedHeaders.set("x-client-source", "anticapture-frontend");
+
   if (data !== undefined && data !== null && !isFormData(data)) {
     resolvedHeaders.set("Content-Type", "application/json");
   }

--- a/packages/graphql-client/codegen.ts
+++ b/packages/graphql-client/codegen.ts
@@ -15,8 +15,8 @@ const config: CodegenConfig = {
         "typescript-react-apollo",
       ],
       config: {
-        dedupeFragments: true,
         avoidOptionals: true,
+        dedupeFragments: true,
         strictScalars: true,
         scalars: {
           DateTime: "string",


### PR DESCRIPTION
## What

Adds an observability layer and a new Grafana dashboard ("Anticapture V2") for monitoring the platform's request traffic, cache behaviour, and system health.

## Changes

**`apps/api-gateway`**
- Records `http_server_request_duration_seconds` (histogram) per request, labelled by method, route, status code, and `client_source` (derived from the `x-client-source` request header).

**`apps/gateful`**
- Records `cache_requests_total` (counter) per cache lookup, labelled by `result` (`hit`, `miss`, `corrupt`) and `route`.

**`apps/dashboard`**
- Forwards the `x-client-source` header through the Next.js proxy so the gateway can attribute traffic to the frontend.

**`packages/anticapture-client`**
- Injects `x-client-source: anticapture-frontend` on every outgoing API request.

**`infra/monitoring/grafana/dashboards/anticapture-v2.json`**
New dashboard with the following sections:

| Section | Panels |
|---|---|
| Service Health | API and Indexer up/down per DAO |
| Traffic Overview | DAO × route table — req/s, p99 latency, error ratio |
| Traffic Detail | Request rate, error rate, p99/p95/p50 latency, latency by route, status code breakdown |
| Gateful Cache | Hit rate over time, hits vs misses (stacked bars) |
| Client Traffic | Share by client source (donut), rate over time |
| System Metrics | Process and system CPU/memory, RPC request rate |
| eRPC | Incoming RPS, successful responses, critical errors, vendor/upstream p99 latency |