### PR TITLE
[needs-clarification] 86ah795xv: refine front-end / UI

### DIFF
--- a/.claude/clickup-86ah795xv.md
+++ b/.claude/clickup-86ah795xv.md
@@ -1,0 +1,4 @@
+# Clarification placeholder for ClickUp task 86ah795xv
+
+This file was created by the ClickUp autofixer to satisfy the GitHub PR requirement of at least one commit.
+No functional code changes are included — see the PR description for why clarification is needed before any implementation.


### PR DESCRIPTION
## Summary

This draft PR was opened automatically by the ClickUp autofixer for task **[86ah795xv](https://app.clickup.com/t/86ah795xv)**. No functional code changes have been made. This is a clarification request — see questions below.

## Why I stopped without implementing

Three blockers prevented me from making any code changes:

1. **Task is already marked complete.** The ClickUp task has status `complete` (closed 2025-05-11). The description reads as a retrospective changelog of UI work already shipped, not a request for new changes.

2. **Wrong repository / project scope.** The task belongs to the **condo.forum** project (tag `condo.forum`, list `Sprint 1 (5/4 - 5/17)`). The `blockful/anticapture` repository is a governance-analytics platform, not the condo.forum app. I do not have access to a condo.forum repository.

3. **No actionable diff.** The description is a bullet-point summary spanning ~10 screens (sign-up flow, home page, topic detail, edit profile, condominium settings, invites, members, animations, accessibility, PWA icon). Implementing any of it without the target codebase would require pure guesswork.

## Files changed

- `.claude/clickup-86ah795xv.md` — placeholder file required by GitHub to open a PR from a branch with no functional changes. **This file should be deleted before merging.**

## Assumptions I made

- The task was routed to this repository by the autofixer trigger; it may belong to a different repo entirely.

## What I did NOT do

- No application source files were created, modified, or deleted.
- No tests were run or added.
- No dependency or config changes.

## Open questions for review

- Is this task tracking work **already done** elsewhere, or is it requesting new code in this repository?
- If new code is needed: which repository and branch should the autofixer target?
- If the task was misfiled: should it be closed/re-routed so the autofixer doesn't re-process it?

## Link

ClickUp task: https://app.clickup.com/t/86ah795xv

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgPWfDvKi2z7egLLg984is)_