### PR TITLE
86ahcp5xu: Improve insufficient voting power modal message

### DIFF
--- a/apps/dashboard/features/create-proposal/components/ProposalCreationForm.tsx
+++ b/apps/dashboard/features/create-proposal/components/ProposalCreationForm.tsx
@@ -479,6 +479,10 @@ export const ProposalCreationForm = ({
         currentVp={currentVpText}
         requiredVp={thresholdFormatted ?? "—"}
         onFindDelegate={() => router.push(`${basePath}/holders-and-delegates`)}
+        onViewDraft={() => {
+          setInsufficientOpen(false);
+          router.push(`${basePath}/proposals?tab=drafts`);
+        }}
       />
     </FormProvider>
   );

--- a/apps/dashboard/features/create-proposal/components/modals/InsufficientVPModal.tsx
+++ b/apps/dashboard/features/create-proposal/components/modals/InsufficientVPModal.tsx
@@ -11,6 +11,7 @@ interface InsufficientVPModalProps {
   currentVp: string;
   requiredVp: string;
   onFindDelegate: () => void;
+  onViewDraft: () => void;
 }
 
 export const InsufficientVPModal = ({
@@ -19,14 +20,15 @@ export const InsufficientVPModal = ({
   currentVp,
   requiredVp,
   onFindDelegate,
+  onViewDraft,
 }: InsufficientVPModalProps) => (
   <Modal
     open={open}
     onOpenChange={onOpenChange}
     title="Insufficient voting power"
-    cancelLabel="Cancel"
+    cancelLabel="View my draft"
     confirmLabel="Find a delegate"
-    onCancel={() => onOpenChange(false)}
+    onCancel={onViewDraft}
     onConfirm={onFindDelegate}
   >
     <div className="flex flex-col items-center gap-3 py-4">
@@ -35,9 +37,9 @@ export const InsufficientVPModal = ({
         Insufficient voting power
       </h3>
       <p className="text-secondary max-w-sm text-center text-sm leading-5">
-        You don&apos;t have enough voting power to create an ENS proposal. Vote
-        on active proposals, or delegate your tokens to someone who can propose
-        on your behalf.
+        You don&apos;t have enough voting power to submit this proposal
+        on-chain. Your proposal has been saved as a draft — share it with
+        someone who has enough voting power to submit it on your behalf.
       </p>
       <div className="border-border-default rounded-base mt-2 flex w-full flex-col gap-2 border p-3 text-sm">
         <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary

- The `InsufficientVPModal` body text now explicitly tells users their proposal was **auto-saved as a draft** and that they can **share it with someone who has enough voting power to submit it on their behalf**.
- The "Cancel" button is renamed to **"View my draft"** and navigates directly to the drafts tab (`/proposals?tab=drafts`) so users can immediately find and share their saved draft.
- Removed the hardcoded "ENS proposal" reference — the message now says "submit this proposal on-chain" which is DAO-agnostic.

## Approach

`handlePublishClick` already calls `handleSaveDraft({ navigateToDrafts: false })` before opening the modal, so the draft is always saved by the time the modal appears. The fix surfaces that fact in the modal copy and adds a direct path to the drafts list via the new `onViewDraft` prop.

## Files changed and why

| File | Why |
|---|---|
| `apps/dashboard/features/create-proposal/components/modals/InsufficientVPModal.tsx` | Updated body text, renamed cancel label to "View my draft", added `onViewDraft` prop |
| `apps/dashboard/features/create-proposal/components/ProposalCreationForm.tsx` | Passed `onViewDraft` handler that closes the modal and navigates to `?tab=drafts` |

## Assumptions I made

- The existing `?tab=drafts` query param on the proposals list page correctly activates the Drafts tab — I did not trace the tab routing but assumed it works the same way `handleSaveDraft` uses it.
- No i18n / translation layer is in use for these strings (all other modal strings in the file are also plain string literals).

## What I did NOT do

- Did not add a separate "Save draft" button — the draft is already saved before the modal opens; adding a second save would be confusing.
- Did not change modal button order or styling.
- Did not modify any other modal or unrelated component.

## Open questions for review

1. **Draft sharing UX** — the task mentions "send it to someone who can submit", but the platform may not have a share-draft feature yet. If not, should the copy say "share the draft link" or is the current wording ("share it with someone") sufficient for now?
2. **"View my draft" label** — if the user hasn't filled in a title/body the auto-save might produce an empty draft. Should the button only appear when a saveable draft actually exists?

## ClickUp task

https://app.clickup.com/t/86ahcp5xu

---
_Generated by [Claude Code](https://claude.ai/code/session_017QniN1P9TVtsTb3SAiS1tN)_