### PR TITLE
Footer dashboard version

### DIFF
--- a/.changeset/fix-footer-dashboard-version.md
+++ b/.changeset/fix-footer-dashboard-version.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Footer now shows the latest dashboard release version instead of the most recent repo release (which could belong to another package like gateful).

--- a/apps/dashboard/features/governance/hooks/useProposal.ts
+++ b/apps/dashboard/features/governance/hooks/useProposal.ts
@@ -21,7 +21,12 @@ export const useProposal = ({
   daoId,
 }: UseProposalParams): UseProposalResult => {
   const daoKey = daoId.toLowerCase() as ProposalPathParamsDaoEnumKey;
-  const { data, isLoading, error } = useProposalSDK(daoKey, proposalId, {});
+  const { data, isLoading, error } = useProposalSDK(
+    daoKey,
+    proposalId,
+    {},
+    { query: { enabled: !!proposalId } },
+  );
 
   return {
     data: data

--- a/apps/dashboard/shared/components/design-system/footer/Footer.tsx
+++ b/apps/dashboard/shared/components/design-system/footer/Footer.tsx
@@ -29,7 +29,7 @@ export type FooterProps = VariantProps<typeof footerVariant> & {
 
 export const Footer = ({ variant, className }: FooterProps) => {
   const { data: release } = useGitHubRelease();
-  const version = release?.tag_name || "v1.1.0";
+  const version = release?.version || "v1.1.0";
   const releaseUrl =
     release?.html_url || "https://github.com/blockful/anticapture/releases";
 

--- a/apps/dashboard/shared/hooks/useGitHubRelease.ts
+++ b/apps/dashboard/shared/hooks/useGitHubRelease.ts
@@ -8,18 +8,33 @@ interface GitHubRelease {
   published_at: string;
 }
 
-const GITHUB_API_URL =
-  "https://api.github.com/repos/blockful/anticapture/releases/latest";
+interface DashboardRelease extends GitHubRelease {
+  version: string;
+}
 
-export const fetchLatestRelease = async (): Promise<GitHubRelease> => {
-  const response = await axios.get(GITHUB_API_URL);
-  return response.data;
-};
+const GITHUB_API_URL =
+  "https://api.github.com/repos/blockful/anticapture/releases";
+const DASHBOARD_TAG_PREFIX = "dashboard@";
+
+export const fetchLatestDashboardRelease =
+  async (): Promise<DashboardRelease | null> => {
+    const response = await axios.get<GitHubRelease[]>(GITHUB_API_URL, {
+      params: { per_page: 100 },
+    });
+    const dashboardRelease = response.data.find((release) =>
+      release.tag_name.startsWith(DASHBOARD_TAG_PREFIX),
+    );
+    if (!dashboardRelease) return null;
+    return {
+      ...dashboardRelease,
+      version: `v${dashboardRelease.tag_name.slice(DASHBOARD_TAG_PREFIX.length)}`,
+    };
+  };
 
 export const useGitHubRelease = () => {
-  return useQuery<GitHubRelease, Error>({
-    queryKey: ["github-latest-release"],
-    queryFn: fetchLatestRelease,
+  return useQuery<DashboardRelease | null, Error>({
+    queryKey: ["github-latest-dashboard-release"],
+    queryFn: fetchLatestDashboardRelease,
     staleTime: 3600000, // Cache for 1 hour
     gcTime: 3600000, // Keep in cache for 1 hour
     refetchOnWindowFocus: false,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Display and client-side query gating only; no auth, data writes, or critical path changes.
> 
> **Overview**
> **Footer version** now comes from the latest GitHub release whose tag starts with `dashboard@`, not the monorepo’s single “latest” release (which could be another package). The hook lists releases (up to 100), picks the first matching tag, and exposes a a normalized `version` string; the footer reads `release?.version` instead of `tag_name`.
> 
> **Proposal details** only run the SDK query when `proposalId` is truthy via React Query’s `enabled: !!proposalId`, avoiding fetches with an empty id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc7fc0aea4aca97869a62d08423c41e61790a6ab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->