### PR TITLE
Downgrade Chainstack subscription

### DIFF
--- a/apps/dashboard/shared/dao-config/ens.ts
+++ b/apps/dashboard/shared/dao-config/ens.ts
@@ -24,7 +24,7 @@ export const ENS: DaoConfiguration = {
   forumLink: "https://discuss.ens.domains/",
   icon: EnsIcon,
   ogIcon: EnsOgIcon,
-  hostnames: ["staging.anticapture.com"],
+  hostnames: ["ens.gov.blockful.io"],
   whitelabel: {},
   daoOverview: {
     token: "ERC20",

--- a/infra/erpc/erpc.dev.yaml
+++ b/infra/erpc/erpc.dev.yaml
@@ -233,7 +233,7 @@ rateLimiters:
     - id: chainstack
       rules:
         - method: "*"
-          maxCount: 80
+          maxCount: 50
           period: 1s
           waitTime: 30s
 

--- a/infra/erpc/erpc.prod.yaml
+++ b/infra/erpc/erpc.prod.yaml
@@ -233,7 +233,7 @@ rateLimiters:
     - id: chainstack
       rules:
         - method: "*"
-          maxCount: 320
+          maxCount: 170
           period: 1s
           waitTime: 30s
 

--- a/infra/erpc/erpc.prod.yaml
+++ b/infra/erpc/erpc.prod.yaml
@@ -233,7 +233,7 @@ rateLimiters:
     - id: chainstack
       rules:
         - method: "*"
-          maxCount: 170
+          maxCount: 200
           period: 1s
           waitTime: 30s
 


### PR DESCRIPTION
Since Nodeful is taking most of the requests, we could downgrade the Chainstack subscription from the Pro back to the Growth one.

<img width="438" height="283" alt="image" src="https://github.com/user-attachments/assets/73404876-3a27-4050-8655-e835732270b6" />
