### PR TITLE
86agzktge: Migrate Overview to Kubb SDK

### DIFF
--- a/.changeset/overview-kubb-sdk-migration.md
+++ b/.changeset/overview-kubb-sdk-migration.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": minor
+---
+
+Migrate DAO Overview data hooks from GraphQL client to Kubb SDK REST API. The `useDaoOverviewData`, `useDaoTreasuryStats`, `useCompareTreasury`, and `useLastProposals` hooks now use `@anticapture/client` hooks instead of `@anticapture/graphql-client`.

--- a/apps/dashboard/features/dao-overview/hooks/useCompareTreasury.ts
+++ b/apps/dashboard/features/dao-overview/hooks/useCompareTreasury.ts
@@ -1,7 +1,5 @@
-import {
-  DaysWindow,
-  useCompareTreasuryQuery,
-} from "@anticapture/graphql-client/hooks";
+import type { CompareTreasuryPathParamsDaoEnumKey } from "@anticapture/client";
+import { useCompareTreasury as useCompareTreasuryHook } from "@anticapture/client/hooks";
 
 import type { DaoIdEnum } from "@/shared/types/daos";
 import type { TimeInterval } from "@/shared/types/enums";
@@ -23,21 +21,20 @@ export const useCompareTreasury = (
   daoId: DaoIdEnum,
   days: TimeInterval,
 ): UseCompareTreasuryResult => {
-  const { data, loading, error, refetch } = useCompareTreasuryQuery({
-    variables: {
-      days: DaysWindow[days],
-    },
-    context: {
-      headers: {
-        "anticapture-dao-id": daoId,
-      },
-    },
-  });
+  const {
+    data,
+    isLoading,
+    error,
+    refetch,
+  } = useCompareTreasuryHook(
+    daoId.toLowerCase() as CompareTreasuryPathParamsDaoEnumKey,
+    { days },
+  );
 
   return {
-    data: data?.compareTreasury as CompareTreasury | null,
-    loading,
-    error: error || null,
+    data: data as CompareTreasury | null,
+    loading: isLoading,
+    error: error instanceof Error ? error : error ? new Error(String(error)) : null,
     refetch: () => refetch(),
   };
 };

--- a/apps/dashboard/features/dao-overview/hooks/useDaoOverviewData.ts
+++ b/apps/dashboard/features/dao-overview/hooks/useDaoOverviewData.ts
@@ -1,18 +1,22 @@
+import type {
+  CompareActiveSupplyPathParamsDaoEnumKey,
+  CompareAverageTurnoutPathParamsDaoEnumKey,
+  DaoPathParamsDaoEnumKey,
+  TokenPathParamsDaoEnumKey,
+  VotingPowersPathParamsDaoEnumKey,
+} from "@anticapture/client";
 import {
-  OrderDirection,
-  useGetDelegatesQuery,
-} from "@anticapture/graphql-client/hooks";
+  useCompareActiveSupply,
+  useCompareAverageTurnout,
+  useDao,
+  useToken,
+  useVotingPowers,
+} from "@anticapture/client/hooks";
 import { formatUnits } from "viem";
 
 import { useDaoTreasuryStats } from "@/features/dao-overview/hooks/useDaoTreasuryStats";
 import { useTopDelegatesToPass } from "@/features/dao-overview/hooks/useTopDelegatesToPass";
 import type { DaoConfiguration } from "@/shared/dao-config/types";
-import {
-  useDaoData,
-  useActiveSupply,
-  useAverageTurnout,
-  useTokenData,
-} from "@/shared/hooks";
 import type { DaoIdEnum } from "@/shared/types/daos";
 import { TimeInterval } from "@/shared/types/enums";
 import { formatNumberUserReadable } from "@/shared/utils";
@@ -25,58 +29,60 @@ export const useDaoOverviewData = ({
   daoConfig: DaoConfiguration;
 }) => {
   const { decimals } = daoConfig;
+  const daoKey = daoId.toLowerCase();
 
-  const daoData = useDaoData(daoId);
-  const activeSupply = useActiveSupply(daoId, TimeInterval.NINETY_DAYS);
-  const averageTurnout = useAverageTurnout(daoId, TimeInterval.NINETY_DAYS);
-  const tokenData = useTokenData(daoId);
-
-  const delegates = useGetDelegatesQuery({
-    variables: {
-      orderDirection: OrderDirection.Desc,
+  const { data: daoData, isLoading: daoLoading } = useDao(
+    daoKey as DaoPathParamsDaoEnumKey,
+  );
+  const { data: activeSupplyData, isLoading: activeSupplyLoading } =
+    useCompareActiveSupply(
+      daoKey as CompareActiveSupplyPathParamsDaoEnumKey,
+      { days: TimeInterval.NINETY_DAYS },
+    );
+  const { data: averageTurnoutData, isLoading: averageTurnoutLoading } =
+    useCompareAverageTurnout(
+      daoKey as CompareAverageTurnoutPathParamsDaoEnumKey,
+      { days: TimeInterval.NINETY_DAYS },
+    );
+  const { data: tokenData, isLoading: tokenLoading } = useToken(
+    daoKey as TokenPathParamsDaoEnumKey,
+    { currency: "usd" },
+  );
+  const { data: votingPowersData, isLoading: delegatesLoading } =
+    useVotingPowers(daoKey as VotingPowersPathParamsDaoEnumKey, {
       limit: 20,
-      addresses: null,
-      fromDate: null,
-      toDate: null,
-    },
-    context: {
-      headers: {
-        "anticapture-dao-id": daoId,
-      },
-    },
-    notifyOnNetworkStatusChange: true,
-    fetchPolicy: "cache-and-network", // Always check network for fresh data
-  });
+      orderDirection: "desc",
+    });
 
-  const totalSupply = tokenData.data?.totalSupply;
+  const totalSupply = tokenData?.totalSupply;
 
   const proposalThresholdPercentage =
-    daoData?.data?.proposalThreshold && totalSupply
+    daoData?.proposalThreshold && totalSupply
       ? (
           (Number(
-            formatUnits(BigInt(daoData.data.proposalThreshold), decimals),
+            formatUnits(BigInt(daoData.proposalThreshold), decimals),
           ) /
             Number(formatUnits(BigInt(totalSupply), decimals))) *
           100
         ).toString()
       : "0";
 
-  const proposalThresholdValue = daoData?.data?.proposalThreshold
-    ? `${formatNumberUserReadable(Number(formatUnits(BigInt(daoData.data.proposalThreshold), decimals)))}`
+  const proposalThresholdValue = daoData?.proposalThreshold
+    ? `${formatNumberUserReadable(Number(formatUnits(BigInt(daoData.proposalThreshold), decimals)))}`
     : "No Threshold";
 
   const quorumValue = Number(
-    formatUnits(BigInt(daoData.data?.quorum || 0), decimals),
+    formatUnits(BigInt(daoData?.quorum || 0), decimals),
   );
 
   const treasuryStats = useDaoTreasuryStats({
     daoId,
-    tokenData,
+    tokenData: { data: tokenData ?? null },
   });
 
   const topDelegatesToPass = useTopDelegatesToPass({
     topDelegates:
-      delegates.data?.votingPowers?.items.filter(
+      votingPowersData?.items.filter(
         (item) => item !== null && item !== undefined,
       ) || [],
     quorumValue,
@@ -84,16 +90,16 @@ export const useDaoOverviewData = ({
   });
 
   return {
-    daoData: daoData.data,
+    daoData: daoData ?? null,
     activeSupply: Number(
-      formatUnits(BigInt(activeSupply.data?.activeSupply || 0), decimals),
+      formatUnits(BigInt(activeSupplyData?.activeSupply || 0), decimals),
     ),
     delegatedSupply: Number(
-      formatUnits(BigInt(tokenData.data?.delegatedSupply || 0), decimals),
+      formatUnits(BigInt(tokenData?.delegatedSupply || 0), decimals),
     ),
     averageTurnout: Number(
       formatUnits(
-        BigInt(averageTurnout.data?.currentAverageTurnout || 0),
+        BigInt(averageTurnoutData?.currentAverageTurnout || 0),
         decimals,
       ),
     ),
@@ -103,14 +109,14 @@ export const useDaoOverviewData = ({
     proposalThresholdValue,
     proposalThresholdPercentage,
     quorumValueFormatted: quorumValue,
-    votingPeriod: Number(daoData.data?.votingPeriod ?? 0),
-    votingDelay: Number(daoData.data?.votingDelay ?? 0),
-    timelockDelay: Number(daoData.data?.timelockDelay ?? 0),
+    votingPeriod: Number(daoData?.votingPeriod ?? 0),
+    votingDelay: Number(daoData?.votingDelay ?? 0),
+    timelockDelay: Number(daoData?.timelockDelay ?? 0),
     isLoading:
-      daoData.loading ||
-      activeSupply.isLoading ||
-      averageTurnout.isLoading ||
-      tokenData.isLoading ||
-      delegates.loading,
+      daoLoading ||
+      activeSupplyLoading ||
+      averageTurnoutLoading ||
+      tokenLoading ||
+      delegatesLoading,
   };
 };

--- a/apps/dashboard/features/dao-overview/hooks/useDaoTreasuryStats.ts
+++ b/apps/dashboard/features/dao-overview/hooks/useDaoTreasuryStats.ts
@@ -1,7 +1,16 @@
 import { useMemo } from "react";
 
-import { useTreasury } from "@/features/attack-profitability/hooks/useTreasury";
-import type { TokenDataResponse } from "@/shared/hooks";
+import type {
+  GetDaoTokenTreasuryPathParamsDaoEnumKey,
+  GetLiquidTreasuryPathParamsDaoEnumKey,
+  GetTotalTreasuryPathParamsDaoEnumKey,
+} from "@anticapture/client";
+import {
+  useGetDaoTokenTreasury,
+  useGetLiquidTreasury,
+  useGetTotalTreasury,
+} from "@anticapture/client/hooks";
+
 import type { DaoIdEnum } from "@/shared/types/daos";
 import { TimeInterval } from "@/shared/types/enums/TimeInterval";
 
@@ -10,33 +19,28 @@ export const useDaoTreasuryStats = ({
   tokenData,
 }: {
   daoId: DaoIdEnum;
-  tokenData: { data?: TokenDataResponse | null };
+  tokenData: { data?: { price?: string | null } | null };
 }) => {
-  // Use 7 days (minimum supported) with desc order to get most recent first
-  const { data: liquidTreasury } = useTreasury(
-    daoId,
-    "liquid",
-    TimeInterval.SEVEN_DAYS,
-    "desc",
+  const daoKey = daoId.toLowerCase();
+
+  const { data: liquidTreasuryData } = useGetLiquidTreasury(
+    daoKey as GetLiquidTreasuryPathParamsDaoEnumKey,
+    { days: TimeInterval.SEVEN_DAYS, orderDirection: "desc" },
   );
-  const { data: tokenTreasury } = useTreasury(
-    daoId,
-    "dao-token",
-    TimeInterval.SEVEN_DAYS,
-    "desc",
+  const { data: tokenTreasuryData } = useGetDaoTokenTreasury(
+    daoKey as GetDaoTokenTreasuryPathParamsDaoEnumKey,
+    { days: TimeInterval.SEVEN_DAYS, orderDirection: "desc" },
   );
-  const { data: allTreasury } = useTreasury(
-    daoId,
-    "total",
-    TimeInterval.SEVEN_DAYS,
-    "desc",
+  const { data: allTreasuryData } = useGetTotalTreasury(
+    daoKey as GetTotalTreasuryPathParamsDaoEnumKey,
+    { days: TimeInterval.SEVEN_DAYS, orderDirection: "desc" },
   );
 
   return useMemo(() => {
     const lastPrice = Number(tokenData.data?.price) || 0;
-    const liquidValue = liquidTreasury[0]?.value ?? 0;
-    const tokenValue = tokenTreasury[0]?.value ?? 0;
-    const totalValue = allTreasury[0]?.value ?? 0;
+    const liquidValue = liquidTreasuryData?.items[0]?.value ?? 0;
+    const tokenValue = tokenTreasuryData?.items[0]?.value ?? 0;
+    const totalValue = allTreasuryData?.items[0]?.value ?? 0;
 
     const liquidTreasuryAllPercent = totalValue
       ? Math.round((tokenValue / totalValue) * 100).toString()
@@ -48,5 +52,5 @@ export const useDaoTreasuryStats = ({
       liquidTreasuryAllValue: totalValue,
       liquidTreasuryAllPercent,
     };
-  }, [liquidTreasury, tokenTreasury, allTreasury, tokenData]);
+  }, [liquidTreasuryData, tokenTreasuryData, allTreasuryData, tokenData]);
 };

--- a/apps/dashboard/features/dao-overview/hooks/useLastProposals.ts
+++ b/apps/dashboard/features/dao-overview/hooks/useLastProposals.ts
@@ -1,56 +1,82 @@
-import {
-  OrderDirection,
-  useGetProposalsFromDaoQuery,
-} from "@anticapture/graphql-client/hooks";
-import type { ApolloError } from "@apollo/client";
+import type { OnchainProposal, ProposalsPathParamsDaoEnumKey } from "@anticapture/client";
+import { useProposals } from "@anticapture/client/hooks";
 import { useMemo } from "react";
+import { formatUnits } from "viem";
 
 import type { Proposal as GovernanceProposal } from "@/features/governance/types";
-import { transformToGovernanceProposal } from "@/features/governance/utils/transformToGovernanceProposal";
+import {
+  getTimeText,
+  getProposalStatus,
+  getProposalState,
+} from "@/features/governance/utils";
 import daoConfig from "@/shared/dao-config";
 import type { DaoIdEnum } from "@/shared/types/daos";
 
 export interface UseLastProposalsResult {
   proposals: GovernanceProposal[];
   loading: boolean;
-  error: ApolloError | undefined;
+  error: Error | null;
 }
 
 const LAST_PROPOSALS_LIMIT = 3;
 
-/**
- * Hook to fetch the last 3 proposals for a DAO.
- * This is a simplified version of useProposals without pagination.
- */
+const transformProposal = (
+  proposal: OnchainProposal,
+  decimals: number,
+): GovernanceProposal => {
+  const forVotes = Number(formatUnits(BigInt(proposal.forVotes || "0"), decimals));
+  const againstVotes = Number(formatUnits(BigInt(proposal.againstVotes || "0"), decimals));
+  const abstainVotes = Number(formatUnits(BigInt(proposal.abstainVotes || "0"), decimals));
+  const quorum = Number(formatUnits(BigInt(proposal.quorum || "0"), decimals));
+  const total = forVotes + againstVotes + abstainVotes;
+  const forPercentage = total > 0 ? (forVotes / total) * 100 : 0;
+  const againstPercentage = total > 0 ? (againstVotes / total) * 100 : 0;
+  const timeText = getTimeText(
+    proposal.startTimestamp.toString(),
+    proposal.endTimestamp.toString(),
+  );
+
+  return {
+    ...proposal,
+    title: proposal.title || "Untitled Proposal",
+    status: getProposalStatus(proposal.status),
+    state: getProposalState(proposal.status),
+    proposer: proposal.proposerAccountId,
+    votes: {
+      for: forVotes.toFixed(2),
+      against: againstVotes.toFixed(2),
+      total: total.toFixed(2),
+      forPercentage: forPercentage.toFixed(0),
+      againstPercentage: againstPercentage.toFixed(0),
+    },
+    quorum: quorum.toFixed(2),
+    timeText,
+    values: proposal.values,
+    targets: proposal.targets,
+  } as unknown as GovernanceProposal;
+};
+
 export const useLastProposals = (daoId: DaoIdEnum): UseLastProposalsResult => {
   const { decimals } = daoConfig[daoId];
 
-  const { data, loading, error } = useGetProposalsFromDaoQuery({
-    variables: {
+  const { data, isLoading, error } = useProposals(
+    daoId.toLowerCase() as ProposalsPathParamsDaoEnumKey,
+    {
       skip: 0,
       limit: LAST_PROPOSALS_LIMIT,
-      orderDirection: OrderDirection.Desc,
-      status: null,
-      fromDate: null,
+      orderDirection: "desc",
     },
-    context: {
-      headers: {
-        "anticapture-dao-id": daoId,
-      },
-    },
-  });
+  );
 
   const proposals = useMemo(() => {
-    const rawProposals = data?.proposals?.items || [];
-
-    return rawProposals
-      .filter((proposal) => proposal !== null)
-      .map((proposal) => transformToGovernanceProposal(proposal, decimals));
+    return (data?.items ?? []).map((proposal) =>
+      transformProposal(proposal, decimals),
+    );
   }, [data, decimals]);
 
   return {
     proposals,
-    loading,
-    error,
+    loading: isLoading,
+    error: error instanceof Error ? error : error ? new Error(String(error)) : null,
   };
 };


### PR DESCRIPTION
## Summary

- Replaces GraphQL client calls in 4 DAO Overview hooks with Kubb SDK REST hooks from `@anticapture/client/hooks`
- Migrates `useDaoOverviewData`, `useDaoTreasuryStats`, `useCompareTreasury`, and `useLastProposals` off Apollo/GraphQL
- Public API of each hook is preserved — components consume the same return shape

## Approach

Each hook was mapped from its GraphQL operation to the equivalent REST endpoint:

| Hook | GraphQL query | REST hook (Kubb SDK) |
|---|---|---|
| `useDaoOverviewData` | `useGetDelegatesQuery` | `useVotingPowers` |
| `useDaoOverviewData` | `useGetDaoDataQuery` (via `useDaoData`) | `useDao` |
| `useDaoOverviewData` | `useCompareActiveSupplyQuery` (via `useActiveSupply`) | `useCompareActiveSupply` |
| `useDaoOverviewData` | `useCompareAverageTurnoutQuery` (via `useAverageTurnout`) | `useCompareAverageTurnout` |
| `useDaoOverviewData` | `useTokenDataQuery` (via `useTokenData`) | `useToken` |
| `useDaoTreasuryStats` | `useTreasury` (liquid/dao-token/total) | `useGetLiquidTreasury`, `useGetDaoTokenTreasury`, `useGetTotalTreasury` |
| `useCompareTreasury` | `useCompareTreasuryQuery` | `useCompareTreasury` (Kubb, aliased) |
| `useLastProposals` | `useGetProposalsFromDaoQuery` | `useProposals` |

The `DaysWindow` GraphQL enum is replaced by direct `TimeInterval` string values, which are the same string format used by the REST API (`"7d"`, `"90d"`, etc.).

## Files changed and why

- `features/dao-overview/hooks/useDaoOverviewData.ts` — Core orchestrator; removed 4 shared GraphQL hooks, added 5 Kubb SDK hooks inline
- `features/dao-overview/hooks/useDaoTreasuryStats.ts` — Replaced `useTreasury` (GraphQL) with 3 direct Kubb treasury hooks; broadened `tokenData` prop type to `{ price?: string | null }` to decouple from GraphQL-specific type
- `features/dao-overview/hooks/useCompareTreasury.ts` — Replaced `useCompareTreasuryQuery` with aliased `useCompareTreasuryHook`; removed `DaysWindow` mapping
- `features/dao-overview/hooks/useLastProposals.ts` — Replaced `useGetProposalsFromDaoQuery` + `transformToGovernanceProposal` with `useProposals` + inline `transformProposal` to avoid the GraphQL-typed input constraint

## Assumptions I made

- `DaysWindow` GraphQL enum values map 1:1 to the REST `DaysWindow` string schema (`"7d"`, `"30d"`, `"90d"`, `"365d"`)
- Kubb SDK hook names follow `use{PascalCase(operationId)}` convention and path param types follow `{PascalCase(operationId)}PathParamsDaoEnumKey`
- The REST response shapes are structurally equivalent to the GraphQL equivalents for all affected fields
- The shared hooks (`useDaoData`, `useTokenData`, `useActiveSupply`, `useAverageTurnout`, `useTreasury`) are left unchanged because they are also used by other features (attack-profitability, holders-and-delegates, panel)

## What I did NOT do

- Did **not** touch the shared hooks in `shared/hooks/` — they still use GraphQL and are used by other features
- Did **not** update `transformToGovernanceProposal` (governance utility); a new inline `transformProposal` in `useLastProposals` handles the REST type
- Did **not** update the `Proposal` / `GovernanceProposal` type in `features/governance/types/` — decoupling it from GraphQL is a separate refactor
- Did **not** run codegen or typecheck — `@anticapture/client` requires `pnpm client codegen` first (no node_modules in this environment)

## Open questions for review

1. **Type cast in `useLastProposals`**: The `transformProposal` function returns `as unknown as GovernanceProposal` because `Proposal` extends `GraphqlProposalListItem`. Should the `Proposal` type be decoupled from the GraphQL base type as a follow-up?
2. **`tokenData` prop type broadening**: `useDaoTreasuryStats` now accepts `{ data?: { price?: string | null } | null }` instead of `{ data?: TokenDataResponse | null }`. Is this acceptable, or should `TokenDataResponse` be replaced with the REST type entirely?
3. **Kubb SDK type name verification**: The generated path param types (`VotingPowersPathParamsDaoEnumKey`, `DaoPathParamsDaoEnumKey`, etc.) follow the observed naming convention — please verify these match the actual generated types after running `pnpm client codegen`.
4. **`useCompareTreasury` return type**: `data` is cast to `CompareTreasury | null` since `SupplyComparisonResponse` is structurally identical but a different TypeScript type. Should a proper type mapping be added?

## ClickUp task

https://app.clickup.com/t/86agzktge

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpHdpbzLGsTmyKg81KYejQ)_