### PR TITLE
86aharbjk: Voting Relayer — UI error messages & FE response design

### DIFF
--- a/apps/dashboard/features/governance/components/modals/VotingModal.tsx
+++ b/apps/dashboard/features/governance/components/modals/VotingModal.tsx
@@ -13,6 +13,7 @@ import type { ProposalDetails } from "@/features/governance/types";
 import { voteOnProposal } from "@/features/governance/utils/voteOnProposal";
 import { BadgeStatus } from "@/shared/components/design-system/badges/badge-status/BadgeStatus";
 import { Button } from "@/shared/components/design-system/buttons/button/Button";
+import { InlineAlert } from "@/shared/components/design-system/alerts/inline-alert/InlineAlert";
 import {
   DrawerContent,
   DrawerRoot,
@@ -29,6 +30,7 @@ interface VotingModalProps {
   rawVotingPower: string;
   decimals: number;
   daoId: DaoIdEnum;
+  relayerOpsRemaining?: number;
 }
 
 export const VotingModal = ({
@@ -39,6 +41,7 @@ export const VotingModal = ({
   rawVotingPower,
   decimals,
   daoId,
+  relayerOpsRemaining,
 }: VotingModalProps) => {
   const [vote, setVote] = useState<string>("");
   const [comment, setComment] = useState<string>("");
@@ -279,6 +282,15 @@ export const VotingModal = ({
               onChange={(e) => setComment(e.target.value)}
             />
           </div>
+
+          {relayerOpsRemaining !== undefined && (
+            <div className="px-4 pb-2">
+              <InlineAlert
+                variant="info"
+                text={`You have ${relayerOpsRemaining} free vote${relayerOpsRemaining === 1 ? "" : "s"} remaining today.`}
+              />
+            </div>
+          )}
         </>
       )}
 

--- a/apps/dashboard/features/governance/components/proposal-overview/ProposalHeader.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/ProposalHeader.tsx
@@ -22,6 +22,7 @@ interface ProposalHeaderProps {
   proposalStatus: string;
   snapshotLink?: string | null;
   isWhitelabel?: boolean;
+  isRelayerEligible?: boolean;
 }
 
 const ProposalHeaderAction = ({
@@ -30,12 +31,14 @@ const ProposalHeaderAction = ({
   proposalStatus,
   setIsVotingModalOpen,
   isWhitelabel,
+  isRelayerEligible,
 }: {
   address: string | undefined;
   supportValue: number | undefined;
   proposalStatus: string;
   setIsVotingModalOpen: (isOpen: boolean) => void;
   isWhitelabel: boolean;
+  isRelayerEligible?: boolean;
 }) => {
   const isOngoing = proposalStatus.toLowerCase() === "ongoing";
 
@@ -48,6 +51,11 @@ const ProposalHeaderAction = ({
             onClick={() => setIsVotingModalOpen(true)}
           >
             Cast your vote
+            {isRelayerEligible && (
+              <span className="rounded-sm bg-success/20 px-1 py-0.5 text-[10px] font-semibold uppercase leading-none text-success">
+                Free
+              </span>
+            )}
             <ArrowRight className="size-3.5" />
           </Button>
         );
@@ -85,6 +93,7 @@ export const ProposalHeader = ({
   proposalStatus,
   snapshotLink,
   isWhitelabel = false,
+  isRelayerEligible,
 }: ProposalHeaderProps) => {
   const pathname = usePathname();
   const supportValue =
@@ -150,6 +159,7 @@ export const ProposalHeader = ({
                 proposalStatus={proposalStatus}
                 setIsVotingModalOpen={setIsVotingModalOpen}
                 isWhitelabel={isWhitelabel}
+                isRelayerEligible={isRelayerEligible}
               />
             </>
           ) : snapshotLink ? (
@@ -170,6 +180,7 @@ export const ProposalHeader = ({
                 proposalStatus={proposalStatus}
                 setIsVotingModalOpen={setIsVotingModalOpen}
                 isWhitelabel={isWhitelabel}
+                isRelayerEligible={isRelayerEligible}
               />
             </>
           ) : (
@@ -195,6 +206,7 @@ export const ProposalHeader = ({
                 proposalStatus={proposalStatus}
                 setIsVotingModalOpen={setIsVotingModalOpen}
                 isWhitelabel={isWhitelabel}
+                isRelayerEligible={isRelayerEligible}
               />
               {address &&
                 proposalStatus === "succeeded" &&

--- a/apps/dashboard/features/governance/utils/voteOnProposal.ts
+++ b/apps/dashboard/features/governance/utils/voteOnProposal.ts
@@ -130,7 +130,24 @@ export const voteOnProposal = async (
     return transaction;
   } catch (error) {
     console.error(error);
-    showCustomToast("Failed to vote", "error");
+    const message =
+      error instanceof Error ? error.message.toLowerCase() : "";
+    if (message.includes("insufficient_voting_power")) {
+      showCustomToast(
+        "You don't have sufficient voting power to delegate.",
+        "error",
+      );
+    } else if (message.includes("daily_limit_reached")) {
+      showCustomToast(
+        "You've reached the maximum operations per day.",
+        "error",
+      );
+    } else {
+      showCustomToast(
+        "Something went wrong with your operation. Try again later.",
+        "error",
+      );
+    }
     return null;
   }
 };


### PR DESCRIPTION
## Summary

- Adds a **"Free" badge** on the "Cast your vote" button in `ProposalHeader` when the user qualifies for relayer-sponsored voting (`isRelayerEligible` prop).
- Adds an **InlineAlert** inside `VotingModal` showing how many free operations the user has left today (`relayerOpsRemaining` prop).
- Replaces the generic `"Failed to vote"` toast in `voteOnProposal.ts` with **three specific error messages** keyed on relayer error codes.

## Approach

All new props are **optional** — no existing callers are broken. The UI scaffolding is fully wired; only the data-fetching layer (relayer eligibility hook + remaining-ops count) still needs to be connected once the relayer API is available.

Error detection in `voteOnProposal.ts` uses `error.message.toLowerCase().includes(...)` matching against the relayer error codes `insufficient_voting_power` and `daily_limit_reached`. These string keys should match whatever the relayer API/SDK surfaces — **reviewers should confirm the exact error codes**.

## Files changed and why

| File | Change |
|------|--------|
| `apps/dashboard/features/governance/components/proposal-overview/ProposalHeader.tsx` | Added `isRelayerEligible?: boolean` prop to `ProposalHeaderProps` and `ProposalHeaderAction`; renders a small "FREE" pill badge inside the vote button when eligible. Prop forwarded to all three `ProposalHeaderAction` call sites. |
| `apps/dashboard/features/governance/components/modals/VotingModal.tsx` | Added `relayerOpsRemaining?: number` prop; renders an `InlineAlert` (info variant) below the comment textarea showing remaining daily operations. |
| `apps/dashboard/features/governance/utils/voteOnProposal.ts` | Replaced single-catch generic toast with three-branch error handling matching the copy finalized in the design task. |

## Assumptions I made

1. The relayer surfaces errors as `Error` objects whose `.message` contains the snake_case codes `insufficient_voting_power` and `daily_limit_reached`. If the relayer uses numeric codes, HTTP status codes, or a different message format, the `message.includes(...)` guards in `voteOnProposal.ts` need to be updated.
2. The minimum VP threshold ("X value is TBD" per the task) is not rendered in the insufficient-VP toast — it reads "You don't have sufficient voting power to delegate." without the minimum value. Once the threshold is decided, the string can be updated to include it.
3. The "free" badge and remaining-ops alert apply only to on-chain voting (via `VotingModal`). The delegation flow (`/features/holders-and-delegates/`) is a separate component and was intentionally left out of this PR to keep scope contained.

## What I did NOT do

- Wire up the `isRelayerEligible` and `relayerOpsRemaining` props to any actual data source — that requires a new hook (e.g. `useRelayerEligibility`) backed by the relayer API, which does not exist yet.
- Touch the Delegate button or drawer (`/features/holders-and-delegates/`) — the Final Decision says both Vote and Delegate need the free badge, but that component was out of scope for this PR.
- Add the insufficient-VP error case for delegation specifically (task copy mentions "delegate" in the error string, but the relayer API contract for delegation errors is unknown).

## Open questions for review

1. **Relayer error codes**: What exact error string/code does the relayer return for each failure case? The `message.includes(...)` matching in `voteOnProposal.ts` needs to match real codes.
2. **Minimum VP value**: When is the threshold finalized? Once known, update the insufficient-VP toast to include "You need a minimum X."
3. **Relayer data hook**: Who is implementing `useRelayerEligibility` and the remaining-ops endpoint? These hooks need to be created and passed down from the page component to `ProposalHeader` and `VotingModal`.
4. **Delegation component**: Should this PR be extended to cover the Delegate drawer, or tracked in a separate task?
5. **Error handling for delegation**: `voteOnProposal.ts` only handles vote transactions. Is there a `delegateViaRelayer` utility that also needs the same error handling?

## ClickUp task

https://app.clickup.com/t/86aharbjk

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9aJbNozd2bFF2cEE256qW)_