### PR TITLE
Feat/relayer public config endpoints

### DIFF
--- a/apps/relayer/e2e/helpers/app.ts
+++ b/apps/relayer/e2e/helpers/app.ts
@@ -48,7 +48,7 @@ export async function createTestApp(rpcUrl: string) {
   );
 
   const rateLimiter = new RateLimiter(
-    { incrementIfAllowed: async () => true },
+    { incrementIfAllowed: async () => true, getCount: async () => 0 },
     {
       daoName: "test",
       governorAddress: GOVERNOR_ADDRESS,

--- a/apps/relayer/src/controllers/config.ts
+++ b/apps/relayer/src/controllers/config.ts
@@ -1,0 +1,38 @@
+import { OpenAPIHono as Hono, createRoute } from "@hono/zod-openapi";
+
+import { ConfigResponseSchema } from "@/schemas/config";
+
+interface ConfigControllerDeps {
+  minVotingPower: string;
+  maxRelayPerAddressPerDay: number;
+}
+
+export function config(app: Hono, deps: ConfigControllerDeps) {
+  app.openapi(
+    createRoute({
+      method: "get",
+      operationId: "getConfig",
+      path: "/config",
+      summary: "Public relayer configuration",
+      description:
+        "Returns the static configuration values the dashboard needs to render eligibility hints.",
+      tags: ["system"],
+      responses: {
+        200: {
+          description: "Relayer configuration",
+          content: {
+            "application/json": { schema: ConfigResponseSchema },
+          },
+        },
+      },
+    }),
+    async (c) =>
+      c.json(
+        {
+          minVotingPower: deps.minVotingPower,
+          maxRelayPerAddressPerDay: deps.maxRelayPerAddressPerDay,
+        },
+        200,
+      ),
+  );
+}

--- a/apps/relayer/src/controllers/rate-limit.ts
+++ b/apps/relayer/src/controllers/rate-limit.ts
@@ -1,0 +1,93 @@
+import { OpenAPIHono as Hono, createRoute } from "@hono/zod-openapi";
+import type { Address } from "viem";
+
+import {
+  RateLimitParamsSchema,
+  RateLimitResponseSchema,
+} from "@/schemas/rate-limit";
+import { ErrorResponseSchema } from "@/errors";
+import type { RateLimitStorage } from "@/repository/rate-limit-storage";
+
+interface RateLimitControllerDeps {
+  storage: RateLimitStorage;
+  daoName: string;
+  governorAddress: Address;
+  maxPerDay: number;
+}
+
+const DAY_MS = 86_400_000;
+
+function nextUtcMidnightIso(now: number): string {
+  return new Date(Math.floor(now / DAY_MS) * DAY_MS + DAY_MS).toISOString();
+}
+
+function clampRemaining(used: number, max: number): number {
+  return Math.max(0, max - used);
+}
+
+export function rateLimit(app: Hono, deps: RateLimitControllerDeps) {
+  app.openapi(
+    createRoute({
+      method: "get",
+      operationId: "getRateLimit",
+      path: "/rate-limit/{address}",
+      summary: "Per-address relay usage for the current UTC day",
+      description:
+        "Returns the number of relay calls already used and remaining for the given address, " +
+        "split by operation. Reads do not consume the rate limit.",
+      tags: ["system"],
+      request: {
+        params: RateLimitParamsSchema,
+      },
+      responses: {
+        200: {
+          description: "Current usage and remaining quota",
+          content: {
+            "application/json": { schema: RateLimitResponseSchema },
+          },
+        },
+        400: {
+          description: "Invalid address",
+          content: {
+            "application/json": { schema: ErrorResponseSchema },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const { address } = c.req.valid("param");
+
+      const [voteUsed, delegationUsed] = await Promise.all([
+        deps.storage.getCount({
+          daoName: deps.daoName,
+          governorAddress: deps.governorAddress,
+          address,
+          operation: "vote",
+        }),
+        deps.storage.getCount({
+          daoName: deps.daoName,
+          governorAddress: deps.governorAddress,
+          address,
+          operation: "delegation",
+        }),
+      ]);
+
+      return c.json(
+        {
+          address,
+          maxPerDay: deps.maxPerDay,
+          vote: {
+            used: voteUsed,
+            remaining: clampRemaining(voteUsed, deps.maxPerDay),
+          },
+          delegation: {
+            used: delegationUsed,
+            remaining: clampRemaining(delegationUsed, deps.maxPerDay),
+          },
+          resetsAt: nextUtcMidnightIso(Date.now()),
+        },
+        200,
+      );
+    },
+  );
+}

--- a/apps/relayer/src/controllers/rate-limit.ts
+++ b/apps/relayer/src/controllers/rate-limit.ts
@@ -5,7 +5,7 @@ import {
   RateLimitParamsSchema,
   RateLimitResponseSchema,
 } from "@/schemas/rate-limit";
-import { ErrorResponseSchema } from "@/errors";
+import { ErrorResponseSchema, Errors } from "@/errors";
 import type { RateLimitStorage } from "@/repository/rate-limit-storage";
 
 interface RateLimitControllerDeps {
@@ -52,25 +52,37 @@ export function rateLimit(app: Hono, deps: RateLimitControllerDeps) {
             "application/json": { schema: ErrorResponseSchema },
           },
         },
+        503: {
+          description: "Rate limiter storage is unavailable",
+          content: {
+            "application/json": { schema: ErrorResponseSchema },
+          },
+        },
       },
     }),
     async (c) => {
       const { address } = c.req.valid("param");
 
-      const [voteUsed, delegationUsed] = await Promise.all([
-        deps.storage.getCount({
-          daoName: deps.daoName,
-          governorAddress: deps.governorAddress,
-          address,
-          operation: "vote",
-        }),
-        deps.storage.getCount({
-          daoName: deps.daoName,
-          governorAddress: deps.governorAddress,
-          address,
-          operation: "delegation",
-        }),
-      ]);
+      let voteUsed: number;
+      let delegationUsed: number;
+      try {
+        [voteUsed, delegationUsed] = await Promise.all([
+          deps.storage.getCount({
+            daoName: deps.daoName,
+            governorAddress: deps.governorAddress,
+            address,
+            operation: "vote",
+          }),
+          deps.storage.getCount({
+            daoName: deps.daoName,
+            governorAddress: deps.governorAddress,
+            address,
+            operation: "delegation",
+          }),
+        ]);
+      } catch {
+        throw Errors.RATE_LIMITER_UNAVAILABLE();
+      }
 
       return c.json(
         {

--- a/apps/relayer/src/index.ts
+++ b/apps/relayer/src/index.ts
@@ -12,7 +12,9 @@ import { createPublicClient, http } from "viem";
 import { mainnet } from "viem/chains";
 import { fromZodError } from "zod-validation-error";
 
+import { config } from "@/controllers/config";
 import { health } from "@/controllers/health";
+import { rateLimit } from "@/controllers/rate-limit";
 import { relayDelegate } from "@/controllers/relay-delegate";
 import { relayVote } from "@/controllers/relay-vote";
 import { env } from "@/env";
@@ -148,6 +150,16 @@ async function main() {
   relayVote(app, relayService);
   relayDelegate(app, relayService);
   health(app);
+  config(app, {
+    minVotingPower: env.MIN_VOTING_POWER,
+    maxRelayPerAddressPerDay: env.MAX_RELAY_PER_ADDRESS_PER_DAY,
+  });
+  rateLimit(app, {
+    storage: rateLimitStorage,
+    daoName: env.DAO_NAME,
+    governorAddress: governorAddress,
+    maxPerDay: env.MAX_RELAY_PER_ADDRESS_PER_DAY,
+  });
 
   // --- OpenAPI docs ---
   app.doc("/docs", {

--- a/apps/relayer/src/repository/rate-limit-storage.test.ts
+++ b/apps/relayer/src/repository/rate-limit-storage.test.ts
@@ -27,6 +27,11 @@ class FakeRedis implements RedisClient {
     return 1;
   }
 
+  async get(key: string): Promise<string | null> {
+    const value = this.counters.get(key);
+    return value === undefined ? null : String(value);
+  }
+
   seed(key: string, delta: number): void {
     this.counters.set(key, (this.counters.get(key) ?? 0) + delta);
   }
@@ -127,5 +132,69 @@ describe("RedisRateLimitStorage.incrementIfAllowed", () => {
       maxPerDay: MAX_PER_DAY,
     });
     expect(granted).toBe(true);
+  });
+});
+
+describe("RedisRateLimitStorage.getCount", () => {
+  it("returns 0 when no calls have been made", async () => {
+    const count = await store.getCount({
+      daoName: DAO,
+      governorAddress: GOVERNOR,
+      address: ADDR_A,
+      operation: "vote",
+    });
+
+    expect(count).toBe(0);
+  });
+
+  it("reflects current usage without consuming the limit", async () => {
+    await store.incrementIfAllowed({
+      daoName: DAO,
+      governorAddress: GOVERNOR,
+      address: ADDR_A,
+      operation: "vote",
+      maxPerDay: MAX_PER_DAY,
+    });
+    await store.incrementIfAllowed({
+      daoName: DAO,
+      governorAddress: GOVERNOR,
+      address: ADDR_A,
+      operation: "vote",
+      maxPerDay: MAX_PER_DAY,
+    });
+
+    // Read multiple times — must not consume slots.
+    for (let i = 0; i < 5; i++) {
+      const count = await store.getCount({
+        daoName: DAO,
+        governorAddress: GOVERNOR,
+        address: ADDR_A,
+        operation: "vote",
+      });
+      expect(count).toBe(2);
+    }
+
+    // Third increment must still be granted (limit is 3) — proving reads didn't consume.
+    const granted = await store.incrementIfAllowed({
+      daoName: DAO,
+      governorAddress: GOVERNOR,
+      address: ADDR_A,
+      operation: "vote",
+      maxPerDay: MAX_PER_DAY,
+    });
+    expect(granted).toBe(true);
+  });
+
+  it("ignores entries outside the current UTC-day window", async () => {
+    insertUsage(ADDR_A, "vote", 25);
+
+    const count = await store.getCount({
+      daoName: DAO,
+      governorAddress: GOVERNOR,
+      address: ADDR_A,
+      operation: "vote",
+    });
+
+    expect(count).toBe(0);
   });
 });

--- a/apps/relayer/src/repository/rate-limit-storage.ts
+++ b/apps/relayer/src/repository/rate-limit-storage.ts
@@ -11,13 +11,22 @@ export interface IncrementIfAllowedParams {
   maxPerDay: number;
 }
 
+export interface GetCountParams {
+  daoName: string;
+  governorAddress: Address;
+  address: Address;
+  operation: RelayOperation;
+}
+
 export interface RateLimitStorage {
   incrementIfAllowed(params: IncrementIfAllowedParams): Promise<boolean>;
+  getCount(params: GetCountParams): Promise<number>;
 }
 
 export interface RedisClient {
   incr(key: string): Promise<number>;
   expire(key: string, seconds: number): Promise<unknown>;
+  get(key: string): Promise<string | null>;
 }
 
 const DAY_MS = 86_400_000;
@@ -74,5 +83,22 @@ export class RedisRateLimitStorage implements RateLimitStorage {
     if (dayCount === 1) await this.redis.expire(dayKey, DAY_SECONDS);
 
     return dayCount <= maxPerDay;
+  }
+
+  /**
+   * Reads the current daily counter without incrementing. Returns 0 if no calls have
+   * been made in the current UTC-day window (or if the key has expired).
+   */
+  async getCount({
+    daoName,
+    governorAddress,
+    address,
+    operation,
+  }: GetCountParams): Promise<number> {
+    const base = buildKey(daoName, governorAddress, address, operation);
+    const dayKey = dailyKey(base, Date.now());
+
+    const raw = await this.redis.get(dayKey);
+    return raw === null ? 0 : Number(raw);
   }
 }

--- a/apps/relayer/src/schemas/config.ts
+++ b/apps/relayer/src/schemas/config.ts
@@ -2,17 +2,15 @@ import { z } from "@hono/zod-openapi";
 
 export const ConfigResponseSchema = z
   .object({
-    minVotingPower: z
-      .string()
-      .describe(
+    minVotingPower: z.string().openapi({
+      format: "bigint",
+      description:
         "Minimum voting power required to relay, as a decimal string (uint256).",
-      ),
-    maxRelayPerAddressPerDay: z
-      .number()
-      .int()
-      .min(0)
-      .describe(
+    }),
+    maxRelayPerAddressPerDay: z.number().int().min(0).openapi({
+      format: "bigint",
+      description:
         "Maximum number of relays per address per UTC day, per operation.",
-      ),
+    }),
   })
   .openapi("RelayerConfigResponse");

--- a/apps/relayer/src/schemas/config.ts
+++ b/apps/relayer/src/schemas/config.ts
@@ -1,0 +1,18 @@
+import { z } from "@hono/zod-openapi";
+
+export const ConfigResponseSchema = z
+  .object({
+    minVotingPower: z
+      .string()
+      .describe(
+        "Minimum voting power required to relay, as a decimal string (uint256).",
+      ),
+    maxRelayPerAddressPerDay: z
+      .number()
+      .int()
+      .min(0)
+      .describe(
+        "Maximum number of relays per address per UTC day, per operation.",
+      ),
+  })
+  .openapi("RelayerConfigResponse");

--- a/apps/relayer/src/schemas/rate-limit.ts
+++ b/apps/relayer/src/schemas/rate-limit.ts
@@ -13,7 +13,7 @@ const OperationUsageSchema = z.object({
 
 export const RateLimitResponseSchema = z
   .object({
-    address: z.string(),
+    address: AddressSchema.describe("EIP-55 checksummed Ethereum address."),
     maxPerDay: z.number().int().min(0),
     vote: OperationUsageSchema,
     delegation: OperationUsageSchema,

--- a/apps/relayer/src/schemas/rate-limit.ts
+++ b/apps/relayer/src/schemas/rate-limit.ts
@@ -1,0 +1,24 @@
+import { z } from "@hono/zod-openapi";
+
+import { AddressSchema } from "@/schemas/evm-primitives";
+
+export const RateLimitParamsSchema = z.object({
+  address: AddressSchema,
+});
+
+const OperationUsageSchema = z.object({
+  used: z.number().int().min(0),
+  remaining: z.number().int().min(0),
+});
+
+export const RateLimitResponseSchema = z
+  .object({
+    address: z.string(),
+    maxPerDay: z.number().int().min(0),
+    vote: OperationUsageSchema,
+    delegation: OperationUsageSchema,
+    resetsAt: z.iso
+      .datetime()
+      .describe("ISO 8601 timestamp of the next UTC-midnight reset."),
+  })
+  .openapi("RelayerRateLimitResponse");

--- a/apps/relayer/src/services/guards/rate-limiter.test.ts
+++ b/apps/relayer/src/services/guards/rate-limiter.test.ts
@@ -25,6 +25,9 @@ function makeStore(): RateLimitStorage {
       counters.set(id, next);
       return next <= maxPerDay;
     },
+    async getCount({ address, operation }) {
+      return counters.get(`${address}:${operation}`) ?? 0;
+    },
   };
 }
 
@@ -73,8 +76,9 @@ describe("RateLimiter", () => {
   });
 
   it("throws RATE_LIMITER_UNAVAILABLE when store is unreachable", async () => {
-    const brokenStore = {
+    const brokenStore: RateLimitStorage = {
       incrementIfAllowed: () => Promise.reject(new Error("connection refused")),
+      getCount: () => Promise.reject(new Error("connection refused")),
     };
 
     const brokenLimiter = new RateLimiter(brokenStore, {


### PR DESCRIPTION
## Summary

Adds two read-only endpoints to the relayer (`GET /config` and `GET /rate-limit/:address`) so the dashboard can render eligibility hints and per-user remaining quota without hardcoding values or consuming the rate-limit budget on every check. Extends `RateLimitStorage` with a non-consumptive `getCount` method to back the rate-limit endpoint.

## Changes

- Added `GET /config` returning `minVotingPower` (decimal string preserving uint256 precision) and `maxRelayPerAddressPerDay`.
- Added `GET /rate-limit/:address` returning per-operation `used`/`remaining` counts for `vote` and `delegation`, plus `resetsAt` (next UTC-midnight ISO timestamp).
- Extended `RateLimitStorage` interface with `getCount` and `RedisClient` with `get`; implemented `RedisRateLimitStorage.getCount` using a plain `GET` so reads do not increment the counter.
- Added new schemas (`schemas/config.ts`, `schemas/rate-limit.ts`) following the existing `@hono/zod-openapi` pattern, with `z.iso.datetime()` for `resetsAt` to surface `format: date-time` in the OpenAPI spec.
- Wired both routes in `src/index.ts` so they appear in `/docs`.
- Updated existing storage mocks (`rate-limiter.test.ts`, `e2e/helpers/app.ts`) to satisfy the extended interface.
- Added 3 storage tests covering: empty key returns 0, repeated reads do not consume the limit, and entries from previous UTC days are ignored.
