### PR TITLE
[needs-clarification] 86ahd6x6a

### DIFF
--- a/.autofixer/86ahd6x6a.txt
+++ b/.autofixer/86ahd6x6a.txt
@@ -1,0 +1,1 @@
+Task 86ahd6x6a could not be fetched. See PR body for details.


### PR DESCRIPTION
## Summary

This is an automated clarification PR opened by the ClickUp autofixer because the referenced task could not be accessed.

## Problem

When attempting to fetch ClickUp task `86ahd6x6a` (also tried as `86AHD6X6A`), the API returned:

```
{"error": "Team not authorized"}
```

The authenticated ClickUp token belongs to workspace `90132341641` ("Workspace"), but task `86AHD6X6A` appears to belong to a **different team/workspace** that this token does not have access to.

## Questions for Review

1. **Does task `86ahd6x6a` belong to a different ClickUp workspace?** If so, the autofixer integration needs to be configured with a token that has access to that workspace.
2. **Was the task ID typed correctly?** Please double-check that `86ahd6x6a` is the intended task ID.
3. **Should a different ClickUp API token be used?** If the task lives in a separate workspace, the MCP ClickUp integration may need its credentials updated.

## What I Did NOT Do

- No code changes were made — this branch is identical to `dev`.
- No guesses were made about the intended change.

## Link

- ClickUp task: `86ahd6x6a` (inaccessible — see above)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ts4PachGnu8iDr1Xz8hCGg)_