### PR TITLE
Gateful 🤝 address enrichment

### DIFF
--- a/apps/gateful/openapi/gateful.json
+++ b/apps/gateful/openapi/gateful.json
@@ -1986,7 +1986,37 @@
       "get": {
         "responses": {
           "200": {
-            "description": "Health check"
+            "description": "Gateway health and per-DAO circuit breaker states",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": ["ok"]
+                    },
+                    "circuits": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                          "state": {
+                            "type": "string",
+                            "enum": ["CLOSED", "OPEN", "HALF_OPEN"]
+                          },
+                          "nextRetryIn": {
+                            "type": "number"
+                          }
+                        },
+                        "required": ["state"]
+                      }
+                    }
+                  },
+                  "required": ["status", "circuits"]
+                }
+              }
+            }
           }
         }
       }
@@ -6975,6 +7005,235 @@
           "description": "DAO identifier"
         }
       ]
+    },
+    "/address-enrichment/address/{address}": {
+      "get": {
+        "operationId": "getAddress",
+        "summary": "Get enriched data for an address",
+        "description": "Returns label information from Arkham, ENS data, and whether the address is an EOA or contract. Arkham data is stored permanently. ENS data is cached with a configurable TTL.",
+        "tags": ["address"],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Ethereum address (checksummed or lowercase)",
+              "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+            },
+            "required": true,
+            "name": "address",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved address enrichment data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "address": {
+                      "type": "string",
+                      "description": "EIP-55 checksummed Ethereum address",
+                      "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                    },
+                    "isContract": {
+                      "type": "boolean",
+                      "description": "Whether the address is a smart contract (true) or an externally-owned account (false)",
+                      "example": false
+                    },
+                    "arkham": {
+                      "type": "object",
+                      "nullable": true,
+                      "properties": {
+                        "entity": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Human-readable name of the entity that owns the address according to Arkham Intelligence",
+                          "example": "Vitalik Buterin"
+                        },
+                        "entityType": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Category of the entity (e.g. 'individual', 'exchange', 'protocol', 'fund')",
+                          "example": "individual"
+                        },
+                        "label": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Fine-grained label for the specific address within the entity",
+                          "example": "Vitalik Buterin: Personal Wallet"
+                        },
+                        "twitter": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Twitter/X handle associated with the entity, without '@'",
+                          "example": "VitalikButerin"
+                        }
+                      },
+                      "required": ["entity", "entityType", "label", "twitter"],
+                      "description": "Arkham Intelligence label data. null when no data is available for the address."
+                    },
+                    "ens": {
+                      "type": "object",
+                      "nullable": true,
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Primary ENS name reverse-resolved for this address",
+                          "example": "vitalik.eth"
+                        },
+                        "avatar": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "URL of the ENS avatar image",
+                          "example": "https://metadata.ens.domains/mainnet/avatar/vitalik.eth"
+                        },
+                        "banner": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "URL of the ENS profile banner image",
+                          "example": null
+                        }
+                      },
+                      "required": ["name", "avatar", "banner"],
+                      "description": "ENS (Ethereum Name Service) data. null when no ENS name is registered for the address. Cached with a configurable TTL."
+                    }
+                  },
+                  "required": ["address", "isContract", "arkham", "ens"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/address-enrichment/addresses": {
+      "get": {
+        "operationId": "getAddresses",
+        "summary": "Get enriched data for multiple addresses",
+        "description": "Returns label information from Arkham, ENS data, and address type for multiple addresses. Maximum 100 addresses per request. Arkham data is stored permanently. ENS data is cached with a configurable TTL.",
+        "tags": ["address"],
+        "parameters": [
+          {
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "maxItems": 100,
+              "description": "One or more Ethereum addresses to enrich. Can be passed as a repeated query parameter or a single value. Maximum 100 addresses per request.",
+              "example": [
+                "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+                "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B"
+              ]
+            },
+            "required": true,
+            "name": "addresses",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved batch enrichment data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "address": {
+                            "type": "string",
+                            "description": "EIP-55 checksummed Ethereum address",
+                            "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                          },
+                          "isContract": {
+                            "type": "boolean",
+                            "description": "Whether the address is a smart contract (true) or an externally-owned account (false)",
+                            "example": false
+                          },
+                          "arkham": {
+                            "type": "object",
+                            "nullable": true,
+                            "properties": {
+                              "entity": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Human-readable name of the entity that owns the address according to Arkham Intelligence",
+                                "example": "Vitalik Buterin"
+                              },
+                              "entityType": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Category of the entity (e.g. 'individual', 'exchange', 'protocol', 'fund')",
+                                "example": "individual"
+                              },
+                              "label": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Fine-grained label for the specific address within the entity",
+                                "example": "Vitalik Buterin: Personal Wallet"
+                              },
+                              "twitter": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Twitter/X handle associated with the entity, without '@'",
+                                "example": "VitalikButerin"
+                              }
+                            },
+                            "required": [
+                              "entity",
+                              "entityType",
+                              "label",
+                              "twitter"
+                            ],
+                            "description": "Arkham Intelligence label data. null when no data is available for the address."
+                          },
+                          "ens": {
+                            "type": "object",
+                            "nullable": true,
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Primary ENS name reverse-resolved for this address",
+                                "example": "vitalik.eth"
+                              },
+                              "avatar": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "URL of the ENS avatar image",
+                                "example": "https://metadata.ens.domains/mainnet/avatar/vitalik.eth"
+                              },
+                              "banner": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "URL of the ENS profile banner image",
+                                "example": null
+                              }
+                            },
+                            "required": ["name", "avatar", "banner"],
+                            "description": "ENS (Ethereum Name Service) data. null when no ENS name is registered for the address. Cached with a configurable TTL."
+                          }
+                        },
+                        "required": ["address", "isContract", "arkham", "ens"]
+                      },
+                      "description": "Enrichment results for each successfully resolved address. Addresses that failed to resolve are omitted."
+                    }
+                  },
+                  "required": ["results"]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "webhooks": {},

--- a/apps/gateful/src/index.ts
+++ b/apps/gateful/src/index.ts
@@ -72,8 +72,13 @@ if (config.redisUrl) {
 }
 
 logger.info(
-  { daoApis: Array.from(config.daoApis.keys()) },
-  `discovered ${config.daoApis.size} DAO APIs`,
+  {
+    daoApis: Array.from(config.daoApis.keys()),
+    addressEnrichmentUrl: config.addressEnrichmentUrl ?? null,
+  },
+  `discovered ${config.daoApis.size} DAO APIs${
+    config.addressEnrichmentUrl ? " + address enrichment" : ""
+  }`,
 );
 
 const registry = new CircuitBreakerRegistry(config.circuitBreaker);
@@ -107,7 +112,11 @@ openApiDocument.components = {
   },
 };
 
-const getOpenApiSpec = storeOpenApiSpec(openApiDocument, config.daoApis);
+const getOpenApiSpec = storeOpenApiSpec(
+  openApiDocument,
+  config.daoApis,
+  config.addressEnrichmentUrl,
+);
 
 app.get("/docs/json", async (c) => {
   return c.json(await getOpenApiSpec());

--- a/apps/gateful/src/resolvers/address-enrichment/route.test.ts
+++ b/apps/gateful/src/resolvers/address-enrichment/route.test.ts
@@ -27,27 +27,39 @@ describe("address-enrichment route", () => {
   });
 
   it("should proxy to upstream and return its response", async () => {
-    vi.spyOn(global, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ ens: "vitalik.eth" }), { status: 200 }),
-    );
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ens: "vitalik.eth" }), { status: 200 }),
+      );
 
-    const res = await app.request("/address-enrichment/0x123");
+    const res = await app.request("/address-enrichment/address/0x123");
     const body = (await res.json()) as { ens: string };
 
     expect(res.status).toBe(200);
     expect(body.ens).toBe("vitalik.eth");
+    const arg = fetchSpy.mock.calls[0]?.[0];
+    const calledUrl = arg instanceof Request ? arg.url : String(arg);
+    expect(calledUrl).toBe("http://enrichment-api/address/0x123");
   });
 
   it("should forward query strings to upstream", async () => {
-    vi.spyOn(global, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ ok: true }), { status: 200 }),
-    );
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      );
 
     const res = await app.request(
-      "/address-enrichment/0x123?include=ens&chain=1",
+      "/address-enrichment/address/0x123?include=ens&chain=1",
     );
 
     expect(res.status).toBe(200);
+    const arg = fetchSpy.mock.calls[0]?.[0];
+    const calledUrl = arg instanceof Request ? arg.url : String(arg);
+    expect(calledUrl).toBe(
+      "http://enrichment-api/address/0x123?include=ens&chain=1",
+    );
   });
 
   it("should propagate upstream error status", async () => {

--- a/apps/gateful/src/resolvers/address-enrichment/route.ts
+++ b/apps/gateful/src/resolvers/address-enrichment/route.ts
@@ -10,8 +10,8 @@ export function addressEnrichment(app: OpenAPIHono, upstreamUrl?: string) {
       );
     }
 
-    const path = c.req.path.replace(/^\/address-enrichment/, "/");
-    const url = new URL(path || "/", upstreamUrl);
+    const path = c.req.path.replace(/^\/address-enrichment/, "") || "/";
+    const url = new URL(path, upstreamUrl);
     url.search = new URL(c.req.url).search;
 
     return proxy(url.toString(), { ...c.req });

--- a/apps/gateful/src/upstream-docs.test.ts
+++ b/apps/gateful/src/upstream-docs.test.ts
@@ -52,6 +52,7 @@ describe("storeOpenApiSpec", () => {
     const getOpenApiSpec = storeOpenApiSpec(
       ownSpec,
       new Map([["uni", "http://uni-api"]]),
+      undefined,
       outputPath,
     );
 
@@ -101,6 +102,7 @@ describe("storeOpenApiSpec", () => {
     const getOpenApiSpec = storeOpenApiSpec(
       ownSpec,
       new Map([["uni", "http://uni-api"]]),
+      undefined,
       outputPath,
     );
 
@@ -110,5 +112,157 @@ describe("storeOpenApiSpec", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(first.paths).not.toHaveProperty("/{dao}/delegates");
     expect(second.paths).toHaveProperty("/{dao}/delegates");
+  });
+
+  it("merges address enrichment docs under the address-enrichment prefix", async () => {
+    const ownSpec: OpenAPIObject = {
+      openapi: "3.1.0",
+      info: { title: "Gateway", version: "1.0.0" },
+      paths: {
+        "/health": {
+          get: {
+            responses: {
+              "200": { description: "OK" },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          GatewayStatus: {
+            type: "object",
+            properties: {
+              status: { type: "string" },
+            },
+          },
+        },
+      },
+    };
+    const daoSpec: OpenAPIObject = {
+      openapi: "3.1.0",
+      info: { title: "DAO API", version: "1.0.0" },
+      paths: {
+        "/proposals": {
+          get: {
+            responses: {
+              "200": { description: "OK" },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Proposal: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+            },
+          },
+        },
+      },
+    };
+    const addressEnrichmentSpec: OpenAPIObject = {
+      openapi: "3.0.0",
+      info: { title: "Address Enrichment API", version: "0.1.0" },
+      paths: {
+        "/address/{address}": {
+          get: {
+            responses: {
+              "200": { description: "OK" },
+            },
+          },
+        },
+        "/addresses": {
+          get: {
+            responses: {
+              "200": { description: "OK" },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          AddressEnrichment: {
+            type: "object",
+            properties: {
+              address: { type: "string" },
+            },
+          },
+        },
+      },
+    };
+
+    const fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockImplementation((input: string | URL | Request) => {
+        const url = input.toString();
+        const body = url.endsWith("/docs/json")
+          ? addressEnrichmentSpec
+          : daoSpec;
+
+        return Promise.resolve(
+          new Response(JSON.stringify(body), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      });
+
+    const outputPath = join(tempDir, "openapi", "gateful.json");
+    const getOpenApiSpec = storeOpenApiSpec(
+      ownSpec,
+      new Map([["uni", "http://uni-api"]]),
+      "http://address-api",
+      outputPath,
+    );
+
+    const spec = await getOpenApiSpec();
+
+    expect(fetchMock).toHaveBeenCalledWith("http://uni-api/docs");
+    expect(fetchMock).toHaveBeenCalledWith("http://address-api/docs/json");
+    expect(spec.paths).toHaveProperty("/{dao}/proposals");
+    expect(spec.paths).toHaveProperty("/address-enrichment/address/{address}");
+    expect(spec.paths).toHaveProperty("/address-enrichment/addresses");
+    expect(spec.paths).toHaveProperty("/health");
+    expect(spec.components?.schemas).toMatchObject({
+      GatewayStatus: expect.any(Object),
+      Proposal: expect.any(Object),
+      AddressEnrichment: expect.any(Object),
+    });
+  });
+
+  it("keeps the gateway spec when address enrichment docs cannot be fetched", async () => {
+    const ownSpec: OpenAPIObject = {
+      openapi: "3.1.0",
+      info: { title: "Gateway", version: "1.0.0" },
+      paths: {
+        "/health": {
+          get: {
+            responses: {
+              "200": { description: "OK" },
+            },
+          },
+        },
+      },
+    };
+
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response("Unavailable", { status: 503 }),
+    );
+
+    const outputPath = join(tempDir, "openapi", "gateful.json");
+    const getOpenApiSpec = storeOpenApiSpec(
+      ownSpec,
+      new Map(),
+      "http://address-api",
+      outputPath,
+    );
+
+    const spec = await getOpenApiSpec();
+
+    expect(spec.paths).toHaveProperty("/health");
+    expect(spec.paths).not.toHaveProperty(
+      "/address-enrichment/address/{address}",
+    );
   });
 });

--- a/apps/gateful/src/upstream-docs.ts
+++ b/apps/gateful/src/upstream-docs.ts
@@ -16,9 +16,14 @@ type Schemas = NonNullable<ComponentsObject["schemas"]>;
 async function fetchDoc(
   name: string,
   baseUrl: string,
+  docsPath = "/docs",
 ): Promise<OpenAPIObject | null> {
   try {
-    const res = await fetch(`${baseUrl}/docs`);
+    const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
+    const normalizedDocsPath = docsPath.startsWith("/")
+      ? docsPath
+      : `/${docsPath}`;
+    const res = await fetch(`${normalizedBaseUrl}${normalizedDocsPath}`);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return (await res.json()) as OpenAPIObject;
   } catch (err) {
@@ -35,6 +40,22 @@ function mergeSchemas(docs: OpenAPIObject[]): Schemas {
     }
   }
   return schemas;
+}
+
+function mergeAddressEnrichmentPaths(doc: OpenAPIObject): PathsObject {
+  const paths: PathsObject = {};
+
+  if (!doc.paths) return paths;
+
+  for (const [path, pathItem] of Object.entries(doc.paths)) {
+    const prefixedPath =
+      path === "/"
+        ? "/address-enrichment"
+        : `/address-enrichment${path.startsWith("/") ? path : `/${path}`}`;
+    paths[prefixedPath] = { ...pathItem };
+  }
+
+  return paths;
 }
 
 function mergePaths(docs: OpenAPIObject[], daoNames: string[]): PathsObject {
@@ -82,11 +103,15 @@ function mergePaths(docs: OpenAPIObject[], daoNames: string[]): PathsObject {
 export async function mergeUpstreamDocs(
   ownSpec: OpenAPIObject,
   daoApis: Map<string, string>,
+  addressEnrichmentUrl?: string,
 ): Promise<OpenAPIObject> {
   const entries = Array.from(daoApis.entries());
-  const results = await Promise.all(
-    entries.map(([name, url]) => fetchDoc(name, url)),
-  );
+  const [results, addressEnrichmentDoc] = await Promise.all([
+    Promise.all(entries.map(([name, url]) => fetchDoc(name, url))),
+    addressEnrichmentUrl
+      ? fetchDoc("address-enrichment", addressEnrichmentUrl, "/docs/json")
+      : Promise.resolve(null),
+  ]);
 
   // Keep only successful fetches, with matching names
   const docs: OpenAPIObject[] = [];
@@ -99,14 +124,24 @@ export async function mergeUpstreamDocs(
     }
   }
 
+  const schemaDocs = addressEnrichmentDoc
+    ? [...docs, addressEnrichmentDoc]
+    : docs;
+
   return {
     ...ownSpec,
-    paths: { ...ownSpec.paths, ...mergePaths(docs, daoNames) },
+    paths: {
+      ...ownSpec.paths,
+      ...mergePaths(docs, daoNames),
+      ...(addressEnrichmentDoc
+        ? mergeAddressEnrichmentPaths(addressEnrichmentDoc)
+        : {}),
+    },
     components: {
       ...ownSpec.components,
       schemas: {
         ...ownSpec.components?.schemas,
-        ...mergeSchemas(docs),
+        ...mergeSchemas(schemaDocs),
       },
     },
   };
@@ -118,10 +153,15 @@ export async function mergeUpstreamDocs(
 export function storeOpenApiSpec(
   ownSpec: OpenAPIObject,
   daoApis: Map<string, string>,
+  addressEnrichmentUrl?: string,
   outputPath = join(process.cwd(), "openapi", "gateful.json"),
 ): () => Promise<OpenAPIObject> {
   return async () => {
-    const spec = await mergeUpstreamDocs(ownSpec, daoApis);
+    const spec = await mergeUpstreamDocs(
+      ownSpec,
+      daoApis,
+      addressEnrichmentUrl,
+    );
 
     try {
       await mkdir(dirname(outputPath), { recursive: true });

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -156,8 +156,8 @@ railway_run() {
   local service=$1
   shift
   if [ "$USE_RAILWAY" = true ]; then
-    log "railway_run: pnpm railway run -e dev -s $service $*"
-    pnpm railway run -e dev -s "$service" "$@"
+    log "railway_run: railway run -e dev -s $service $*"
+    railway run -e dev -s "$service" "$@"
   else
     log "railway_run (no --rw): $*"
     "$@"
@@ -168,9 +168,9 @@ railway_run() {
 railway_run_api() {
   local service=$1
   shift
-  if pnpm railway run -e dev -s "$service" true >/dev/null 2>&1; then
-    log "railway_run_api: pnpm railway run -e dev -s $service $*"
-    pnpm railway run -e dev -s "$service" "$@"
+  if railway run -e dev -s "$service" true >/dev/null 2>&1; then
+    log "railway_run_api: railway run -e dev -s $service $*"
+    railway run -e dev -s "$service" "$@"
   else
     log "railway_run_api: Railway service '$service' not found, falling back to: $*"
     "$@"
@@ -179,7 +179,7 @@ railway_run_api() {
 
 railway_service_available() {
   local service=$1
-  pnpm railway run -e dev -s "$service" true >/dev/null 2>&1
+  railway run -e dev -s "$service" true >/dev/null 2>&1
 }
 
 # Kill anything already running on our ports
@@ -224,7 +224,7 @@ fi
 ADDRESS_ENRICHMENT_AVAILABLE=false
 if railway_service_available "address-enrichment"; then
   log "Starting optional Address Enrichment..."
-  run_with_prefix "$C_ADDRESS_ENRICHMENT" "💰 enrichment" "" "" pnpm railway run -e dev -s address-enrichment pnpm address dev &
+  run_with_prefix "$C_ADDRESS_ENRICHMENT" "💰 enrichment" "" "" railway run -e dev -s address-enrichment pnpm address dev &
   if wait_for_optional_port "$PORT_ADDRESS_ENRICHMENT" "Address Enrichment"; then
     ADDRESS_ENRICHMENT_AVAILABLE=true
     export ADDRESS_ENRICHMENT_API_URL="http://localhost:${PORT_ADDRESS_ENRICHMENT}"


### PR DESCRIPTION
## Summary
- merge the address-enrichment OpenAPI spec into Gateful's `/docs/json` output under the `/address-enrichment` prefix
- include address-enrichment schemas in the merged gateway spec and keep the existing spec intact when that upstream doc is unavailable
- add regression tests covering both the successful merge path and the upstream-failure fallback
- update `scripts/dev.sh` to call the `railway` CLI directly instead of `pnpm railway`