### PR TITLE
86ahfzz4n: Fix missing JSX key props in PanelSection Carousel slides

### DIFF
--- a/.changeset/fix-panel-section-jsx-keys.md
+++ b/.changeset/fix-panel-section-jsx-keys.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+fix(dashboard): add missing JSX key props in PanelSection Carousel slides

--- a/apps/dashboard/features/panel/PanelSection.tsx
+++ b/apps/dashboard/features/panel/PanelSection.tsx
@@ -27,9 +27,9 @@ export const PanelSection = () => {
         <div className="lg:hidden">
           <Carousel
             slides={[
-              <DaoProtectionLevels />,
-              <TreasuryMonitoring />,
-              <DelegatedSupplyHistory />,
+              <DaoProtectionLevels key="dao-protection-levels" />,
+              <TreasuryMonitoring key="treasury-monitoring" />,
+              <DelegatedSupplyHistory key="delegated-supply-history" />,
             ]}
           />
         </div>


### PR DESCRIPTION
## Summary

Adds stable, unique `key` props to the three JSX elements rendered inside the `slides` array literal passed to `<Carousel>` in `PanelSection.tsx`, resolving 3 react-doctor errors about missing keys.

## Approach

React requires a `key` prop on every element in an array or iterator to correctly reconcile list items across re-renders. The `slides` prop on `<Carousel>` is an array literal — React treats each element as a list item, so keys are mandatory. I used descriptive string keys derived from the component names (e.g. `"dao-protection-levels"`) since these slots are static and never reordered, making them stable and unique.

## Files changed and why

- `apps/dashboard/features/panel/PanelSection.tsx` — added `key` props to `<DaoProtectionLevels />`, `<TreasuryMonitoring />`, and `<DelegatedSupplyHistory />` inside the `slides` array (line 30).

## Assumptions I made

- The three carousel slides are static and never dynamically reordered, so descriptive string literals are appropriate keys (no need for data-derived IDs).
- Only the three elements in the `slides` array were missing keys; the grid layout below (`hidden gap-2 lg:grid`) renders the same components individually (not in an array), so no keys are needed there.

## What I did NOT do

- Did not modify the `Carousel` component itself.
- Did not add or change tests.
- Did not change any other files.

## Open questions for review

- None. The fix is mechanical and matches the react-doctor report exactly.

## ClickUp task

https://app.clickup.com/t/86ahfzz4n

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYbjbAYPLXrsX9cDwYpe6D)_