### PR TITLE
refactor: assert delegation eligible

### DIFF
--- a/apps/relayer/src/services/relay.test.ts
+++ b/apps/relayer/src/services/relay.test.ts
@@ -173,11 +173,25 @@ describe("RelayService", () => {
       expect(result).toEqual({ hash: TX_HASH, signer: VOTER });
     });
 
-    it("rejects when neither voting power nor balance meets threshold", async () => {
+    it("rejects when balance is below threshold", async () => {
       const service = createService({
         chainState: createStubChainState({
-          getVotingPower: async () => 999n,
+          getVotingPower: async () => 0n,
           getTokenBalance: async () => 500n,
+        }),
+        minVotingPower: 1000n,
+      });
+
+      await expect(service.relayDelegation(delegateParams)).rejects.toThrow(
+        "minimum voting power",
+      );
+    });
+
+    it("rejects delegate-of-whale: voting power alone does not qualify", async () => {
+      const service = createService({
+        chainState: createStubChainState({
+          getVotingPower: async () => 5000n,
+          getTokenBalance: async () => 0n,
         }),
         minVotingPower: 1000n,
       });

--- a/apps/relayer/src/services/relay.ts
+++ b/apps/relayer/src/services/relay.ts
@@ -140,17 +140,12 @@ export class RelayService {
   }
 
   /**
-   * Delegation accepts voting power OR raw token balance. The balance fallback
-   * covers first-time delegators, whose getVotes() is 0 until they delegate at
-   * least once.
+   * `delegateBySig` moves balanceOf(delegator) on-chain, so eligibility must
+   * gate on balance .
    */
   private async assertDelegationEligible(address: Address): Promise<void> {
-    const [votingPower, balance] = await Promise.all([
-      this.chainState.getVotingPower(address),
-      this.chainState.getTokenBalance(address),
-    ]);
-
-    if (votingPower < this.minVotingPower && balance < this.minVotingPower) {
+    const balance = await this.chainState.getTokenBalance(address);
+    if (balance < this.minVotingPower) {
       throw Errors.INSUFFICIENT_VOTING_POWER(this.minVotingPower.toString());
     }
   }


### PR DESCRIPTION
## Summary

Tighten the relayer's delegation eligibility check to gate solely on the delegator's token balance. The previous `votingPower OR balance` fallback admitted addresses that received delegated voting power but held zero tokens — their `delegateBySig` call would be a paid no-op on-chain, letting an attacker burn relayer gas and consume rate-limit slots without producing any real delegation.

## Changes

- `apps/relayer/src/services/relay.ts`: replace the `votingPower < MIN && balance < MIN` check in `assertDelegationEligible` with a `balance < MIN` check, and drop the now-redundant parallel `getVotingPower` RPC call.
- `apps/relayer/src/services/relay.test.ts`: rename the "neither meets threshold" case to "balance below threshold" and add a regression test asserting that a delegate-of-whale (high `getVotes`, zero `balanceOf`) is rejected.
