### PR TITLE
feat(dashboard): track analytics on whitelabel portal

### DIFF
--- a/.changeset/whitelabel-umami-tracking.md
+++ b/.changeset/whitelabel-umami-tracking.md
@@ -2,4 +2,4 @@
 "@anticapture/dashboard": patch
 ---
 
-Add Umami event tracking for `proposal_create_click` on the governance "New Proposal" button (with `dao` property) and `feature_request_click` on the whitelabel "Request feature" links in both the shell and sidebar (with `source` property).
+Add Umami and PostHog event tracking for `proposal_create_click` on the governance "New Proposal" button (with `dao` property) and `feature_request_click` on the whitelabel "Request feature" links in both the shell and sidebar (with `source` property). The PostHog click handler now also captures an optional `dao` property from `data-ph-dao`.

--- a/.changeset/whitelabel-umami-tracking.md
+++ b/.changeset/whitelabel-umami-tracking.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Add Umami event tracking for `proposal_create_click` on the governance "New Proposal" button (with `dao` property) and `feature_request_click` on the whitelabel "Request feature" links in both the shell and sidebar (with `source` property).

--- a/apps/dashboard/features/governance/components/governance-overview/GovernanceSection.tsx
+++ b/apps/dashboard/features/governance/components/governance-overview/GovernanceSection.tsx
@@ -259,6 +259,9 @@ export const GovernanceSection = () => {
           className="flex-1 whitespace-nowrap lg:w-fit lg:flex-none"
           data-umami-event="proposal_create_click"
           data-umami-event-dao={daoId}
+          data-ph-event="proposal_create_click"
+          data-ph-source="governance_overview"
+          data-ph-dao={daoId}
         >
           <Plus className="size-4" />
           New Proposal

--- a/apps/dashboard/features/governance/components/governance-overview/GovernanceSection.tsx
+++ b/apps/dashboard/features/governance/components/governance-overview/GovernanceSection.tsx
@@ -257,6 +257,8 @@ export const GovernanceSection = () => {
           size="md"
           onClick={handleNewProposal}
           className="flex-1 whitespace-nowrap lg:w-fit lg:flex-none"
+          data-umami-event="proposal_create_click"
+          data-umami-event-dao={daoId}
         >
           <Plus className="size-4" />
           New Proposal

--- a/apps/dashboard/shared/services/posthog/ConditionalPostHog.tsx
+++ b/apps/dashboard/shared/services/posthog/ConditionalPostHog.tsx
@@ -36,6 +36,11 @@ const ConditionalPostHog = () => {
         properties.href = element.href;
       }
 
+      // Optionally add dao when provided
+      if (element.dataset.phDao) {
+        properties.dao = element.dataset.phDao;
+      }
+
       windowWithPostHog.posthog.capture(
         element.dataset.phEvent || "",
         properties,

--- a/apps/dashboard/widgets/WhitelabelShell.tsx
+++ b/apps/dashboard/widgets/WhitelabelShell.tsx
@@ -161,6 +161,8 @@ export const WhitelabelShell = ({
                 rel="noopener noreferrer"
                 data-umami-event="feature_request_click"
                 data-umami-event-source="whitelabel_shell"
+                data-ph-event="feature_request_click"
+                data-ph-source="whitelabel_shell"
               >
                 Request feature
               </a>

--- a/apps/dashboard/widgets/WhitelabelShell.tsx
+++ b/apps/dashboard/widgets/WhitelabelShell.tsx
@@ -159,6 +159,8 @@ export const WhitelabelShell = ({
                 }
                 target="_blank"
                 rel="noopener noreferrer"
+                data-umami-event="feature_request_click"
+                data-umami-event-source="whitelabel_shell"
               >
                 Request feature
               </a>

--- a/apps/dashboard/widgets/WhitelabelSidebar.tsx
+++ b/apps/dashboard/widgets/WhitelabelSidebar.tsx
@@ -214,6 +214,8 @@ export const WhitelabelSidebar = ({
               }
               target="_blank"
               rel="noopener noreferrer"
+              data-umami-event="feature_request_click"
+              data-umami-event-source="whitelabel_sidebar"
             >
               <Sparkles className="size-4" />
               {!isCollapsed && "Request feature"}

--- a/apps/dashboard/widgets/WhitelabelSidebar.tsx
+++ b/apps/dashboard/widgets/WhitelabelSidebar.tsx
@@ -216,6 +216,8 @@ export const WhitelabelSidebar = ({
               rel="noopener noreferrer"
               data-umami-event="feature_request_click"
               data-umami-event-source="whitelabel_sidebar"
+              data-ph-event="feature_request_click"
+              data-ph-source="whitelabel_sidebar"
             >
               <Sparkles className="size-4" />
               {!isCollapsed && "Request feature"}


### PR DESCRIPTION
## Summary

Adds Umami event tracking for two KR8 product signals on the whitelabel portal so we can measure usage on `ens.gov.blockful.io` (and any future non-ENS whitelabel deploys):

- `proposal_create_click` (with `dao` property) on the **New Proposal** button in `GovernanceSection`
- `feature_request_click` (with `source` property: `whitelabel_shell` | `whitelabel_sidebar`) on the **Request feature** links

No domain or Umami config change needed — Umami Cloud is already collecting from `ens.gov.blockful.io` (verified: 33 pageviews / last 30d, filterable by hostname).

ClickUp: https://app.clickup.com/t/86ahncrq7

## Test plan

- [ ] On `ens.gov.blockful.io`, click **New Proposal** → confirm `proposal_create_click` event with `dao` property appears in Umami within ~1 min
- [ ] Click **Request feature** in the sidebar → confirm `feature_request_click` with `source=whitelabel_sidebar`
- [ ] Click **Request feature** in the shell footer (mobile/drawer) → confirm `source=whitelabel_shell`
- [ ] Existing events on ENS portal (`vote_submit`, `vote_offchain_submit`, etc.) still fire — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)