### PR TITLE
[needs-clarification] 86ahcwwad

### DIFF
--- a/claude-clarifications/86ahcwwad.md
+++ b/claude-clarifications/86ahcwwad.md
@@ -1,0 +1,6 @@
+# Clarification needed: ClickUp task 86ahcwwad
+
+This file was created by the clickup-autofixer to enable a draft PR.
+It should be deleted once the clarification is resolved.
+
+Task URL: https://app.clickup.com/t/86ahcwwad


### PR DESCRIPTION
## Summary

ClickUp task `86ahcwwad` ("Fabiano + Alex: AI adoption Irani") was routed to the autofixer but contains no actionable software development work.

## What the task contains

- **Type:** `meeting_note`
- **Status:** To do
- **Date:** May 5, 2026
- **Attendees:** Alex Netto (Blockful), Fabiano Oliveira (Irani)
- **Description:** Notes from a discovery conversation about AI adoption opportunities at Irani (Brazilian manufacturing). Three pilot candidates were identified: market intelligence, commercial operations, and IT access management. Next step is Fabiano presenting to the Irani board the week of May 11.

## Why no code was written

This task is a business meeting note — it documents a client discovery call outcome. There is no bug, feature request, or code change described anywhere in the task content. I cannot restate this as a software problem because it is not one.

## Open questions for review

1. Was this task routed to the autofixer by mistake? If so, which task was intended?
2. Is there a linked dev task (via the "Tasks" relationship field) that contains the actual engineering work?
3. Should the autofixer skip tasks with `task_type: meeting_note` in the future?

## What I did NOT do

- Write any code (none was needed or appropriate)
- Interpret the meeting notes as implicit requirements
- Guess at a related engineering task

## Files changed

- `claude-clarifications/86ahcwwad.md` — placeholder file to allow this draft PR to exist; should be deleted once clarification is resolved.

## Link to ClickUp task

https://app.clickup.com/t/86ahcwwad

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNhck27GEcEZEYtJukWBd4)_