### PR TITLE
[needs-clarification] 86ahcpav4

### DIFF
--- a/.claude/clickup-86ahcpav4-clarification.md
+++ b/.claude/clickup-86ahcpav4-clarification.md
@@ -1,4 +1,0 @@
-# Clarification placeholder for ClickUp task 86ahcpav4
-
-This file exists solely to allow a draft PR to be opened.
-It should be deleted once the task is re-routed or clarified.

--- a/.claude/clickup-86ahcpav4-clarification.md
+++ b/.claude/clickup-86ahcpav4-clarification.md
@@ -1,0 +1,4 @@
+# Clarification placeholder for ClickUp task 86ahcpav4
+
+This file exists solely to allow a draft PR to be opened.
+It should be deleted once the task is re-routed or clarified.

--- a/tmp/clickup-86ahcpav4-clarification.md
+++ b/tmp/clickup-86ahcpav4-clarification.md
@@ -1,0 +1,4 @@
+# Clarification placeholder — ClickUp task 86ahcpav4
+
+This file exists solely so a draft PR can be opened for a non-code task.
+Delete this file once the task is re-routed or clarified.


### PR DESCRIPTION
## Summary

ClickUp task **86ahcpav4** ("create post for sindicos") was routed to the `clickup-autofixer` skill, which produces code-level PRs. After inspecting the task it is clearly a **social media content / design task** — not a software-engineering task. No meaningful code changes are proposed here.

---

## Task as written

> **Title:** create post for sindicos
> **Description:** should say to the sindicos that we're cool and use the template with a image
> **List:** Social Media Design
> **Tag:** condoforum
> **Status:** writing copy

---

## Why this is a clarification PR, not a fix

The task requests creating a social-media post (copy + image) for an audience called *sindicos* (building managers). That work belongs in a design tool or content pipeline, not in this codebase. The `clickup-autofixer` skill only modifies source code.

---

## Open questions for the team

1. Was this task accidentally routed to the autofixer? If so, which pipeline should Social Media Design tasks use?
2. Is there a related **code** task (e.g. a new landing-page section, a component, or a copy change) that should have been filed separately?
3. If there is a code component, please re-file a task with the specific files and copy to change, and re-trigger the autofixer.

---

## Files changed and why

| File | Reason |
|------|--------|
| `tmp/clickup-86ahcpav4-clarification.md` | Placeholder required to open this PR; delete once task is re-routed. |

## What I did NOT do

- Write or modify any source files.
- Guess at a code interpretation of a design/content task.

---

## Link to ClickUp task

https://app.clickup.com/t/86ahcpav4

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxTMvVYwh2i9gb4Wak9YGN)_