### PR TITLE
Fix: prometheus indexer alert spam

### DIFF
--- a/infra/monitoring/Dockerfile.alertmanager
+++ b/infra/monitoring/Dockerfile.alertmanager
@@ -1,5 +1,4 @@
 FROM prom/alertmanager:latest
-ARG CACHEBUST=1
 COPY alertmanager.yml /etc/alertmanager/config.yml.tmpl
 COPY slack.tmpl /etc/alertmanager/slack.tmpl
 COPY entrypoint.alertmanager.sh /entrypoint.sh

--- a/infra/monitoring/Dockerfile.alertmanager
+++ b/infra/monitoring/Dockerfile.alertmanager
@@ -1,4 +1,5 @@
 FROM prom/alertmanager:latest
+ARG CACHEBUST=1
 COPY alertmanager.yml /etc/alertmanager/config.yml.tmpl
 COPY slack.tmpl /etc/alertmanager/slack.tmpl
 COPY entrypoint.alertmanager.sh /entrypoint.sh

--- a/infra/monitoring/Dockerfile.alertmanager
+++ b/infra/monitoring/Dockerfile.alertmanager
@@ -1,5 +1,6 @@
 FROM prom/alertmanager:latest
 COPY alertmanager.yml /etc/alertmanager/config.yml.tmpl
+COPY slack.tmpl /etc/alertmanager/slack.tmpl
 COPY entrypoint.alertmanager.sh /entrypoint.sh
 USER root
 RUN chmod +x /entrypoint.sh

--- a/infra/monitoring/Dockerfile.prometheus
+++ b/infra/monitoring/Dockerfile.prometheus
@@ -1,7 +1,6 @@
 FROM prom/prometheus:latest AS prometheus
 
 FROM alpine:3.19
-ARG CACHEBUST=1
 RUN apk add --no-cache gettext
 COPY --from=prometheus /bin/prometheus /bin/prometheus
 COPY --from=prometheus /bin/promtool /bin/promtool

--- a/infra/monitoring/Dockerfile.prometheus
+++ b/infra/monitoring/Dockerfile.prometheus
@@ -1,6 +1,7 @@
 FROM prom/prometheus:latest AS prometheus
 
 FROM alpine:3.19
+ARG CACHEBUST=1
 RUN apk add --no-cache gettext
 COPY --from=prometheus /bin/prometheus /bin/prometheus
 COPY --from=prometheus /bin/promtool /bin/promtool

--- a/infra/monitoring/alertmanager.yml
+++ b/infra/monitoring/alertmanager.yml
@@ -1,3 +1,6 @@
+templates:
+  - /etc/alertmanager/slack.tmpl
+
 route:
   receiver: default
   group_by: [alertname, job]
@@ -10,5 +13,7 @@ receivers:
     slack_configs:
       - api_url: "${SLACK_WEBHOOK_URL}"
         channel: "${SLACK_CHANNEL}"
-        title: "[{{ .Status | toUpper }}] {{ .CommonAnnotations.summary }}"
-        text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
+        color: '{{ template "slack.anticapture.color" . }}'
+        title: '{{ template "slack.anticapture.title" . }}'
+        text: '{{ template "slack.anticapture.text" . }}'
+        send_resolved: true

--- a/infra/monitoring/alertmanager.yml
+++ b/infra/monitoring/alertmanager.yml
@@ -1,6 +1,9 @@
 templates:
   - /etc/alertmanager/slack.tmpl
 
+global:
+  resolve_timeout: 5m
+
 route:
   receiver: default
   group_by: [alertname, job]

--- a/infra/monitoring/alerts.yml
+++ b/infra/monitoring/alerts.yml
@@ -4,7 +4,7 @@ groups:
     rules:
       # Service is not responding (no scrape data for 1 minute)
       - alert: ServiceDown
-        expr: up == 0 and on(job) group_left() (group by(job) ({job!~".*-indexer"}))
+        expr: up{job!~".*-indexer"} == 0
         for: 1m
         labels:
           severity: critical
@@ -17,7 +17,7 @@ groups:
 
       # Indexer is not responding — longer window to account for slow startup
       - alert: IndexerDown
-        expr: up == 0 and on(job) group_left() (group by(job) ({job=~".*-indexer"}))
+        expr: up{job=~".*-indexer"} == 0
         for: 10m
         labels:
           severity: critical

--- a/infra/monitoring/alerts.yml
+++ b/infra/monitoring/alerts.yml
@@ -9,8 +9,11 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: "Service {{ $labels.job }} is down"
-          description: "Prometheus cannot scrape {{ $labels.job }} at {{ $labels.instance }}"
+          summary: "[CRITICAL] {{ $labels.job }} is unreachable"
+          description: >
+            Prometheus has been unable to scrape {{ $labels.job }} at {{ $labels.instance }}
+            for more than 1 minute. The service may be crashed, OOM-killed, or misconfigured.
+            Check container/process status and recent logs immediately.
 
       # Indexer is not responding — longer window to account for slow startup
       - alert: IndexerDown
@@ -19,8 +22,12 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: "Indexer {{ $labels.job }} is down"
-          description: "Prometheus cannot scrape {{ $labels.job }} at {{ $labels.instance }}"
+          summary: "[CRITICAL] {{ $labels.job }} is unreachable"
+          description: >
+            Prometheus has been unable to scrape {{ $labels.job }} at {{ $labels.instance }}
+            for more than 10 minutes. Note: indexers take time to bind their HTTP server on
+            cold start, so this alert has an extended window. If the indexer was not recently
+            deployed, check container/process status and recent logs.
 
       # CPU usage above 80% for 5 minutes
       - alert: HighCPUUsage
@@ -29,8 +36,11 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: "High CPU on {{ $labels.job }}"
-          description: '{{ $labels.job }} CPU at {{ printf "%.1f" $value }}% for 5 minutes'
+          summary: "[WARNING] High CPU usage on {{ $labels.job }}"
+          description: >
+            {{ $labels.job }} has been using {{ printf "%.1f" $value }}% CPU for more than
+            5 minutes. This may indicate a processing backlog, tight indexing loop, or a
+            runaway query. Review process metrics and recent workload.
 
       # p99 HTTP latency above 2s for 5 minutes
       - alert: HighLatency
@@ -42,8 +52,11 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: "High p99 latency"
-          description: 'p99 latency is {{ printf "%.2f" $value }}s'
+          summary: "[WARNING] High p99 HTTP latency"
+          description: >
+            The p99 HTTP response time has been {{ printf "%.2f" $value }}s for more than
+            5 minutes (threshold: 2s). This may indicate slow database queries, resource
+            contention, or downstream bottlenecks. Check slow query logs and DB connection pool.
 
       # 5xx error rate above 1% for 2 minutes
       - alert: HighErrorRate
@@ -56,5 +69,9 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: "High 5xx error rate"
-          description: '5xx rate is {{ printf "%.2f" $value }}%'
+          summary: "[CRITICAL] Elevated 5xx error rate"
+          description: >
+            The 5xx error rate has been {{ printf "%.2f" $value }}% for more than 2 minutes
+            (threshold: 1%). Users are experiencing server errors. Check application logs for
+            stack traces, database connectivity, and any recent deployments that may have
+            introduced regressions.

--- a/infra/monitoring/alerts.yml
+++ b/infra/monitoring/alerts.yml
@@ -4,12 +4,22 @@ groups:
     rules:
       # Service is not responding (no scrape data for 1 minute)
       - alert: ServiceDown
-        expr: up == 0
+        expr: up == 0 and on(job) group_left() (group by(job) ({job!~".*-indexer"}))
         for: 1m
         labels:
           severity: critical
         annotations:
           summary: "Service {{ $labels.job }} is down"
+          description: "Prometheus cannot scrape {{ $labels.job }} at {{ $labels.instance }}"
+
+      # Indexer is not responding — longer window to account for slow startup
+      - alert: IndexerDown
+        expr: up == 0 and on(job) group_left() (group by(job) ({job=~".*-indexer"}))
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Indexer {{ $labels.job }} is down"
           description: "Prometheus cannot scrape {{ $labels.job }} at {{ $labels.instance }}"
 
       # CPU usage above 80% for 5 minutes

--- a/infra/monitoring/entrypoint.prometheus.sh
+++ b/infra/monitoring/entrypoint.prometheus.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 envsubst < /etc/prometheus/prometheus.yml.tmpl > /etc/prometheus/prometheus.yml
-rm -rf /prometheus/*
+if [ ! -f /prometheus/.initialized ]; then
+  rm -rf /prometheus/*
+  touch /prometheus/.initialized
+fi
 exec /bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.enable-lifecycle --web.enable-remote-write-receiver "$@"

--- a/infra/monitoring/entrypoint.prometheus.sh
+++ b/infra/monitoring/entrypoint.prometheus.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 envsubst < /etc/prometheus/prometheus.yml.tmpl > /etc/prometheus/prometheus.yml
+rm -rf /prometheus/*
 exec /bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.enable-lifecycle --web.enable-remote-write-receiver "$@"

--- a/infra/monitoring/entrypoint.prometheus.sh
+++ b/infra/monitoring/entrypoint.prometheus.sh
@@ -1,7 +1,4 @@
 #!/bin/sh
 envsubst < /etc/prometheus/prometheus.yml.tmpl > /etc/prometheus/prometheus.yml
-if [ ! -f /prometheus/.initialized ]; then
-  rm -rf /prometheus/*
-  touch /prometheus/.initialized
-fi
+rm -rf /prometheus/*
 exec /bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus --web.enable-lifecycle --web.enable-remote-write-receiver "$@"

--- a/infra/monitoring/slack.tmpl
+++ b/infra/monitoring/slack.tmpl
@@ -1,0 +1,27 @@
+{{ define "slack.anticapture.color" -}}
+  {{- if eq .Status "firing" -}}
+    {{- if eq (index .Alerts 0).Labels.severity "critical" -}}danger{{- else -}}warning{{- end -}}
+  {{- else -}}good{{- end -}}
+{{- end }}
+
+{{ define "slack.anticapture.icon" -}}
+  {{- if eq .Status "firing" -}}
+    {{- if eq (index .Alerts 0).Labels.severity "critical" -}}:red_circle:{{- else -}}:large_yellow_circle:{{- end -}}
+  {{- else -}}:large_green_circle:{{- end -}}
+{{- end }}
+
+{{ define "slack.anticapture.title" -}}
+  {{ template "slack.anticapture.icon" . }} *{{ if eq .Status "firing" }}{{ (index .Alerts 0).Labels.severity | toUpper }}{{ else }}RESOLVED{{ end }}* — {{ .CommonAnnotations.summary }}
+{{- end }}
+
+{{ define "slack.anticapture.text" -}}
+  {{- range .Alerts }}
+*Description:* {{ .Annotations.description }}
+
+*Details:*
+• *Alert:* `{{ .Labels.alertname }}`
+• *Job:* `{{ .Labels.job }}`{{ if .Labels.instance }}
+• *Instance:* `{{ .Labels.instance }}`{{ end }}
+• *Since:* {{ .StartsAt.Format "2006-01-02 15:04:05 UTC" }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
## Problem

Indexer services were triggering false-positive DOWN alerts on startup. Prometheus was evaluating `up == 0` for all services with a 1-minute window, but indexers take longer to become reachable —
 and stale alert state in the Prometheus WAL caused these alerts to replay on every restart, spamming the Slack channel.

## Changes

- Split `ServiceDown` into two rules - `ServiceDown` (1m window, non-indexers) and `IndexerDown` (10m window, indexers only) to account for slower indexer startup;
- Clear Prometheus WAL on startup - `rm -rf /prometheus/*` in the entrypoint prevents stale alert state from replaying across restarts;
- Custom Slack template (`slack.tmpl`) - color-coded severity sidebar (red/yellow/green), emoji prefix, structured details block (alert name, job, instance, timestamp), and resolution
notifications via `send_resolved: true`;
- Richer alert descriptions - all alerts now include likely causes and a concrete first investigative step;
