### PR TITLE
86aej7zj1: add home screen app icon and web manifest

### DIFF
--- a/.changeset/add-home-screen-app-icon.md
+++ b/.changeset/add-home-screen-app-icon.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+feat(dashboard): add home screen app icon and web manifest for PWA support

--- a/apps/dashboard/app/apple-icon.tsx
+++ b/apps/dashboard/app/apple-icon.tsx
@@ -1,0 +1,37 @@
+import { ImageResponse } from "next/og"
+
+export const size = { width: 180, height: 180 }
+export const contentType = "image/png"
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#09090B",
+      }}
+    >
+      <svg
+        width={126}
+        height={126}
+        viewBox="0 0 36 36"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M25 30L20.9274 6H15.6969L13.0791 19.3897L11 30H15.4301L18.2794 15.0173L18.954 19.4662L19.2611 21.5567L20.5347 30H25Z"
+          fill="#EC762E"
+        />
+        <path d="M11 2H2V11" stroke="#EC762E" strokeWidth="3.5" />
+        <path d="M34 11L34 2L25 2" stroke="#EC762E" strokeWidth="3.5" />
+        <path d="M25 34L34 34L34 25" stroke="#EC762E" strokeWidth="3.5" />
+        <path d="M2 25L2 34L11 34" stroke="#EC762E" strokeWidth="3.5" />
+      </svg>
+    </div>,
+    { ...size },
+  )
+}

--- a/apps/dashboard/app/icon1.tsx
+++ b/apps/dashboard/app/icon1.tsx
@@ -1,9 +1,9 @@
 import { ImageResponse } from "next/og";
 
-export const size = { width: 180, height: 180 };
+export const size = { width: 192, height: 192 };
 export const contentType = "image/png";
 
-export default function AppleIcon() {
+export default function Icon192() {
   return new ImageResponse(
     <div
       style={{
@@ -16,8 +16,8 @@ export default function AppleIcon() {
       }}
     >
       <svg
-        width={126}
-        height={126}
+        width={134}
+        height={134}
         viewBox="0 0 36 36"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"

--- a/apps/dashboard/app/icon2.tsx
+++ b/apps/dashboard/app/icon2.tsx
@@ -1,9 +1,9 @@
 import { ImageResponse } from "next/og";
 
-export const size = { width: 180, height: 180 };
+export const size = { width: 512, height: 512 };
 export const contentType = "image/png";
 
-export default function AppleIcon() {
+export default function Icon512() {
   return new ImageResponse(
     <div
       style={{
@@ -16,8 +16,8 @@ export default function AppleIcon() {
       }}
     >
       <svg
-        width={126}
-        height={126}
+        width={358}
+        height={358}
         viewBox="0 0 36 36"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"

--- a/apps/dashboard/app/manifest.ts
+++ b/apps/dashboard/app/manifest.ts
@@ -20,7 +20,7 @@ export default function manifest(): MetadataRoute.Manifest {
         src: "/icon.svg",
         sizes: "any",
         type: "image/svg+xml",
-        purpose: "any maskable",
+        purpose: "maskable",
       },
     ],
   }

--- a/apps/dashboard/app/manifest.ts
+++ b/apps/dashboard/app/manifest.ts
@@ -1,4 +1,4 @@
-import type { MetadataRoute } from "next"
+import type { MetadataRoute } from "next";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
@@ -17,11 +17,23 @@ export default function manifest(): MetadataRoute.Manifest {
         type: "image/png",
       },
       {
+        src: "/icon1",
+        sizes: "192x192",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/icon2",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
         src: "/icon.svg",
         sizes: "any",
         type: "image/svg+xml",
         purpose: "any",
       },
     ],
-  }
+  };
 }

--- a/apps/dashboard/app/manifest.ts
+++ b/apps/dashboard/app/manifest.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from "next"
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Anticapture",
+    short_name: "Anticapture",
+    description:
+      "DAO governance security platform that quantifies hostile takeover risk, detects governance capture, and tracks resilience metrics across major DAOs.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#09090B",
+    theme_color: "#EC762E",
+    icons: [
+      {
+        src: "/apple-icon",
+        sizes: "180x180",
+        type: "image/png",
+      },
+      {
+        src: "/icon.svg",
+        sizes: "any",
+        type: "image/svg+xml",
+        purpose: "any maskable",
+      },
+    ],
+  }
+}

--- a/apps/dashboard/app/manifest.ts
+++ b/apps/dashboard/app/manifest.ts
@@ -20,7 +20,7 @@ export default function manifest(): MetadataRoute.Manifest {
         src: "/icon.svg",
         sizes: "any",
         type: "image/svg+xml",
-        purpose: "maskable",
+        purpose: "any",
       },
     ],
   }


### PR DESCRIPTION
## Summary

- Adds `apple-icon.tsx` so iOS Safari "Add to Home Screen" displays the Anticapture brand icon instead of a blank/screenshot placeholder
- Adds `manifest.ts` so Android Chrome and other PWA-capable browsers recognise the app with a name, theme colour, and icon when saved to the home screen
- Both use the existing Anticapture logo (the `A` letterform with corner brackets, `#EC762E` on `#09090B`) already present in `app/icon.svg`

## Approach

Next.js App Router has built-in conventions for both artefacts:

| File | What Next.js does |
|---|---|
| `app/apple-icon.tsx` | Generates `/apple-icon` route (PNG via `ImageResponse`) and injects `<link rel="apple-touch-icon">` automatically |
| `app/manifest.ts` | Generates `/manifest.webmanifest` and injects `<link rel="manifest">` automatically |

`apple-icon.tsx` renders the inline SVG paths (copied verbatim from `app/icon.svg`) at 126×126 px inside a 180×180 dark background square using the same `ImageResponse` / Satori pattern already used in `shared/og/root-page-og-image.tsx`.

## Files changed and why

| File | Why |
|---|---|
| `apps/dashboard/app/apple-icon.tsx` | **New.** Generates the iOS home screen icon (180×180 PNG) |
| `apps/dashboard/app/manifest.ts` | **New.** Declares the PWA web manifest — name, theme/background colours, icon references |

## Assumptions I made

- The logo to use is the existing `icon.svg` (the `A` + corner brackets). The ClickUp attachment was behind authentication and could not be fetched, but the task description references brand assets and the existing SVG matches.
- `#09090B` background matches the OG image background already used in this project.
- `app/icon.svg` stays as-is (it already handles the browser-tab favicon).

## What I did NOT do

- Did NOT add 192×192 or 512×512 PNG icons. Android Chrome may still show the icon via the SVG entry (`"sizes": "any"`) in the manifest, but for maximum Android compatibility a future pass should add those PNG sizes (e.g. via additional `icon.tsx` routes).
- Did NOT modify `layout.tsx` — Next.js injects the manifest and apple-icon links automatically from the file-system conventions.
- Did NOT touch CI, infra, migrations, or `.github/` files.

## Open questions for review

1. Should the manifest include `192x192` and `512x512` PNG variants? If yes, we can add a second `icon-192.tsx` / `icon-512.tsx` in a follow-up.
2. Is `display: "standalone"` correct, or should it be `"minimal-ui"` / `"browser"`?
3. The `purpose: "any maskable"` on the SVG icon assumes the icon has safe-zone padding — worth double-checking against the Maskable.app tool.

## ClickUp task

https://app.clickup.com/t/86aej7zj1

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6RybtUM7xSF9QtH6EUyTg)_