### PR TITLE
ci: skip changeset and API contract checks on dev→main release PRs

### DIFF
--- a/.github/workflows/api-contract-updates.yaml
+++ b/.github/workflows/api-contract-updates.yaml
@@ -3,6 +3,8 @@ name: API Contract Updates
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    branches-ignore:
+      - main
 
 jobs:
   detect-contract-updates:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   changeset-path-filter:
     name: Detect changeset requirement
+    if: github.base_ref != 'main'
     runs-on: ubuntu-latest
     outputs:
       needs_changeset: ${{ steps.filter.outputs.needs_changeset }}


### PR DESCRIPTION
These checks fail on the weekly dev→main release PR because the changesets in its diff have already been consumed on dev. Gate them on base_ref != 'main' so release PRs report a clean status.