### PR TITLE
[needs-clarification] 86ahd2tyf: task does not describe a software change

### DIFF
--- a/.claude/autofixer/86ahd2tyf.md
+++ b/.claude/autofixer/86ahd2tyf.md
@@ -1,0 +1,5 @@
+# Autofixer note: 86ahd2tyf
+
+This file was created by the clickup-autofixer skill to anchor the clarification PR.
+The linked ClickUp task (https://app.clickup.com/t/86ahd2tyf) is an Out-of-office
+request and does not contain a software requirement. See the PR body for details.

--- a/.claude/clickup-86ahd2tyf.md
+++ b/.claude/clickup-86ahd2tyf.md
@@ -1,0 +1,4 @@
+# Clarification needed: ClickUp task 86ahd2tyf
+
+This file was created by the ClickUp autofixer to enable a clarification draft PR.
+It can be deleted once the task is resolved or the correct task ID is provided.


### PR DESCRIPTION
## Summary

This draft PR was opened automatically by the clickup-autofixer skill because the linked ClickUp task does not contain enough information to produce a code change.

## What I found

- **Task ID:** 86ahd2tyf
- **Task title:** `pedro`
- **Project:** Out of office / Requests
- **Description:** `TCC 💀`
- **Assignee:** Pedro Binotto
- **Due date:** set (short window — looks like a PTO request)
- **Comments:** none

The task lives in the **"Out of office"** space and appears to be a PTO/absence request related to a Brazilian university thesis (TCC = Trabalho de Conclusão de Curso). There is no software requirement, bug report, or acceptance criteria present.

## Questions for review

1. Was this task linked to the autofixer by mistake? If so, please close this PR and link the correct task.
2. If there *is* a code change intended here, please update the ClickUp task with:
   - A clear problem statement
   - Expected behaviour / acceptance criteria
   - Relevant file paths or feature area

## Files changed and why

- `.claude/autofixer/86ahd2tyf.md` — placeholder anchor required to open a PR (GitHub requires at least one commit ahead of the base branch); contains no production code.

## Assumptions I made

- None — this PR deliberately makes no code assumptions.

## What I did NOT do

- No production code was written or modified.
- No tests were run (nothing to test).
- No assumptions were made about intent.

## Open questions for review

- Is this the correct ClickUp task? The task content looks like an HR/PTO entry, not an engineering ticket.
- Should the anchor file be deleted before merging? (Yes — close/discard this PR instead of merging.)

## ClickUp task

https://app.clickup.com/t/86ahd2tyf

---
_Generated by [Claude Code](https://claude.ai/code/session_013T84kWVezAbQE4mvbZguzf)_