### PR TITLE
[needs-clarification] 86ahcww74

### DIFF
--- a/.autofixer/clarification-86ahcww74.md
+++ b/.autofixer/clarification-86ahcww74.md
@@ -1,0 +1,6 @@
+# Autofixer Clarification — Task 86ahcww74
+
+This file was created solely to open a clarification draft PR.
+It can be deleted once the PR is reviewed and closed.
+
+ClickUp task: https://app.clickup.com/t/86ahcww74

--- a/.clarifications/86ahcww74.txt
+++ b/.clarifications/86ahcww74.txt
@@ -1,0 +1,3 @@
+Clarification needed for ClickUp task 86ahcww74.
+This file exists solely to allow a draft PR to be opened for review.
+See the PR body for details.


### PR DESCRIPTION
## Summary

ClickUp task `86ahcww74` was routed to the autofixer, but it does not contain a software engineering task. It is a **CRM contact record** for a person named Fabiano Oliveira at Irani.

**Task content (verbatim):**
> Driving AI adoption initiative at Irani. Presenting findings to Irani board next week (week of May 11). Strong champion candidate.

This is a sales/business-development entry in the Contacts list, not a development issue.

## Approach

No code was written. The autofixer stopped at step 2 (restate the problem) because the task contains no software engineering requirement.

## Files Changed and Why

- `.clarifications/86ahcww74.txt` — placeholder file added solely to allow this draft PR to be opened; should be deleted when closing/merging.

## Assumptions I Made

- The task ID `86ahcww74` was provided intentionally, not as a typo for a different task.

## What I Did NOT Do

- No production code was changed.
- No tests, configs, or CI files were touched.

## Open Questions for Review

1. Was this task ID sent by mistake? If so, which task was intended?
2. Is there a related engineering task that needs to be created and linked to this contact?
3. Should the autofixer be restricted from receiving tasks from the CRM/Contacts list to avoid future false triggers?

## ClickUp Task

https://app.clickup.com/t/86ahcww74

---
_Generated by [Claude Code](https://claude.ai/code/session_01319FJi7yyKBzGE5sBYhFfh)_