### PR TITLE
Feat/kubb msw pluggin

### DIFF
--- a/packages/anticapture-client/README.md
+++ b/packages/anticapture-client/README.md
@@ -87,6 +87,61 @@ const response = await accountBalances(
 );
 ```
 
+### Testing with MSW
+
+Mock Service Worker handlers seeded with faker data are available from the
+`@anticapture/client/msw` subpath. Use them to mock the Gateful API in tests
+without hitting the network.
+
+```sh
+npm install --save-dev msw
+```
+
+The simplest path is `createTestServer`, which wraps `setupServer` from
+`msw/node` with all generated handlers pre-registered:
+
+```ts
+import { createTestServer } from "@anticapture/client/msw";
+
+const server = createTestServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+test("intercepts a generated route", async () => {
+  const res = await fetch("http://localhost/health");
+  const body = await res.json();
+  expect(body).toBeTruthy();
+});
+```
+
+Handlers match any host (the generator emits `*/path` patterns), so calls to
+`http://localhost`, `https://api.anticapture.xyz`, or any other base URL are
+intercepted without extra configuration.
+
+To append a custom handler, import `http` and `HttpResponse` **from this
+subpath** (not from `msw` directly) and pass them to `createTestServer`:
+
+```ts
+import { createTestServer, http, HttpResponse } from "@anticapture/client/msw";
+
+const custom = http.get("*/custom", () => HttpResponse.json({ ok: true }));
+const server = createTestServer(custom);
+```
+
+> **Why import `http`/`HttpResponse` from this subpath?** MSW v2.8+ ships dual
+> `.d.ts` files that TypeScript treats as nominally distinct via a private
+> `__kind` brand on `RequestHandler` (see
+> [mswjs/msw#498](https://github.com/mswjs/msw/discussions/498)). Routing
+> consumer-built handlers through this re-export funnels them into the same
+> module identity our types resolve to, which avoids `as any` casts at the
+> `setupServer` boundary.
+
+Required `tsconfig` setting: `"moduleResolution": "bundler"` or `"nodenext"`
+so the `@anticapture/client/msw` subpath in `package.json#exports` resolves.
+Classic `"node"` resolution does not honor `exports` maps.
+
 ## Development
 
 The SDK is generated from `apps/gateful/openapi/gateful.json` with Kubb.

--- a/packages/anticapture-client/kubb.config.ts
+++ b/packages/anticapture-client/kubb.config.ts
@@ -85,9 +85,6 @@ export default defineConfig(({ watch }) => ({
       },
       parser: "faker",
       handlers: true,
-      // Wildcard baseURL so handlers match any host (e.g. http://localhost,
-      // production URL). Without this, MSW v2 treats the bare path as
-      // origin-less and consumer Node tests miss the handler.
       baseURL: "*",
       transformers: {
         name: renameDaoOperation,

--- a/packages/anticapture-client/kubb.config.ts
+++ b/packages/anticapture-client/kubb.config.ts
@@ -85,6 +85,10 @@ export default defineConfig(({ watch }) => ({
       },
       parser: "faker",
       handlers: true,
+      // Wildcard baseURL so handlers match any host (e.g. http://localhost,
+      // production URL). Without this, MSW v2 treats the bare path as
+      // origin-less and consumer Node tests miss the handler.
+      baseURL: "*",
       transformers: {
         name: renameDaoOperation,
       },

--- a/packages/anticapture-client/kubb.config.ts
+++ b/packages/anticapture-client/kubb.config.ts
@@ -2,6 +2,8 @@ import { fileURLToPath } from "node:url";
 
 import { defineConfig } from "@kubb/core";
 import { pluginClient } from "@kubb/plugin-client";
+import { pluginFaker } from "@kubb/plugin-faker";
+import { pluginMsw } from "@kubb/plugin-msw";
 import { pluginOas } from "@kubb/plugin-oas";
 import { pluginReactQuery } from "@kubb/plugin-react-query";
 import { pluginTs } from "@kubb/plugin-ts";
@@ -9,6 +11,14 @@ import { pluginTs } from "@kubb/plugin-ts";
 const gatefulOpenApiSpecPath = fileURLToPath(
   new URL("../../apps/gateful/openapi/gateful.json", import.meta.url),
 );
+
+// The `GET /{dao}/dao` route has `operationId: "dao"` and a path parameter
+// also named `dao`. Without this rename, Kubb emits `function dao(dao: ...)`,
+// which is a duplicate-identifier error in TS.
+const renameDaoOperation = (
+  name: string,
+  type?: "function" | "type" | "file" | "const",
+) => (name === "dao" && type === "function" ? "getDao" : name);
 
 export default defineConfig(({ watch }) => ({
   input: {
@@ -33,8 +43,7 @@ export default defineConfig(({ watch }) => ({
         path: "sdk.ts",
       },
       transformers: {
-        name: (name, type) =>
-          name === "dao" && type === "function" ? "getDao" : name,
+        name: renameDaoOperation,
       },
     }),
     pluginReactQuery({
@@ -46,8 +55,7 @@ export default defineConfig(({ watch }) => ({
       },
       mutation: false,
       transformers: {
-        name: (name, type) =>
-          name === "dao" && type === "function" ? "getDao" : name, // rename "dao" operation ID to getDao
+        name: renameDaoOperation,
       },
       suspense: {},
       override: [
@@ -62,6 +70,24 @@ export default defineConfig(({ watch }) => ({
           },
         },
       ],
+    }),
+    pluginFaker({
+      output: {
+        path: "mocks/faker.ts",
+      },
+      transformers: {
+        name: renameDaoOperation,
+      },
+    }),
+    pluginMsw({
+      output: {
+        path: "mocks.ts",
+      },
+      parser: "faker",
+      handlers: true,
+      transformers: {
+        name: renameDaoOperation,
+      },
     }),
   ],
 }));

--- a/packages/anticapture-client/package.json
+++ b/packages/anticapture-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anticapture/client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository": {
     "url": "git+https://github.com/blockful/anticapture.git"
   },

--- a/packages/anticapture-client/package.json
+++ b/packages/anticapture-client/package.json
@@ -28,6 +28,11 @@
       "types": "./dist/hooks.d.ts",
       "import": "./dist/hooks.js",
       "default": "./dist/hooks.js"
+    },
+    "./msw": {
+      "types": "./dist/msw.d.ts",
+      "import": "./dist/msw.js",
+      "default": "./dist/msw.js"
     }
   },
   "files": [
@@ -40,6 +45,8 @@
     "@kubb/cli": "^4.37.2",
     "@kubb/core": "^4.37.2",
     "@kubb/plugin-client": "^4.37.2",
+    "@kubb/plugin-faker": "^4.37.2",
+    "@kubb/plugin-msw": "^4.37.2",
     "@kubb/plugin-oas": "^4.37.2",
     "@kubb/plugin-react-query": "^4.37.2",
     "@kubb/plugin-ts": "^4.37.2",
@@ -50,11 +57,19 @@
     "typescript": "^5.8.3"
   },
   "peerDependencies": {
+    "@faker-js/faker": "^9.0.0",
     "@tanstack/react-query": "^5.0.0",
+    "msw": "^2.0.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@faker-js/faker": {
+      "optional": true
+    },
     "@tanstack/react-query": {
+      "optional": true
+    },
+    "msw": {
       "optional": true
     },
     "react": {

--- a/packages/anticapture-client/package.json
+++ b/packages/anticapture-client/package.json
@@ -41,6 +41,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@faker-js/faker": "^9.0.0"
+  },
   "devDependencies": {
     "@kubb/cli": "^4.37.2",
     "@kubb/core": "^4.37.2",
@@ -57,15 +60,11 @@
     "typescript": "^5.8.3"
   },
   "peerDependencies": {
-    "@faker-js/faker": "^9.0.0",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.0.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
-    "@faker-js/faker": {
-      "optional": true
-    },
     "@tanstack/react-query": {
       "optional": true
     },

--- a/packages/anticapture-client/src/msw.ts
+++ b/packages/anticapture-client/src/msw.ts
@@ -1,0 +1,1 @@
+export * from "../generated/mocks.js";

--- a/packages/anticapture-client/src/msw.ts
+++ b/packages/anticapture-client/src/msw.ts
@@ -1,1 +1,17 @@
+import { setupServer, type SetupServerApi } from "msw/node";
+import { http, HttpResponse, type HttpHandler } from "msw";
+import { handlers } from "../generated/mocks.js";
+
 export * from "../generated/mocks.js";
+
+// Re-export msw runtime + types so consumers building extra handlers go
+// through the same module identity our .d.ts resolves to. MSW v2.8+ ships
+// dual `.d.ts` files and TS treats them as nominally distinct via the
+// `private __kind` brand on RequestHandler — funneling through this
+// subpath defeats that.
+export { http, HttpResponse };
+export type { HttpHandler };
+
+export const createTestServer = (
+  ...extraHandlers: HttpHandler[]
+): SetupServerApi => setupServer(...handlers, ...extraHandlers);

--- a/packages/anticapture-client/tsup.config.ts
+++ b/packages/anticapture-client/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: {
     index: "src/index.ts",
     hooks: "src/hooks.ts",
+    msw: "src/msw.ts",
   },
   format: ["esm"],
   target: "es2020",
@@ -11,5 +12,5 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   splitting: false,
-  external: ["@tanstack/react-query", "react"],
+  external: ["@tanstack/react-query", "react", "msw", "@faker-js/faker"],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,7 +237,7 @@ importers:
         version: 0.108.31(graphql@16.13.1)(ioredis@5.10.1)
       "@graphql-mesh/graphql":
         specifier: ^0.104.3
-        version: 0.104.24(@types/node@25.4.0)(bufferutil@4.0.9)(crossws@0.3.5)(graphql@16.13.1)(ioredis@5.10.1)(utf-8-validate@5.0.10)
+        version: 0.104.24(@types/node@20.19.37)(bufferutil@4.0.9)(crossws@0.3.5)(graphql@16.13.1)(ioredis@5.10.1)(utf-8-validate@5.0.10)
       "@graphql-mesh/http":
         specifier: ^0.106.3
         version: 0.106.29(graphql@16.13.1)(ioredis@5.10.1)
@@ -271,16 +271,16 @@ importers:
     devDependencies:
       "@graphql-mesh/cli":
         specifier: ^0.100.4
-        version: 0.100.36(@types/node@25.4.0)(bufferutil@4.0.9)(crossws@0.3.5)(graphql@16.13.1)(ioredis@5.10.1)(pino@9.14.0)(utf-8-validate@5.0.10)
+        version: 0.100.36(@types/node@20.19.37)(bufferutil@4.0.9)(crossws@0.3.5)(graphql@16.13.1)(ioredis@5.10.1)(pino@9.14.0)(utf-8-validate@5.0.10)
       "@types/jest":
         specifier: ^29.5.14
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.4.0)(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3))
+        version: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.1
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.4.0)(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3)
       tsx:
         specifier: ^4.19.4
         version: 4.21.0
@@ -298,7 +298,7 @@ importers:
         version: link:../../packages/graphql-client
       "@apollo/client":
         specifier: ^3.13.8
-        version: 3.14.0(@types/react@19.2.8)(graphql-ws@6.0.7(crossws@0.3.5)(graphql@16.13.1)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(graphql@16.13.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 3.14.0(@types/react@19.2.8)(graphql-ws@6.0.7(crossws@0.3.5)(graphql@16.13.1)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(graphql@16.13.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       "@codemirror/language":
         specifier: ^6.12.3
         version: 6.12.3
@@ -355,7 +355,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       "@rainbow-me/rainbowkit":
         specifier: ^2.2.0
-        version: 2.2.10(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
+        version: 2.2.10(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
       "@snapshot-labs/snapshot.js":
         specifier: ^0.12.62
         version: 0.12.65(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -394,10 +394,10 @@ importers:
         version: 7.7.17(react@19.2.3)
       next:
         specifier: 16.1.3
-        version: 16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nuqs:
         specifier: ^2.8.4
-        version: 2.8.8(next@16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.8.8(next@16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -445,7 +445,7 @@ importers:
         version: 2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       wagmi:
         specifier: ^2.12.25
-        version: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -470,7 +470,7 @@ importers:
         version: 10.2.8(@vitest/runner@4.1.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.17(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.37)(jiti@2.6.1)(jsdom@24.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       "@storybook/nextjs":
         specifier: ^10.2.0
-        version: 10.2.8(next@16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.17(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.4)
+        version: 10.2.8(next@16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.17(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.4)
       "@storybook/react":
         specifier: ^10.2.0
         version: 10.2.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.17(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(typescript@5.9.3)
@@ -533,7 +533,7 @@ importers:
         version: 4.2.1
       ts-jest:
         specifier: ^29.2.6
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3)
       tw-animate-css:
         specifier: ^1.3.0
         version: 1.4.0
@@ -765,6 +765,13 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.37)(jiti@2.6.1)(jsdom@24.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/anticapture-client:
+    dependencies:
+      "@faker-js/faker":
+        specifier: ^9.0.0
+        version: 9.9.0
+      msw:
+        specifier: ^2.0.0
+        version: 2.12.10(@types/node@20.19.37)(typescript@5.9.3)
     devDependencies:
       "@kubb/cli":
         specifier: ^4.37.2
@@ -775,6 +782,12 @@ importers:
       "@kubb/plugin-client":
         specifier: ^4.37.2
         version: 4.37.2(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(axios@1.13.6)(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      "@kubb/plugin-faker":
+        specifier: ^4.37.2
+        version: 4.37.5(@kubb/fabric-core@0.14.0)(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      "@kubb/plugin-msw":
+        specifier: ^4.37.2
+        version: 4.37.5(@kubb/fabric-core@0.14.0)(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       "@kubb/plugin-oas":
         specifier: ^4.37.2
         version: 4.37.2(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -844,7 +857,7 @@ importers:
         version: 4.9.6
       forge-std:
         specifier: github:foundry-rs/forge-std
-        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/620536fa5277db4e3fd46772d5cbc1ea0696fb43
+        version: https://codeload.github.com/foundry-rs/forge-std/tar.gz/8b531a016f15f761a632f5149a828228573420fc
 
   packages/observability:
     dependencies:
@@ -3899,6 +3912,13 @@ packages:
         integrity: sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==,
       }
 
+  "@faker-js/faker@9.9.0":
+    resolution:
+      {
+        integrity: sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==,
+      }
+    engines: { node: ">=18.0.0", npm: ">=9.0.0" }
+
   "@fastify/busboy@3.1.1":
     resolution:
       {
@@ -5657,6 +5677,13 @@ packages:
       }
     engines: { node: ">=20" }
 
+  "@kubb/ast@4.37.5":
+    resolution:
+      {
+        integrity: sha512-qJmf4ZnQQIxOF3TdfIfSPtAxcoOx4ubZwbNicc9qpkYIjvn6wWY3iTUCKrT4v2GyzZ4FiQaSGiqDzb9Dz0gOlw==,
+      }
+    engines: { node: ">=20" }
+
   "@kubb/cli@4.37.2":
     resolution:
       {
@@ -5669,6 +5696,16 @@ packages:
     resolution:
       {
         integrity: sha512-BGXa+ECZLeJv5z7L0sh9Ktx/IdHjv+roq3+bQ3dQItsa/KIzKLuMpaYWW8PJGjMPiCqqMl+ldFBVTPU/hdwXeA==,
+      }
+    engines: { node: ">=20" }
+    peerDependencies:
+      "@kubb/fabric-core": 0.14.0
+      "@kubb/react-fabric": 0.14.0
+
+  "@kubb/core@4.37.5":
+    resolution:
+      {
+        integrity: sha512-aT3uZFR9xcntq9didIDB+nSK7w5mc7WYNmb2mjMbnZe4/2x4aDEB6CeHRoYTqN5xNpz7mZAVoiMYEwlrykRaCA==,
       }
     engines: { node: ">=20" }
     peerDependencies:
@@ -5691,6 +5728,16 @@ packages:
     peerDependencies:
       "@kubb/fabric-core": 0.14.0
 
+  "@kubb/oas@4.37.5":
+    resolution:
+      {
+        integrity: sha512-kOjQOERs6B/BjgewBM9cTuBGAuQIB0mdYOVasv3J+wLEkvLM13HWiqu7lX/3d+P0M3zD8XbdrXFjn2JaYcG1Ig==,
+      }
+    engines: { node: ">=20" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      "@kubb/fabric-core": 0.14.0
+
   "@kubb/plugin-client@4.37.2":
     resolution:
       {
@@ -5705,12 +5752,38 @@ packages:
       axios:
         optional: true
 
+  "@kubb/plugin-faker@4.37.5":
+    resolution:
+      {
+        integrity: sha512-TpuxenlOAmOZ82VtIeC7rxYYfVP2C+cenKUXbLMmSfqjqfTIWYnbYpmsHOZ4jbqOnE27+3OdXGavAB31vF1PWA==,
+      }
+    engines: { node: ">=20" }
+
+  "@kubb/plugin-msw@4.37.5":
+    resolution:
+      {
+        integrity: sha512-/iEhD19BSkR+HHOvfU7y9QHMLvABs25wZRXFTIN2g7DbN7ryVkyya0sdcHHM9UcrRU7XZ/J1OUAEBzVF5hKBJA==,
+      }
+    engines: { node: ">=20" }
+
   "@kubb/plugin-oas@4.37.2":
     resolution:
       {
         integrity: sha512-MYDZiFap0w9C63m70WJDyL0XGR+efyfwsTgpq6EvZpBk4yCbg6oIXiNPIivKJCqO9RXgBdnyBeGgZMSqBCvdvg==,
       }
     engines: { node: ">=20" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      "@kubb/fabric-core": 0.14.0
+      "@kubb/react-fabric": 0.14.0
+
+  "@kubb/plugin-oas@4.37.5":
+    resolution:
+      {
+        integrity: sha512-1Pcpme1IcNC/0yGSAUGIKPNGM6U0j547cvnIZDFFAkODVh5gT4vbjeEz1sXh+QZpT23T0MY36hiDaZPFx9kneg==,
+      }
+    engines: { node: ">=20" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       "@kubb/fabric-core": 0.14.0
       "@kubb/react-fabric": 0.14.0
@@ -5729,6 +5802,15 @@ packages:
     resolution:
       {
         integrity: sha512-Y8sPbutK1HyR3Tqo/fP0vnRLMmVcAPAnvi6TYVgyPaEbxXwqL6WUCAKmjlCzP1Y7Wanp0rcHsXW+YWIUQ68Y6w==,
+      }
+    engines: { node: ">=20" }
+    peerDependencies:
+      "@kubb/react-fabric": 0.14.0
+
+  "@kubb/plugin-ts@4.37.5":
+    resolution:
+      {
+        integrity: sha512-bYsHbUhR15Tr+apkI3RvVnNO6pTEx5iMx6COsqdcHXmIv7VKVQkzDKAjrzOIiFwq4ykRw1jYUf2esnX4n3De2A==,
       }
     engines: { node: ">=20" }
     peerDependencies:
@@ -14114,10 +14196,10 @@ packages:
       }
     engines: { node: ">=14" }
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/620536fa5277db4e3fd46772d5cbc1ea0696fb43:
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/8b531a016f15f761a632f5149a828228573420fc:
     resolution:
       {
-        tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/620536fa5277db4e3fd46772d5cbc1ea0696fb43,
+        tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/8b531a016f15f761a632f5149a828228573420fc,
       }
     version: 1.16.1
 
@@ -21785,6 +21867,7 @@ packages:
       {
         integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==,
       }
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
@@ -21792,6 +21875,7 @@ packages:
       {
         integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==,
       }
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
@@ -21799,6 +21883,7 @@ packages:
       {
         integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==,
       }
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uvu@0.5.6:
@@ -22747,7 +22832,7 @@ snapshots:
       "@types/json-schema": 7.0.15
       js-yaml: 4.1.1
 
-  "@apollo/client@3.14.0(@types/react@19.2.8)(graphql-ws@6.0.7(crossws@0.3.5)(graphql@16.13.1)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(graphql@16.13.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
+  "@apollo/client@3.14.0(@types/react@19.2.8)(graphql-ws@6.0.7(crossws@0.3.5)(graphql@16.13.1)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(graphql@16.13.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)":
     dependencies:
       "@graphql-typed-document-node/core": 3.2.0(graphql@16.13.1)
       "@wry/caches": 1.0.1
@@ -22764,7 +22849,7 @@ snapshots:
       tslib: 2.8.1
       zen-observable-ts: 1.2.5
     optionalDependencies:
-      graphql-ws: 6.0.7(crossws@0.3.5)(graphql@16.13.1)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      graphql-ws: 6.0.7(crossws@0.3.5)(graphql@16.13.1)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
@@ -23119,6 +23204,12 @@ snapshots:
     dependencies:
       "@babel/core": 7.28.5
 
+  "@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.28.6
+    optional: true
+
   "@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)":
     dependencies:
       "@babel/core": 7.29.0
@@ -23134,10 +23225,22 @@ snapshots:
       "@babel/core": 7.29.0
       "@babel/helper-plugin-utils": 7.27.1
 
+  "@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.28.6
+    optional: true
+
   "@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)":
     dependencies:
       "@babel/core": 7.29.0
       "@babel/helper-plugin-utils": 7.28.6
+
+  "@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.28.6
+    optional: true
 
   "@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)":
     dependencies:
@@ -23179,10 +23282,22 @@ snapshots:
       "@babel/core": 7.29.0
       "@babel/helper-plugin-utils": 7.28.6
 
+  "@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.28.6
+    optional: true
+
   "@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)":
     dependencies:
       "@babel/core": 7.29.0
       "@babel/helper-plugin-utils": 7.28.6
+
+  "@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.28.6
+    optional: true
 
   "@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)":
     dependencies:
@@ -23199,40 +23314,88 @@ snapshots:
       "@babel/core": 7.29.0
       "@babel/helper-plugin-utils": 7.27.1
 
+  "@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.28.6
+    optional: true
+
   "@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0)":
     dependencies:
       "@babel/core": 7.29.0
       "@babel/helper-plugin-utils": 7.28.6
+
+  "@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.28.6
+    optional: true
 
   "@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)":
     dependencies:
       "@babel/core": 7.29.0
       "@babel/helper-plugin-utils": 7.28.6
 
+  "@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.28.6
+    optional: true
+
   "@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)":
     dependencies:
       "@babel/core": 7.29.0
       "@babel/helper-plugin-utils": 7.28.6
+
+  "@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.28.6
+    optional: true
 
   "@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)":
     dependencies:
       "@babel/core": 7.29.0
       "@babel/helper-plugin-utils": 7.28.6
 
+  "@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.28.6
+    optional: true
+
   "@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)":
     dependencies:
       "@babel/core": 7.29.0
       "@babel/helper-plugin-utils": 7.28.6
+
+  "@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.28.6
+    optional: true
 
   "@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)":
     dependencies:
       "@babel/core": 7.29.0
       "@babel/helper-plugin-utils": 7.28.6
 
+  "@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.28.6
+    optional: true
+
   "@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)":
     dependencies:
       "@babel/core": 7.29.0
       "@babel/helper-plugin-utils": 7.28.6
+
+  "@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.28.6
+    optional: true
 
   "@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)":
     dependencies:
@@ -23812,9 +23975,9 @@ snapshots:
       "@babel/helper-string-parser": 7.27.1
       "@babel/helper-validator-identifier": 7.28.5
 
-  "@base-org/account@2.4.0(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)":
+  "@base-org/account@2.4.0(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)":
     dependencies:
-      "@coinbase/cdp-sdk": 1.38.6(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@coinbase/cdp-sdk": 1.38.6(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@noble/hashes": 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
@@ -24162,11 +24325,11 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       react-is: 17.0.2
 
-  "@coinbase/cdp-sdk@1.38.6(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
+  "@coinbase/cdp-sdk@1.38.6(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
     dependencies:
-      "@solana-program/system": 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      "@solana-program/token": 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      "@solana/kit": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@solana-program/system": 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      "@solana-program/token": 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      "@solana/kit": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@solana/web3.js": 1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
       abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
       axios: 1.13.6
@@ -25094,6 +25257,8 @@ snapshots:
 
   "@exodus/schemasafe@1.3.0": {}
 
+  "@faker-js/faker@9.9.0": {}
+
   "@fastify/busboy@3.1.1": {}
 
   "@fastify/busboy@3.2.0": {}
@@ -25505,7 +25670,7 @@ snapshots:
       - "@nats-io/nats-core"
       - ioredis
 
-  "@graphql-mesh/cli@0.100.36(@types/node@25.4.0)(bufferutil@4.0.9)(crossws@0.3.5)(graphql@16.13.1)(ioredis@5.10.1)(pino@9.14.0)(utf-8-validate@5.0.10)":
+  "@graphql-mesh/cli@0.100.36(@types/node@20.19.37)(bufferutil@4.0.9)(crossws@0.3.5)(graphql@16.13.1)(ioredis@5.10.1)(pino@9.14.0)(utf-8-validate@5.0.10)":
     dependencies:
       "@graphql-codegen/core": 5.0.1(graphql@16.13.1)
       "@graphql-codegen/typed-document-node": 6.1.7(graphql@16.13.1)
@@ -25517,7 +25682,7 @@ snapshots:
       "@graphql-mesh/cross-helpers": 0.4.12(graphql@16.13.1)
       "@graphql-mesh/http": 0.106.29(graphql@16.13.1)(ioredis@5.10.1)
       "@graphql-mesh/include": 0.3.26(graphql@16.13.1)(ioredis@5.10.1)
-      "@graphql-mesh/incontext-sdk-codegen": 0.0.2(@types/node@25.4.0)(graphql@16.13.1)(ioredis@5.10.1)(pino@9.14.0)
+      "@graphql-mesh/incontext-sdk-codegen": 0.0.2(@types/node@20.19.37)(graphql@16.13.1)(ioredis@5.10.1)(pino@9.14.0)
       "@graphql-mesh/runtime": 0.106.27(graphql@16.13.1)(ioredis@5.10.1)
       "@graphql-mesh/store": 0.104.27(graphql@16.13.1)(ioredis@5.10.1)
       "@graphql-mesh/types": 0.104.23(graphql@16.13.1)(ioredis@5.10.1)
@@ -25609,7 +25774,7 @@ snapshots:
       - ioredis
       - supports-color
 
-  "@graphql-mesh/fusion-runtime@1.8.1(@types/node@25.4.0)(graphql@16.13.1)(ioredis@5.10.1)(pino@9.14.0)":
+  "@graphql-mesh/fusion-runtime@1.8.1(@types/node@20.19.37)(graphql@16.13.1)(ioredis@5.10.1)(pino@9.14.0)":
     dependencies:
       "@envelop/core": 5.5.1
       "@envelop/instrumentation": 1.0.0
@@ -25621,7 +25786,7 @@ snapshots:
       "@graphql-tools/batch-execute": 10.0.7(graphql@16.13.1)
       "@graphql-tools/delegate": 12.0.12(graphql@16.13.1)
       "@graphql-tools/executor": 1.5.1(graphql@16.13.1)
-      "@graphql-tools/federation": 4.3.1(@types/node@25.4.0)(graphql@16.13.1)
+      "@graphql-tools/federation": 4.3.1(@types/node@20.19.37)(graphql@16.13.1)
       "@graphql-tools/merge": 9.1.7(graphql@16.13.1)
       "@graphql-tools/stitch": 10.1.16(graphql@16.13.1)
       "@graphql-tools/stitching-directives": 4.0.18(graphql@16.13.1)
@@ -25640,7 +25805,7 @@ snapshots:
       - pino
       - winston
 
-  "@graphql-mesh/graphql@0.104.24(@types/node@25.4.0)(bufferutil@4.0.9)(crossws@0.3.5)(graphql@16.13.1)(ioredis@5.10.1)(utf-8-validate@5.0.10)":
+  "@graphql-mesh/graphql@0.104.24(@types/node@20.19.37)(bufferutil@4.0.9)(crossws@0.3.5)(graphql@16.13.1)(ioredis@5.10.1)(utf-8-validate@5.0.10)":
     dependencies:
       "@graphql-mesh/cross-helpers": 0.4.12(graphql@16.13.1)
       "@graphql-mesh/store": 0.104.27(graphql@16.13.1)(ioredis@5.10.1)
@@ -25648,9 +25813,9 @@ snapshots:
       "@graphql-mesh/types": 0.104.23(graphql@16.13.1)(ioredis@5.10.1)
       "@graphql-mesh/utils": 0.104.25(graphql@16.13.1)(ioredis@5.10.1)
       "@graphql-tools/delegate": 12.0.12(graphql@16.13.1)
-      "@graphql-tools/federation": 4.2.10(@types/node@25.4.0)(graphql@16.13.1)
+      "@graphql-tools/federation": 4.2.10(@types/node@20.19.37)(graphql@16.13.1)
       "@graphql-tools/merge": 9.1.7(graphql@16.13.1)
-      "@graphql-tools/url-loader": 9.0.6(@types/node@25.4.0)(bufferutil@4.0.9)(crossws@0.3.5)(graphql@16.13.1)(utf-8-validate@5.0.10)
+      "@graphql-tools/url-loader": 9.0.6(@types/node@20.19.37)(bufferutil@4.0.9)(crossws@0.3.5)(graphql@16.13.1)(utf-8-validate@5.0.10)
       "@graphql-tools/utils": 11.0.0(graphql@16.13.1)
       "@whatwg-node/promise-helpers": 1.3.2
       graphql: 16.13.1
@@ -25693,13 +25858,13 @@ snapshots:
       - "@nats-io/nats-core"
       - ioredis
 
-  "@graphql-mesh/incontext-sdk-codegen@0.0.2(@types/node@25.4.0)(graphql@16.13.1)(ioredis@5.10.1)(pino@9.14.0)":
+  "@graphql-mesh/incontext-sdk-codegen@0.0.2(@types/node@20.19.37)(graphql@16.13.1)(ioredis@5.10.1)(pino@9.14.0)":
     dependencies:
       "@graphql-codegen/core": 5.0.1(graphql@16.13.1)
       "@graphql-codegen/plugin-helpers": 6.2.0(graphql@16.13.1)
       "@graphql-codegen/typescript": 5.0.9(graphql@16.13.1)
       "@graphql-mesh/cross-helpers": 0.4.12(graphql@16.13.1)
-      "@graphql-mesh/fusion-runtime": 1.8.1(@types/node@25.4.0)(graphql@16.13.1)(ioredis@5.10.1)(pino@9.14.0)
+      "@graphql-mesh/fusion-runtime": 1.8.1(@types/node@20.19.37)(graphql@16.13.1)(ioredis@5.10.1)(pino@9.14.0)
       "@graphql-mesh/transport-common": 1.0.15(graphql@16.13.1)(ioredis@5.10.1)(pino@9.14.0)
       "@graphql-mesh/types": 0.104.23(graphql@16.13.1)(ioredis@5.10.1)
       "@graphql-mesh/utils": 0.104.25(graphql@16.13.1)(ioredis@5.10.1)
@@ -26089,7 +26254,7 @@ snapshots:
     transitivePeerDependencies:
       - "@types/node"
 
-  "@graphql-tools/executor-http@3.1.0(@types/node@25.4.0)(graphql@16.13.1)":
+  "@graphql-tools/executor-http@3.1.0(@types/node@20.19.37)(graphql@16.13.1)":
     dependencies:
       "@graphql-hive/signal": 2.0.0
       "@graphql-tools/executor-common": 1.0.6(graphql@16.13.1)
@@ -26099,12 +26264,12 @@ snapshots:
       "@whatwg-node/fetch": 0.10.13
       "@whatwg-node/promise-helpers": 1.3.2
       graphql: 16.13.1
-      meros: 1.3.2(@types/node@25.4.0)
+      meros: 1.3.2(@types/node@20.19.37)
       tslib: 2.8.1
     transitivePeerDependencies:
       - "@types/node"
 
-  "@graphql-tools/executor-http@3.1.1(@types/node@25.4.0)(graphql@16.13.1)":
+  "@graphql-tools/executor-http@3.1.1(@types/node@20.19.37)(graphql@16.13.1)":
     dependencies:
       "@graphql-hive/signal": 2.0.0
       "@graphql-tools/executor-common": 1.0.6(graphql@16.13.1)
@@ -26114,7 +26279,7 @@ snapshots:
       "@whatwg-node/fetch": 0.10.13
       "@whatwg-node/promise-helpers": 1.3.2
       graphql: 16.13.1
-      meros: 1.3.2(@types/node@25.4.0)
+      meros: 1.3.2(@types/node@20.19.37)
       tslib: 2.8.1
     transitivePeerDependencies:
       - "@types/node"
@@ -26163,11 +26328,11 @@ snapshots:
       graphql: 16.13.1
       tslib: 2.8.1
 
-  "@graphql-tools/federation@4.2.10(@types/node@25.4.0)(graphql@16.13.1)":
+  "@graphql-tools/federation@4.2.10(@types/node@20.19.37)(graphql@16.13.1)":
     dependencies:
       "@graphql-tools/delegate": 12.0.12(graphql@16.13.1)
       "@graphql-tools/executor": 1.5.1(graphql@16.13.1)
-      "@graphql-tools/executor-http": 3.1.0(@types/node@25.4.0)(graphql@16.13.1)
+      "@graphql-tools/executor-http": 3.1.0(@types/node@20.19.37)(graphql@16.13.1)
       "@graphql-tools/merge": 9.1.7(graphql@16.13.1)
       "@graphql-tools/schema": 10.0.31(graphql@16.13.1)
       "@graphql-tools/stitch": 10.1.16(graphql@16.13.1)
@@ -26183,11 +26348,11 @@ snapshots:
     transitivePeerDependencies:
       - "@types/node"
 
-  "@graphql-tools/federation@4.3.1(@types/node@25.4.0)(graphql@16.13.1)":
+  "@graphql-tools/federation@4.3.1(@types/node@20.19.37)(graphql@16.13.1)":
     dependencies:
       "@graphql-tools/delegate": 12.0.12(graphql@16.13.1)
       "@graphql-tools/executor": 1.5.1(graphql@16.13.1)
-      "@graphql-tools/executor-http": 3.1.1(@types/node@25.4.0)(graphql@16.13.1)
+      "@graphql-tools/executor-http": 3.1.1(@types/node@20.19.37)(graphql@16.13.1)
       "@graphql-tools/merge": 9.1.7(graphql@16.13.1)
       "@graphql-tools/schema": 10.0.31(graphql@16.13.1)
       "@graphql-tools/stitch": 10.1.16(graphql@16.13.1)
@@ -26473,10 +26638,10 @@ snapshots:
       - crossws
       - utf-8-validate
 
-  "@graphql-tools/url-loader@9.0.6(@types/node@25.4.0)(bufferutil@4.0.9)(crossws@0.3.5)(graphql@16.13.1)(utf-8-validate@5.0.10)":
+  "@graphql-tools/url-loader@9.0.6(@types/node@20.19.37)(bufferutil@4.0.9)(crossws@0.3.5)(graphql@16.13.1)(utf-8-validate@5.0.10)":
     dependencies:
       "@graphql-tools/executor-graphql-ws": 3.1.4(bufferutil@4.0.9)(crossws@0.3.5)(graphql@16.13.1)(utf-8-validate@5.0.10)
-      "@graphql-tools/executor-http": 3.1.0(@types/node@25.4.0)(graphql@16.13.1)
+      "@graphql-tools/executor-http": 3.1.0(@types/node@20.19.37)(graphql@16.13.1)
       "@graphql-tools/executor-legacy-ws": 1.1.25(bufferutil@4.0.9)(graphql@16.13.1)(utf-8-validate@5.0.10)
       "@graphql-tools/utils": 11.0.0(graphql@16.13.1)
       "@graphql-tools/wrap": 11.1.12(graphql@16.13.1)
@@ -26882,41 +27047,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  "@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3))":
-    dependencies:
-      "@jest/console": 29.7.0
-      "@jest/reporters": 29.7.0
-      "@jest/test-result": 29.7.0
-      "@jest/transform": 29.7.0
-      "@jest/types": 29.6.3
-      "@types/node": 20.19.37
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   "@jest/environment@29.7.0":
     dependencies:
       "@jest/fake-timers": 29.7.0
@@ -27078,6 +27208,8 @@ snapshots:
 
   "@kubb/ast@4.37.2": {}
 
+  "@kubb/ast@4.37.5": {}
+
   "@kubb/cli@4.37.2(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.3)":
     dependencies:
       "@clack/prompts": 1.2.0
@@ -27094,6 +27226,17 @@ snapshots:
   "@kubb/core@4.37.2(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
     dependencies:
       "@kubb/ast": 4.37.2
+      "@kubb/fabric-core": 0.14.0
+      "@kubb/react-fabric": 0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      empathic: 2.0.0
+      fflate: 0.8.2
+      remeda: 2.33.7
+      semver: 7.7.4
+      tinyexec: 1.1.1
+
+  "@kubb/core@4.37.5(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
+    dependencies:
+      "@kubb/ast": 4.37.5
       "@kubb/fabric-core": 0.14.0
       "@kubb/react-fabric": 0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       empathic: 2.0.0
@@ -27126,6 +27269,23 @@ snapshots:
       - "@kubb/react-fabric"
       - encoding
 
+  "@kubb/oas@4.37.5(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
+    dependencies:
+      "@kubb/ast": 4.37.5
+      "@kubb/core": 4.37.5(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@kubb/fabric-core": 0.14.0
+      "@redocly/openapi-core": 2.27.1
+      "@stoplight/yaml": 4.3.0
+      jsonpointer: 5.0.1
+      oas: 31.1.2
+      oas-normalize: 16.0.4
+      openapi-types: 12.1.3
+      remeda: 2.33.7
+      swagger2openapi: 7.0.8
+    transitivePeerDependencies:
+      - "@kubb/react-fabric"
+      - encoding
+
   "@kubb/plugin-client@4.37.2(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(axios@1.13.6)(bufferutil@4.0.9)(utf-8-validate@5.0.10)":
     dependencies:
       "@kubb/core": 4.37.2(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -27142,11 +27302,48 @@ snapshots:
       - encoding
       - utf-8-validate
 
+  "@kubb/plugin-faker@4.37.5(@kubb/fabric-core@0.14.0)(bufferutil@4.0.9)(utf-8-validate@5.0.10)":
+    dependencies:
+      "@kubb/core": 4.37.5(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@kubb/oas": 4.37.5(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@kubb/plugin-oas": 4.37.5(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@kubb/plugin-ts": 4.37.5(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@kubb/react-fabric": 0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - "@kubb/fabric-core"
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  "@kubb/plugin-msw@4.37.5(@kubb/fabric-core@0.14.0)(bufferutil@4.0.9)(utf-8-validate@5.0.10)":
+    dependencies:
+      "@kubb/core": 4.37.5(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@kubb/oas": 4.37.5(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@kubb/plugin-faker": 4.37.5(@kubb/fabric-core@0.14.0)(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      "@kubb/plugin-oas": 4.37.5(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@kubb/plugin-ts": 4.37.5(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@kubb/react-fabric": 0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - "@kubb/fabric-core"
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
   "@kubb/plugin-oas@4.37.2(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
     dependencies:
       "@kubb/core": 4.37.2(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@kubb/fabric-core": 0.14.0
       "@kubb/oas": 4.37.2(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@kubb/react-fabric": 0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      remeda: 2.33.7
+    transitivePeerDependencies:
+      - encoding
+
+  "@kubb/plugin-oas@4.37.5(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
+    dependencies:
+      "@kubb/core": 4.37.5(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@kubb/fabric-core": 0.14.0
+      "@kubb/oas": 4.37.5(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@kubb/react-fabric": 0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       remeda: 2.33.7
     transitivePeerDependencies:
@@ -27176,6 +27373,19 @@ snapshots:
       "@kubb/fabric-core": 0.14.0
       "@kubb/oas": 4.37.2(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@kubb/plugin-oas": 4.37.2(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@kubb/react-fabric": 0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      remeda: 2.33.7
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - encoding
+
+  "@kubb/plugin-ts@4.37.5(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
+    dependencies:
+      "@kubb/ast": 4.37.5
+      "@kubb/core": 4.37.5(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@kubb/fabric-core": 0.14.0
+      "@kubb/oas": 4.37.5(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@kubb/plugin-oas": 4.37.5(@kubb/fabric-core@0.14.0)(@kubb/react-fabric@0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@kubb/react-fabric": 0.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       remeda: 2.33.7
       typescript: 5.9.3
@@ -28723,7 +28933,7 @@ snapshots:
 
   "@radix-ui/rect@1.1.1": {}
 
-  "@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))":
+  "@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))":
     dependencies:
       "@tanstack/react-query": 5.90.21(react@19.2.3)
       "@vanilla-extract/css": 1.17.3
@@ -28736,7 +28946,7 @@ snapshots:
       react-remove-scroll: 2.6.2(@types/react@19.2.8)(react@19.2.3)
       ua-parser-js: 1.0.40
       viem: 2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
     transitivePeerDependencies:
       - "@types/react"
       - babel-plugin-macros
@@ -29273,13 +29483,13 @@ snapshots:
 
   "@socket.io/component-emitter@3.1.2": {}
 
-  "@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))":
+  "@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))":
     dependencies:
-      "@solana/kit": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@solana/kit": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
-  "@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))":
+  "@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))":
     dependencies:
-      "@solana/kit": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@solana/kit": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   "@solana/accounts@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)":
     dependencies:
@@ -29409,7 +29619,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  "@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
+  "@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
     dependencies:
       "@solana/accounts": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/addresses": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -29423,11 +29633,11 @@ snapshots:
       "@solana/rpc": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/rpc-parsed-types": 3.0.3(typescript@5.9.3)
       "@solana/rpc-spec-types": 3.0.3(typescript@5.9.3)
-      "@solana/rpc-subscriptions": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@solana/rpc-subscriptions": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@solana/rpc-types": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/signers": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/sysvars": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      "@solana/transaction-confirmation": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@solana/transaction-confirmation": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@solana/transaction-messages": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/transactions": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       typescript: 5.9.3
@@ -29506,14 +29716,14 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  "@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
+  "@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
     dependencies:
       "@solana/errors": 3.0.3(typescript@5.9.3)
       "@solana/functional": 3.0.3(typescript@5.9.3)
       "@solana/rpc-subscriptions-spec": 3.0.3(typescript@5.9.3)
       "@solana/subscribable": 3.0.3(typescript@5.9.3)
       typescript: 5.9.3
-      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
   "@solana/rpc-subscriptions-spec@3.0.3(typescript@5.9.3)":
     dependencies:
@@ -29523,7 +29733,7 @@ snapshots:
       "@solana/subscribable": 3.0.3(typescript@5.9.3)
       typescript: 5.9.3
 
-  "@solana/rpc-subscriptions@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
+  "@solana/rpc-subscriptions@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
     dependencies:
       "@solana/errors": 3.0.3(typescript@5.9.3)
       "@solana/fast-stable-stringify": 3.0.3(typescript@5.9.3)
@@ -29531,7 +29741,7 @@ snapshots:
       "@solana/promises": 3.0.3(typescript@5.9.3)
       "@solana/rpc-spec-types": 3.0.3(typescript@5.9.3)
       "@solana/rpc-subscriptions-api": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      "@solana/rpc-subscriptions-channel-websocket": 3.0.3(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@solana/rpc-subscriptions-channel-websocket": 3.0.3(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@solana/rpc-subscriptions-spec": 3.0.3(typescript@5.9.3)
       "@solana/rpc-transformers": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/rpc-types": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -29616,7 +29826,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  "@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
+  "@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
     dependencies:
       "@solana/addresses": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/codecs-strings": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -29624,7 +29834,7 @@ snapshots:
       "@solana/keys": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/promises": 3.0.3(typescript@5.9.3)
       "@solana/rpc": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      "@solana/rpc-subscriptions": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@solana/rpc-subscriptions": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@solana/rpc-types": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/transaction-messages": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/transactions": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -29782,7 +29992,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  "@storybook/nextjs@10.2.8(next@16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.17(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.4)":
+  "@storybook/nextjs@10.2.8(next@16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.17(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(utf-8-validate@5.0.10))(type-fest@4.41.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.4)":
     dependencies:
       "@babel/core": 7.28.5
       "@babel/plugin-syntax-bigint": 7.8.3(@babel/core@7.28.5)
@@ -29806,7 +30016,7 @@ snapshots:
       css-loader: 6.11.0(webpack@5.105.4)
       image-size: 2.0.2
       loader-utils: 3.3.1
-      next: 16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.105.4)
       postcss: 8.5.8
       postcss-loader: 8.1.1(postcss@8.5.8)(typescript@5.9.3)(webpack@5.105.4)
@@ -30702,9 +30912,9 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.0.3
 
-  "@wagmi/connectors@6.2.0(5c4773a768a9f9ed4a0f333e6a4d7cbe)":
+  "@wagmi/connectors@6.2.0(4965d06122479b00bf04512a89004630)":
     dependencies:
-      "@base-org/account": 2.4.0(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      "@base-org/account": 2.4.0(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       "@coinbase/wallet-sdk": 4.3.6(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.76)
       "@gemini-wallet/core": 0.3.2(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       "@metamask/sdk": 0.33.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -30713,7 +30923,7 @@ snapshots:
       "@wagmi/core": 2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       "@walletconnect/ethereum-provider": 2.21.1(@types/react@19.2.8)(bufferutil@4.0.9)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: "@coinbase/wallet-sdk@3.9.3"
-      porto: 0.2.35(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
+      porto: 0.2.35(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
       viem: 2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
@@ -31791,6 +32001,20 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  babel-jest@29.7.0(@babel/core@7.28.5):
+    dependencies:
+      "@babel/core": 7.28.5
+      "@jest/transform": 29.7.0
+      "@types/babel__core": 7.20.5
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@7.28.5)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   babel-jest@29.7.0(@babel/core@7.29.0):
     dependencies:
       "@babel/core": 7.29.0
@@ -31852,6 +32076,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-preset-current-node-syntax@1.1.0(@babel/core@7.28.5):
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/plugin-syntax-async-generators": 7.8.4(@babel/core@7.28.5)
+      "@babel/plugin-syntax-bigint": 7.8.3(@babel/core@7.28.5)
+      "@babel/plugin-syntax-class-properties": 7.12.13(@babel/core@7.28.5)
+      "@babel/plugin-syntax-class-static-block": 7.14.5(@babel/core@7.28.5)
+      "@babel/plugin-syntax-import-attributes": 7.28.6(@babel/core@7.28.5)
+      "@babel/plugin-syntax-import-meta": 7.10.4(@babel/core@7.28.5)
+      "@babel/plugin-syntax-json-strings": 7.8.3(@babel/core@7.28.5)
+      "@babel/plugin-syntax-logical-assignment-operators": 7.10.4(@babel/core@7.28.5)
+      "@babel/plugin-syntax-nullish-coalescing-operator": 7.8.3(@babel/core@7.28.5)
+      "@babel/plugin-syntax-numeric-separator": 7.10.4(@babel/core@7.28.5)
+      "@babel/plugin-syntax-object-rest-spread": 7.8.3(@babel/core@7.28.5)
+      "@babel/plugin-syntax-optional-catch-binding": 7.8.3(@babel/core@7.28.5)
+      "@babel/plugin-syntax-optional-chaining": 7.8.3(@babel/core@7.28.5)
+      "@babel/plugin-syntax-private-property-in-object": 7.14.5(@babel/core@7.28.5)
+      "@babel/plugin-syntax-top-level-await": 7.14.5(@babel/core@7.28.5)
+    optional: true
+
   babel-preset-current-node-syntax@1.1.0(@babel/core@7.29.0):
     dependencies:
       "@babel/core": 7.29.0
@@ -31870,6 +32114,13 @@ snapshots:
       "@babel/plugin-syntax-optional-chaining": 7.8.3(@babel/core@7.29.0)
       "@babel/plugin-syntax-private-property-in-object": 7.14.5(@babel/core@7.29.0)
       "@babel/plugin-syntax-top-level-await": 7.14.5(@babel/core@7.29.0)
+
+  babel-preset-jest@29.6.3(@babel/core@7.28.5):
+    dependencies:
+      "@babel/core": 7.28.5
+      babel-plugin-jest-hoist: 29.6.3
+      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.28.5)
+    optional: true
 
   babel-preset-jest@29.6.3(@babel/core@7.29.0):
     dependencies:
@@ -32467,21 +32718,6 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-config: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - "@types/node"
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  create-jest@29.7.0(@types/node@25.4.0)(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3)):
-    dependencies:
-      "@jest/types": 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.4.0)(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -33938,7 +34174,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/620536fa5277db4e3fd46772d5cbc1ea0696fb43:
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/8b531a016f15f761a632f5149a828228573420fc:
     {}
 
   fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.105.4):
@@ -34210,12 +34446,12 @@ snapshots:
     dependencies:
       graphql: 16.13.1
 
-  graphql-ws@6.0.7(crossws@0.3.5)(graphql@16.13.1)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+  graphql-ws@6.0.7(crossws@0.3.5)(graphql@16.13.1)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
       graphql: 16.13.1
     optionalDependencies:
       crossws: 0.3.5
-      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optional: true
 
   graphql-ws@6.0.7(crossws@0.3.5)(graphql@16.13.1)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
@@ -34923,25 +35159,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@25.4.0)(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3)):
-    dependencies:
-      "@jest/core": 29.7.0(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3))
-      "@jest/test-result": 29.7.0
-      "@jest/types": 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.4.0)(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.4.0)(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - "@types/node"
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-config@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)):
     dependencies:
       "@babel/core": 7.29.0
@@ -34969,68 +35186,6 @@ snapshots:
     optionalDependencies:
       "@types/node": 20.19.37
       ts-node: 10.9.2(@types/node@20.19.37)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3)):
-    dependencies:
-      "@babel/core": 7.29.0
-      "@jest/test-sequencer": 29.7.0
-      "@jest/types": 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      "@types/node": 20.19.37
-      ts-node: 10.9.2(@types/node@25.4.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@25.4.0)(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3)):
-    dependencies:
-      "@babel/core": 7.29.0
-      "@jest/test-sequencer": 29.7.0
-      "@jest/types": 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      "@types/node": 25.4.0
-      ts-node: 10.9.2(@types/node@25.4.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -35262,18 +35417,6 @@ snapshots:
       "@jest/types": 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
-    transitivePeerDependencies:
-      - "@types/node"
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@25.4.0)(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3)):
-    dependencies:
-      "@jest/core": 29.7.0(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3))
-      "@jest/types": 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.4.0)(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - "@types/node"
       - babel-plugin-macros
@@ -35950,10 +36093,6 @@ snapshots:
     optionalDependencies:
       "@types/node": 20.19.37
 
-  meros@1.3.2(@types/node@25.4.0):
-    optionalDependencies:
-      "@types/node": 25.4.0
-
   mersenne-twister@1.1.0: {}
 
   micro-ftch@0.3.1: {}
@@ -36366,7 +36505,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       "@next/env": 16.1.3
       "@swc/helpers": 0.5.15
@@ -36375,7 +36514,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.3)
     optionalDependencies:
       "@next/swc-darwin-arm64": 16.1.3
       "@next/swc-darwin-x64": 16.1.3
@@ -36482,12 +36621,12 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
-  nuqs@2.8.8(next@16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+  nuqs@2.8.8(next@16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
     dependencies:
       "@standard-schema/spec": 1.0.0
       react: 19.2.3
     optionalDependencies:
-      next: 16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   nwsapi@2.2.23: {}
 
@@ -37219,7 +37358,7 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.35(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  porto@0.2.35(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       "@wagmi/core": 2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hono: 4.12.7
@@ -37233,7 +37372,7 @@ snapshots:
       "@tanstack/react-query": 5.90.21(react@19.2.3)
       react: 19.2.3
       typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
     transitivePeerDependencies:
       - "@types/react"
       - immer
@@ -38520,12 +38659,12 @@ snapshots:
 
   style-mod@4.1.3: {}
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.3):
+  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
     optionalDependencies:
-      "@babel/core": 7.29.0
+      "@babel/core": 7.28.5
 
   styled-jsx@5.1.7(@babel/core@7.28.5)(react@19.2.3):
     dependencies:
@@ -38801,7 +38940,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -38815,18 +38954,18 @@ snapshots:
       typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      "@babel/core": 7.29.0
+      "@babel/core": 7.28.5
       "@jest/transform": 29.7.0
       "@jest/types": 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
+      babel-jest: 29.7.0(@babel/core@7.28.5)
       jest-util: 29.7.0
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.4.0)(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@25.4.0)(ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@20.19.37)(ts-node@10.9.2(@types/node@20.19.37)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -38867,25 +39006,6 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-
-  ts-node@10.9.2(@types/node@25.4.0)(typescript@5.9.3):
-    dependencies:
-      "@cspotcode/source-map-support": 0.8.1
-      "@tsconfig/node10": 1.0.11
-      "@tsconfig/node12": 1.0.11
-      "@tsconfig/node14": 1.0.3
-      "@tsconfig/node16": 1.0.4
-      "@types/node": 25.4.0
-      acorn: 8.16.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:
@@ -39584,10 +39704,10 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
+  wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       "@tanstack/react-query": 5.90.21(react@19.2.3)
-      "@wagmi/connectors": 6.2.0(5c4773a768a9f9ed4a0f333e6a4d7cbe)
+      "@wagmi/connectors": 6.2.0(4965d06122479b00bf04512a89004630)
       "@wagmi/core": 2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       react: 19.2.3
       use-sync-external-store: 1.4.0(react@19.2.3)


### PR DESCRIPTION
## Summary

Adds MSW mock handler generation to `@anticapture/client` so consumers can stub the Gateful API in tests without hitting the network. The Kubb pipeline now emits faker-seeded fixtures and MSW handlers, exposed through a new `@anticapture/client/msw` subpath that also re-exports MSW's runtime to sidestep MSW v2.8+ nominal-type issues at the `setupServer` boundary.

## Changes

- `kubb.config.ts`: register `pluginFaker` and `pluginMsw` (with `baseURL: "*"` so handlers match any host); extract the `dao → getDao` rename into a shared `renameDaoOperation` transformer reused across all plugins.
- `src/msw.ts`: new entry exporting generated `handlers`, a `createTestServer` helper wrapping `msw/node`'s `setupServer`, and re-exports of `http` / `HttpResponse` / `HttpHandler` so consumer handlers share module identity with the generated ones.
- `package.json`: bump to `1.1.0`; add `./msw` export map; promote `@faker-js/faker` to a runtime dependency; add `msw` as an optional peer dependency; add `@kubb/plugin-faker` and `@kubb/plugin-msw` devDeps.
- `tsup.config.ts`: add `msw` build entry and externalize `msw` and `@faker-js/faker`.
- `README.md`: document the MSW testing workflow, `createTestServer` usage, the rationale for importing `http`/`HttpResponse` from the subpath, and the required `moduleResolution` setting.
- `pnpm-lock.yaml`: lockfile updates for the new dependencies.
