### PR TITLE
[needs-clarification] 86ahd766b: create post for sindicos

### DIFF
--- a/.claude/clarifications/86ahd766b.md
+++ b/.claude/clarifications/86ahd766b.md
@@ -1,0 +1,17 @@
+# Clarification Needed: ClickUp Task 86ahd766b
+
+**Task:** create post for sindicos  
+**ClickUp URL:** https://app.clickup.com/t/86ahd766b  
+**ClickUp List:** Social Media Design  
+**Status:** writing copy
+
+## Why this PR exists
+
+This task is a social media content/design request — not a code change.
+The autofixer cannot generate or schedule social media posts.
+
+## Questions for the team
+
+1. Was this task routed to the autofixer by mistake? It lives in the "Social Media Design" list, not in a dev/engineering list.
+2. If there *is* a code component (e.g., adding a new DAO, updating copy in the dashboard), please clarify the exact files and content to change.
+3. Who is the intended audience for "sindicos" — is this a new target segment that needs a landing page, a dashboard label update, or purely external marketing content?


### PR DESCRIPTION
## Summary

ClickUp task **86ahd766b** ("create post for sindicos") was routed to the code autofixer, but it is a **social media content/design task** — not a code change. There is nothing to implement in this repository.

## Approach

No code was written. This PR exists only to surface the routing issue and ask for clarification before any work proceeds.

## Files changed and why

- `.claude/clarifications/86ahd766b.md` — documents the situation and lists open questions for the team.

## Assumptions I made

- "Sindicos" refers to building/condo administrators (Portuguese/Spanish), which appears to be a target audience for a marketing post, not an engineering deliverable.
- The task belongs to the **Social Media Design** ClickUp list, which is outside the scope of this autofixer.

## What I did NOT do

- Did not write any code.
- Did not modify any dashboard, API, indexer, or gateway files.
- Did not create or schedule any social media content.

## Open questions for review

1. Was this task sent to the autofixer by mistake? It lives in the "Social Media Design" list, not an engineering list.
2. Is there a code component hidden in this task (e.g., new dashboard copy, a new DAO config, an updated label)? If so, please add that detail to the ClickUp task and re-trigger.
3. Who should handle social media content tasks — a designer, copywriter, or a different automation?

## ClickUp task

https://app.clickup.com/t/86ahd766b

---
_Generated by [Claude Code](https://claude.ai/code/session_012huNWE7q9BbMzkCZZRs4UA)_