### PR TITLE
fix(dashboard): support Snapshot copeland votes and readable offchain choice labels

### DIFF
--- a/.changeset/copeland-offchain-voting.md
+++ b/.changeset/copeland-offchain-voting.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Support Snapshot copeland offchain votes and show full choice labels in proposal results.

--- a/apps/dashboard/features/governance/components/modals/OffchainVotingModal.tsx
+++ b/apps/dashboard/features/governance/components/modals/OffchainVotingModal.tsx
@@ -14,6 +14,7 @@ import { WeightedVoteOptions } from "@/features/governance/components/modals/vot
 import { useOffchainVotingPower } from "@/features/governance/hooks/useOffchainVotingPower";
 import { useVoteOnOffchainProposal } from "@/features/governance/hooks/useVoteOnOffchainProposal";
 import { normalizeChoices } from "@/features/governance/utils/offchainProposal";
+import { getOffchainVoteUiType } from "@/features/governance/utils/offchainVotingType";
 import { showCustomToast } from "@/features/governance/utils/showCustomToast";
 import { Button } from "@/shared/components";
 import { formatNumberUserReadable } from "@/shared/utils";
@@ -71,6 +72,7 @@ export const OffchainVotingModal = ({
   });
 
   const choices = normalizeChoices(proposal.choices);
+  const voteUiType = getOffchainVoteUiType(proposal.type);
 
   // Reset state when modal opens
   useEffect(() => {
@@ -112,15 +114,15 @@ export const OffchainVotingModal = ({
 
   const isVoteEnabled = (() => {
     if (!value || !address || isVoting) return false;
-    if (proposal.type === "approval") return (value as number[]).length > 0;
-    if (proposal.type === "weighted") {
+    if (voteUiType === "approval") return (value as number[]).length > 0;
+    if (voteUiType === "weighted") {
       const total = Object.values(value as Record<string, number>).reduce(
         (a, b) => a + b,
         0,
       );
       return total === 100;
     }
-    if (proposal.type === "quadratic") {
+    if (voteUiType === "quadratic") {
       const total = Object.values(value as Record<string, number>).reduce(
         (a, b) => a + b,
         0,
@@ -153,13 +155,7 @@ export const OffchainVotingModal = ({
       await vote({
         spaceId: proposal.spaceId,
         proposalId: proposal.id,
-        type: proposal.type as
-          | "basic"
-          | "single-choice"
-          | "approval"
-          | "ranked-choice"
-          | "weighted"
-          | "quadratic",
+        proposalType: proposal.type,
         choice: value,
         reason: comment,
       });
@@ -174,7 +170,7 @@ export const OffchainVotingModal = ({
   };
 
   const renderVoteOptions = () => {
-    switch (proposal.type) {
+    switch (voteUiType) {
       case "basic":
         return (
           <BasicVoteOptions
@@ -227,7 +223,21 @@ export const OffchainVotingModal = ({
           />
         );
       default:
-        return null;
+        return (
+          <p className="text-secondary text-[14px]">
+            Voting for &quot;{proposal.type}&quot; proposals is not supported in
+            this app yet. Vote on{" "}
+            <a
+              href={proposal.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-link underline"
+            >
+              Snapshot
+            </a>
+            .
+          </p>
+        );
     }
   };
 

--- a/apps/dashboard/features/governance/components/modals/OffchainVotingModal.tsx
+++ b/apps/dashboard/features/governance/components/modals/OffchainVotingModal.tsx
@@ -301,11 +301,11 @@ export const OffchainVotingModal = ({
         </div>
 
         {/* Vote options */}
-        <div className="flex flex-col gap-[6px] p-4">
+        <div className="flex flex-col items-start gap-[6px] p-4 text-left">
           <p className="font-inter text-primary text-[12px] font-medium">
             Your vote
           </p>
-          {renderVoteOptions()}
+          <div className="w-full">{renderVoteOptions()}</div>
         </div>
 
         {/* Comment */}

--- a/apps/dashboard/features/governance/components/modals/vote-options/RankedChoiceOptions.tsx
+++ b/apps/dashboard/features/governance/components/modals/vote-options/RankedChoiceOptions.tsx
@@ -47,13 +47,13 @@ export const RankedChoiceOptions = ({
         <div
           key={choiceIndex}
           className={cn(
-            "border-border-default flex items-center gap-2 border px-[10px] py-2",
+            "border-border-default flex items-start gap-2 border px-[10px] py-2 text-left",
           )}
         >
-          <span className="text-secondary font-inter w-5 shrink-0 text-[14px] font-normal not-italic leading-[20px]">
+          <span className="text-secondary font-inter w-5 shrink-0 text-left text-[14px] font-normal not-italic leading-[20px]">
             {position + 1}
           </span>
-          <span className="font-inter text-primary flex-1 text-[14px] font-normal not-italic leading-[20px]">
+          <span className="font-inter text-primary min-w-0 flex-1 text-left text-[14px] font-normal not-italic leading-[20px]">
             {choices[choiceIndex]}
           </span>
           <div className="flex flex-col">

--- a/apps/dashboard/features/governance/components/proposal-overview/OffchainVoteLabelChip.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/OffchainVoteLabelChip.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { presentOffchainVoteLabel } from "@/features/governance/utils/offchainVoteLabel";
+import { Tooltip } from "@/shared/components/design-system/tooltips/Tooltip";
+import { cn } from "@/shared/utils";
+
+interface OffchainVoteLabelChipProps {
+  label: string;
+  proposalType?: string | null;
+  className?: string;
+  variant?: "badge" | "inline";
+}
+
+export const OffchainVoteLabelChip = ({
+  label,
+  proposalType,
+  className,
+  variant = "badge",
+}: OffchainVoteLabelChipProps) => {
+  const { display, full, showTooltip } = presentOffchainVoteLabel(
+    label,
+    proposalType,
+  );
+
+  const chip = (
+    <span
+      className={cn(
+        "text-primary font-inter truncate text-left font-medium not-italic",
+        variant === "badge"
+          ? "bg-surface-default max-w-[200px] rounded-full px-[6px] py-[2px] text-[12px] leading-[16px]"
+          : "max-w-[140px] text-sm leading-[20px]",
+        className,
+      )}
+    >
+      {display}
+    </span>
+  );
+
+  if (!showTooltip) {
+    return chip;
+  }
+
+  return (
+    <Tooltip
+      asChild
+      triggerClassName="max-w-[200px]"
+      tooltipContent={full}
+      className="text-left"
+    >
+      {chip}
+    </Tooltip>
+  );
+};

--- a/apps/dashboard/features/governance/components/proposal-overview/OffchainVotesContent.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/OffchainVotesContent.tsx
@@ -11,7 +11,9 @@ import { CheckCircle2, CircleMinus, Inbox, XCircle } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Address } from "viem";
 
+import { OffchainVoteLabelChip } from "@/features/governance/components/proposal-overview/OffchainVoteLabelChip";
 import { VotesTable } from "@/features/governance/components/proposal-overview/VotesTable";
+import { getOffchainVoteFullLabel } from "@/features/governance/utils/offchainVoteLabel";
 import { BlankSlate } from "@/shared/components/design-system/blank-slate/BlankSlate";
 import { Button } from "@/shared/components/design-system/buttons/button/Button";
 import { SkeletonRow } from "@/shared/components/skeletons/SkeletonRow";
@@ -38,20 +40,14 @@ const getLabelDisplay = (label: string) => {
 const getChoiceInfo = (choice: string[], choices: string[]) => {
   if (choice.length === 0) return { label: "—", icon: null as React.ReactNode };
 
+  const fullLabel = getOffchainVoteFullLabel(choice, choices);
+  if (!fullLabel) return { label: "—", icon: null as React.ReactNode };
+
   if (choice.length === 1 && choice[0] != null) {
-    const idx = Number(choice[0]);
-    const label = choices[idx - 1] ?? `Choice ${choice[0]}`;
-    return getLabelDisplay(label);
+    return getLabelDisplay(fullLabel);
   }
 
-  const label = choice
-    .filter((c): c is string => c != null)
-    .map((c) => {
-      const idx = Number(c);
-      return choices[idx - 1] ?? `Choice ${c}`;
-    })
-    .join(", ");
-  return { label, icon: null as React.ReactNode };
+  return { label: fullLabel, icon: null as React.ReactNode };
 };
 
 interface OffchainVotesContentProps {
@@ -59,6 +55,7 @@ interface OffchainVotesContentProps {
   daoId: DaoIdEnum;
   totalVotingPower: number;
   choices: string[];
+  proposalType?: string | null;
 }
 
 export const OffchainVotesContent = ({
@@ -66,6 +63,7 @@ export const OffchainVotesContent = ({
   daoId,
   totalVotingPower,
   choices,
+  proposalType,
 }: OffchainVotesContentProps) => {
   const loadingRowRef = useRef<HTMLTableRowElement>(null);
 
@@ -270,11 +268,21 @@ export const OffchainVotesContent = ({
             );
           }
           const choice = row.getValue("choice") as string[];
-          const { icon, label } = getChoiceInfo(choice, choices);
+          const choiceInfo = getChoiceInfo(choice, choices);
+          const { icon, label } = choiceInfo;
+          const isMultiChoice = choice.length > 1;
           return (
-            <div className="flex items-center gap-2 p-2">
+            <div className="flex min-w-0 items-center gap-2 p-2">
               {icon}
-              <span className="text-sm font-medium">{label}</span>
+              {isMultiChoice ? (
+                <OffchainVoteLabelChip
+                  label={label}
+                  proposalType={proposalType}
+                  variant="inline"
+                />
+              ) : (
+                <span className="text-sm font-medium">{label}</span>
+              )}
             </div>
           );
         },
@@ -401,7 +409,14 @@ export const OffchainVotesContent = ({
         },
       },
     ],
-    [totalVotingPower, choices, orderBy, orderDirection, handleSort],
+    [
+      totalVotingPower,
+      choices,
+      proposalType,
+      orderBy,
+      orderDirection,
+      handleSort,
+    ],
   );
 
   if (error) return <div>Error: {error.message}</div>;

--- a/apps/dashboard/features/governance/components/proposal-overview/ProposalHeader.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/ProposalHeader.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { Address } from "viem";
 
+import { OffchainVoteLabelChip } from "@/features/governance/components/proposal-overview/OffchainVoteLabelChip";
 import { BadgeStatus, Button } from "@/shared/components";
 import { ConnectWalletCustom } from "@/shared/components/wallet/ConnectWalletCustom";
 import { WhitelabelConnectWallet } from "@/shared/components/wallet/WhitelabelConnectWallet";
@@ -26,6 +27,7 @@ interface ProposalHeaderProps {
   isWhitelabel?: boolean;
   offchainHasVoted?: boolean;
   offchainVoteLabel?: string | null;
+  offchainProposalType?: string | null;
 }
 
 const ProposalHeaderAction = ({
@@ -36,6 +38,7 @@ const ProposalHeaderAction = ({
   isWhitelabel,
   offchainHasVoted,
   offchainVoteLabel,
+  offchainProposalType,
   daoId,
 }: {
   address: string | undefined;
@@ -45,6 +48,7 @@ const ProposalHeaderAction = ({
   isWhitelabel: boolean;
   offchainHasVoted?: boolean;
   offchainVoteLabel?: string | null;
+  offchainProposalType?: string | null;
   daoId: string;
 }) => {
   const isOngoing = proposalStatus.toLowerCase() === "ongoing";
@@ -61,7 +65,10 @@ const ProposalHeaderAction = ({
         return (
           <div className="hidden items-center gap-4 lg:flex">
             <div className="bg-secondary ml-4 h-7 w-px shrink-0" />
-            <OffchainVotedBadge label={offchainVoteLabel ?? null} />
+            <OffchainVotedBadge
+              label={offchainVoteLabel ?? null}
+              proposalType={offchainProposalType}
+            />
             {isOngoing && (
               <Button
                 className="hidden lg:flex"
@@ -143,6 +150,7 @@ export const ProposalHeader = ({
   isWhitelabel = false,
   offchainHasVoted,
   offchainVoteLabel,
+  offchainProposalType,
 }: ProposalHeaderProps) => {
   const pathname = usePathname();
   const supportValue =
@@ -214,6 +222,9 @@ export const ProposalHeader = ({
                 offchainVoteLabel={
                   snapshotLink !== undefined ? offchainVoteLabel : undefined
                 }
+                offchainProposalType={
+                  snapshotLink !== undefined ? offchainProposalType : undefined
+                }
                 daoId={daoId}
               />
             </>
@@ -237,6 +248,7 @@ export const ProposalHeader = ({
                 isWhitelabel={isWhitelabel}
                 offchainHasVoted={offchainHasVoted}
                 offchainVoteLabel={offchainVoteLabel}
+                offchainProposalType={offchainProposalType}
                 daoId={daoId}
               />
             </>
@@ -306,16 +318,20 @@ const VotedBadge = ({ vote }: { vote: number }) => {
   );
 };
 
-const OffchainVotedBadge = ({ label }: { label: string | null }) => {
+const OffchainVotedBadge = ({
+  label,
+  proposalType,
+}: {
+  label: string | null;
+  proposalType?: string | null;
+}) => {
   return (
     <div className="flex flex-col items-end">
       <p className="text-secondary flex items-center gap-2 text-[12px] font-medium leading-[16px]">
         You voted
       </p>
       {label && (
-        <span className="text-primary bg-surface-default font-inter rounded-full px-[6px] py-[2px] text-[12px] font-medium not-italic leading-[16px]">
-          {label}
-        </span>
+        <OffchainVoteLabelChip label={label} proposalType={proposalType} />
       )}
     </div>
   );

--- a/apps/dashboard/features/governance/components/proposal-overview/ProposalInfoSection.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/ProposalInfoSection.tsx
@@ -115,18 +115,17 @@ export const ProposalInfoSection = ({
 
           <div className="scrollbar-custom flex max-h-[240px] flex-col gap-3 overflow-y-auto overflow-x-hidden lg:w-full">
             {choiceItems.map((item) => (
-              <div
-                key={item.label}
-                className="flex w-full items-center justify-between gap-2 lg:justify-start"
-              >
-                <div className="flex w-[100px] shrink-0 items-center gap-2 overflow-hidden">
+              <div key={item.label} className="flex w-full items-center gap-2">
+                <div className="flex min-w-0 flex-[1.4] items-start gap-2">
                   <ChoiceIcon label={item.label} color={item.color} />
-                  <p className="text-primary font-inter truncate text-[14px] font-normal not-italic leading-[20px]">
-                    {item.label}
-                  </p>
+                  <Tooltip tooltipContent={item.label}>
+                    <p className="text-primary font-inter line-clamp-2 text-[14px] font-normal not-italic leading-[20px]">
+                      {item.label}
+                    </p>
+                  </Tooltip>
                 </div>
 
-                <div className="bg-surface-contrast relative h-1 min-w-0 flex-1">
+                <div className="bg-surface-contrast relative h-1 min-w-[48px] flex-1">
                   <div
                     className="absolute h-full"
                     style={{

--- a/apps/dashboard/features/governance/components/proposal-overview/ProposalInfoSection.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/ProposalInfoSection.tsx
@@ -115,34 +115,37 @@ export const ProposalInfoSection = ({
 
           <div className="scrollbar-custom flex max-h-[240px] flex-col gap-3 overflow-y-auto overflow-x-hidden lg:w-full">
             {choiceItems.map((item) => (
-              <div key={item.label} className="flex w-full items-center gap-2">
-                <div className="flex min-w-0 flex-[1.4] items-start gap-2">
+              <div key={item.label} className="flex w-full flex-col gap-1.5">
+                <div className="flex items-start gap-2 text-left">
                   <ChoiceIcon label={item.label} color={item.color} />
-                  <Tooltip tooltipContent={item.label}>
-                    <p className="text-primary font-inter line-clamp-2 text-[14px] font-normal not-italic leading-[20px]">
+                  <Tooltip
+                    asChild
+                    triggerClassName="min-w-0 flex-1 text-left"
+                    tooltipContent={item.label}
+                    className="text-left"
+                  >
+                    <p className="text-primary font-inter line-clamp-2 text-left text-[14px] font-normal not-italic leading-[20px]">
                       {item.label}
                     </p>
                   </Tooltip>
                 </div>
 
-                <div className="bg-surface-contrast relative h-1 min-w-[48px] flex-1">
-                  <div
-                    className="absolute h-full"
-                    style={{
-                      width: `${item.percentage}%`,
-                      backgroundColor: item.color,
-                    }}
-                  />
-                </div>
+                <div className="flex items-center gap-2 pl-4">
+                  <div className="bg-surface-contrast relative h-1 min-w-0 flex-1">
+                    <div
+                      className="absolute h-full"
+                      style={{
+                        width: `${item.percentage}%`,
+                        backgroundColor: item.color,
+                      }}
+                    />
+                  </div>
 
-                <div className="flex w-[100px] items-center gap-2">
-                  <div className="flex w-12 items-center">
-                    <p className="text-primary font-inter text-[14px] font-normal not-italic leading-[20px]">
+                  <div className="flex shrink-0 items-center gap-2">
+                    <p className="text-primary font-inter w-12 text-left text-[14px] font-normal not-italic leading-[20px]">
                       {formatNumberUserReadable(item.score, 0)}
                     </p>
-                  </div>
-                  <div className="flex w-12 items-center">
-                    <p className="text-primary font-inter text-[14px] font-normal not-italic leading-[20px]">
+                    <p className="text-primary font-inter w-12 text-left text-[14px] font-normal not-italic leading-[20px]">
                       {item.percentage.toFixed(1)}%
                     </p>
                   </div>

--- a/apps/dashboard/features/governance/components/proposal-overview/ProposalInfoSection.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/ProposalInfoSection.tsx
@@ -115,7 +115,7 @@ export const ProposalInfoSection = ({
 
           <div className="scrollbar-custom flex max-h-[240px] flex-col gap-3 overflow-y-auto overflow-x-hidden lg:w-full">
             {choiceItems.map((item) => (
-              <div key={item.label} className="flex w-full flex-col gap-1.5">
+              <div key={item.label} className="flex w-full flex-col">
                 <div className="flex items-start gap-2 text-left">
                   <div className="flex h-5 shrink-0 items-center">
                     <ChoiceIcon label={item.label} color={item.color} />

--- a/apps/dashboard/features/governance/components/proposal-overview/ProposalInfoSection.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/ProposalInfoSection.tsx
@@ -117,7 +117,9 @@ export const ProposalInfoSection = ({
             {choiceItems.map((item) => (
               <div key={item.label} className="flex w-full flex-col gap-1.5">
                 <div className="flex items-start gap-2 text-left">
-                  <ChoiceIcon label={item.label} color={item.color} />
+                  <div className="flex h-5 shrink-0 items-center">
+                    <ChoiceIcon label={item.label} color={item.color} />
+                  </div>
                   <Tooltip
                     asChild
                     triggerClassName="min-w-0 flex-1 text-left"

--- a/apps/dashboard/features/governance/components/proposal-overview/ProposalSection.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/ProposalSection.tsx
@@ -14,6 +14,7 @@ import { useAccount } from "wagmi";
 import { GovernanceActionModal } from "@/features/governance/components/modals/GovernanceActionModal";
 import { OffchainVotingModal } from "@/features/governance/components/modals/OffchainVotingModal";
 import { VotingModal } from "@/features/governance/components/modals/VotingModal";
+import { OffchainVoteLabelChip } from "@/features/governance/components/proposal-overview/OffchainVoteLabelChip";
 import {
   getVoteText,
   ProposalHeader,
@@ -35,6 +36,7 @@ import {
   normalizeChoices,
   normalizeScores,
 } from "@/features/governance/utils/offchainProposal";
+import { getOffchainVoteFullLabel } from "@/features/governance/utils/offchainVoteLabel";
 import { HoldersAndDelegatesDrawer } from "@/features/holders-and-delegates";
 import { ProposalHeaderProvider } from "@/features/governance/context/ProposalHeaderContext";
 import { Button } from "@/shared/components";
@@ -145,12 +147,12 @@ export const ProposalSection = ({
     skip: !isOffchain || !offchainProposalId || !address,
   });
 
-  const apiOffchainVoteChoice =
-    userOffchainVoteData?.votesOffchainByProposalId?.items?.[0]?.choice?.[0] ??
-    null;
+  const apiOffchainVoteChoice = (
+    userOffchainVoteData?.votesOffchainByProposalId?.items?.[0]?.choice ?? []
+  ).filter((c): c is string => c != null);
   const apiOffchainVoteLabel =
-    apiOffchainVoteChoice != null
-      ? (offchainChoices[Number(apiOffchainVoteChoice) - 1] ?? null)
+    apiOffchainVoteChoice.length > 0
+      ? getOffchainVoteFullLabel(apiOffchainVoteChoice, offchainChoices)
       : null;
 
   const offchainHasVoted = !!localOffchainVoteLabel || !!apiOffchainVoteLabel;
@@ -252,6 +254,9 @@ export const ProposalSection = ({
           isWhitelabel={isWhitelabel}
           offchainHasVoted={isOffchain ? offchainHasVoted : undefined}
           offchainVoteLabel={isOffchain ? offchainVoteLabel : undefined}
+          offchainProposalType={
+            isOffchain ? (rawOffchainProposal?.type ?? null) : undefined
+          }
         />
         <div className="mx-auto w-full">
           <div className="bg-surface-background sticky top-[65px] z-10 hidden h-5 w-full lg:block" />
@@ -286,6 +291,7 @@ export const ProposalSection = ({
               offchainProposalId={offchainProposalId}
               offchainChoices={offchainChoices}
               offchainScores={isOffchain ? offchainScores : undefined}
+              offchainProposalType={rawOffchainProposal?.type ?? null}
               daoId={daoEnum}
             />
           </div>
@@ -350,6 +356,7 @@ export const ProposalSection = ({
           onExecuteClick={() => setIsExecuteModalOpen(true)}
           offchainHasVoted={offchainHasVoted}
           offchainVoteLabel={offchainVoteLabel}
+          offchainProposalType={rawOffchainProposal?.type ?? null}
         />
       </div>
     </ProposalHeaderProvider>
@@ -367,6 +374,7 @@ const MobileBottomBar = ({
   onExecuteClick,
   offchainHasVoted,
   offchainVoteLabel,
+  offchainProposalType,
 }: {
   isOffchain: boolean;
   address: string | undefined;
@@ -378,6 +386,7 @@ const MobileBottomBar = ({
   onExecuteClick: () => void;
   offchainHasVoted?: boolean;
   offchainVoteLabel?: string | null;
+  offchainProposalType?: string | null;
 }) => {
   const isOngoing = proposalStatus.toLowerCase() === "ongoing";
 
@@ -388,7 +397,10 @@ const MobileBottomBar = ({
       if (offchainHasVoted) {
         content = (
           <div className="flex w-full flex-col items-center gap-2">
-            <MobileOffchainVotedBadge label={offchainVoteLabel ?? null} />
+            <MobileOffchainVotedBadge
+              label={offchainVoteLabel ?? null}
+              proposalType={offchainProposalType}
+            />
             {isOngoing && (
               <Button className="flex w-full" onClick={onVoteClick}>
                 Change your vote
@@ -460,16 +472,20 @@ const MobileVotedBadge = ({ vote }: { vote: number }) => {
   );
 };
 
-const MobileOffchainVotedBadge = ({ label }: { label: string | null }) => {
+const MobileOffchainVotedBadge = ({
+  label,
+  proposalType,
+}: {
+  label: string | null;
+  proposalType?: string | null;
+}) => {
   return (
     <div className="flex w-full items-center justify-center gap-2">
       <p className="text-secondary text-[12px] font-medium leading-4">
         You voted
       </p>
       {label && (
-        <span className="text-primary bg-surface-default font-inter rounded-full px-[6px] py-[2px] text-[12px] font-medium not-italic leading-[16px]">
-          {label}
-        </span>
+        <OffchainVoteLabelChip label={label} proposalType={proposalType} />
       )}
     </div>
   );

--- a/apps/dashboard/features/governance/components/proposal-overview/TabsSection.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/TabsSection.tsx
@@ -22,6 +22,7 @@ interface TabsSectionProps {
   offchainProposalId?: string;
   offchainChoices?: string[];
   offchainScores?: number[];
+  offchainProposalType?: string | null;
   daoId?: DaoIdEnum;
 }
 
@@ -33,6 +34,7 @@ export const TabsSection = ({
   offchainProposalId,
   offchainChoices = [],
   offchainScores,
+  offchainProposalType,
   daoId,
 }: TabsSectionProps) => {
   const allowedTabs: TabId[] = isOffchain
@@ -62,6 +64,7 @@ export const TabsSection = ({
             daoId={daoId}
             totalVotingPower={totalVotingPower}
             choices={offchainChoices}
+            proposalType={offchainProposalType}
           />
         ) : (
           <VotesTabContent

--- a/apps/dashboard/features/governance/hooks/useVoteOnOffchainProposal.ts
+++ b/apps/dashboard/features/governance/hooks/useVoteOnOffchainProposal.ts
@@ -5,22 +5,17 @@ import snapshot from "@snapshot-labs/snapshot.js";
 import { useMutation } from "@tanstack/react-query";
 import { useAccount, useWalletClient } from "wagmi";
 
+import { getSnapshotVoteSignType } from "@/features/governance/utils/offchainVotingType";
+
 const HUB_URL = "https://hub.snapshot.org";
 
 type VoteChoice = number | number[] | Record<string, number>;
 
-type SnapshotProposalType =
-  | "basic"
-  | "single-choice"
-  | "approval"
-  | "ranked-choice"
-  | "weighted"
-  | "quadratic";
-
 interface VoteParams {
   spaceId: string;
   proposalId: string;
-  type: SnapshotProposalType;
+  /** Snapshot proposal type from the API (e.g. copeland, ranked-choice). */
+  proposalType: string;
   choice: VoteChoice;
   reason?: string;
 }
@@ -45,7 +40,7 @@ export const useVoteOnOffchainProposal = () => {
       await client.vote(web3, address, {
         space: params.spaceId,
         proposal: params.proposalId,
-        type: params.type,
+        type: getSnapshotVoteSignType(params.proposalType),
         choice: params.choice,
         reason: params.reason ?? "",
         app: "anticapture",

--- a/apps/dashboard/features/governance/utils/offchainVoteLabel.test.ts
+++ b/apps/dashboard/features/governance/utils/offchainVoteLabel.test.ts
@@ -1,0 +1,36 @@
+import {
+  getOffchainVoteFullLabel,
+  presentOffchainVoteLabel,
+} from "./offchainVoteLabel";
+
+const choices = [
+  "3 WGs + secretary (As-is)",
+  "Metagov + Eco/PG + secretary",
+  "Metagov + merged Eco/PG",
+  "Metagov only",
+  "DAO Coordination Layer",
+];
+
+describe("offchainVoteLabel", () => {
+  it("joins multiple choice indices into a full label", () => {
+    expect(getOffchainVoteFullLabel(["5", "4", "3", "2", "1"], choices)).toBe(
+      choices.slice().reverse().join(", "),
+    );
+  });
+
+  it("shows a short ranked summary with tooltip for multi-choice ranked votes", () => {
+    const full = getOffchainVoteFullLabel(["5", "4", "3", "2", "1"], choices);
+    const presentation = presentOffchainVoteLabel(full, "copeland");
+
+    expect(presentation.display).toBe("Ranked (5 choices)");
+    expect(presentation.full).toBe(full);
+    expect(presentation.showTooltip).toBe(true);
+  });
+
+  it("keeps single-choice labels as-is", () => {
+    const presentation = presentOffchainVoteLabel(choices[0]!, "single-choice");
+
+    expect(presentation.display).toBe(choices[0]);
+    expect(presentation.showTooltip).toBe(false);
+  });
+});

--- a/apps/dashboard/features/governance/utils/offchainVoteLabel.ts
+++ b/apps/dashboard/features/governance/utils/offchainVoteLabel.ts
@@ -1,0 +1,86 @@
+import {
+  getOffchainVoteUiType,
+  type OffchainVoteUiType,
+} from "@/features/governance/utils/offchainVotingType";
+
+export interface OffchainVoteLabelPresentation {
+  display: string;
+  full: string;
+  showTooltip: boolean;
+}
+
+/** Builds a human-readable label from Snapshot `choice` indices and proposal choices. */
+export const getOffchainVoteFullLabel = (
+  choice: string[],
+  choices: string[],
+): string => {
+  if (choice.length === 0) return "";
+
+  if (choice.length === 1 && choice[0] != null) {
+    const idx = Number(choice[0]);
+    return choices[idx - 1] ?? `Choice ${choice[0]}`;
+  }
+
+  return choice
+    .filter((c): c is string => c != null)
+    .map((c) => {
+      const idx = Number(c);
+      return choices[idx - 1] ?? `Choice ${c}`;
+    })
+    .join(", ");
+};
+
+export const presentOffchainVoteLabel = (
+  fullLabel: string,
+  proposalType: string | null | undefined,
+): OffchainVoteLabelPresentation => {
+  if (!fullLabel) {
+    return { display: "", full: "", showTooltip: false };
+  }
+
+  const uiType: OffchainVoteUiType | null = proposalType
+    ? getOffchainVoteUiType(proposalType)
+    : null;
+
+  if (uiType === "ranked-choice") {
+    const rankedChoices = fullLabel.split(", ");
+    if (rankedChoices.length > 1) {
+      return {
+        display: `Ranked (${rankedChoices.length} choices)`,
+        full: fullLabel,
+        showTooltip: true,
+      };
+    }
+  }
+
+  if (uiType === "approval") {
+    const approved = fullLabel.split(", ");
+    if (approved.length > 1) {
+      return {
+        display: `${approved.length} options approved`,
+        full: fullLabel,
+        showTooltip: true,
+      };
+    }
+  }
+
+  if (uiType === "weighted" || uiType === "quadratic") {
+    if (fullLabel.length > 40 || fullLabel.includes(", ")) {
+      return {
+        display: "Split vote",
+        full: fullLabel,
+        showTooltip: true,
+      };
+    }
+  }
+
+  if (fullLabel.length > 40) {
+    return {
+      display: `${fullLabel.slice(0, 37)}…`,
+      full: fullLabel,
+      showTooltip: true,
+    };
+  }
+
+  return { display: fullLabel, full: fullLabel, showTooltip: false };
+};

--- a/apps/dashboard/features/governance/utils/offchainVotingType.test.ts
+++ b/apps/dashboard/features/governance/utils/offchainVotingType.test.ts
@@ -17,6 +17,13 @@ describe("offchainVotingType", () => {
   it("passes through known types", () => {
     expect(getOffchainVoteUiType("single-choice")).toBe("single-choice");
     expect(getSnapshotVoteSignType("approval")).toBe("approval");
+    expect(usesRankedBallot("ranked-choice")).toBe(true);
+  });
+
+  it("falls back to single-choice for unknown types when signing", () => {
+    expect(getSnapshotVoteSignType("unknown-plugin-type")).toBe(
+      "single-choice",
+    );
   });
 
   it("returns null for unsupported UI types", () => {

--- a/apps/dashboard/features/governance/utils/offchainVotingType.test.ts
+++ b/apps/dashboard/features/governance/utils/offchainVotingType.test.ts
@@ -1,0 +1,25 @@
+import {
+  getOffchainVoteUiType,
+  getSnapshotVoteSignType,
+  usesRankedBallot,
+} from "./offchainVotingType";
+
+describe("offchainVotingType", () => {
+  it("maps copeland to ranked-choice UI", () => {
+    expect(getOffchainVoteUiType("copeland")).toBe("ranked-choice");
+    expect(usesRankedBallot("copeland")).toBe(true);
+  });
+
+  it("signs copeland votes as ranked-choice for snapshot.js", () => {
+    expect(getSnapshotVoteSignType("copeland")).toBe("ranked-choice");
+  });
+
+  it("passes through known types", () => {
+    expect(getOffchainVoteUiType("single-choice")).toBe("single-choice");
+    expect(getSnapshotVoteSignType("approval")).toBe("approval");
+  });
+
+  it("returns null for unsupported UI types", () => {
+    expect(getOffchainVoteUiType("unknown-plugin-type")).toBeNull();
+  });
+});

--- a/apps/dashboard/features/governance/utils/offchainVotingType.ts
+++ b/apps/dashboard/features/governance/utils/offchainVotingType.ts
@@ -3,8 +3,6 @@
  * Some types (e.g. copeland) use ranked ballots but are not listed in @snapshot-labs/snapshot.js types.
  */
 
-const RANKED_BALLOT_TYPES = new Set(["ranked-choice", "copeland"]);
-
 /** UI + validation: which vote-options component to render. */
 export type OffchainVoteUiType =
   | "basic"
@@ -38,22 +36,7 @@ export const getOffchainVoteUiType = (
 /** EIP-712 signing: snapshot.js only uses voteArrayTypes for approval + ranked-choice. */
 export const getSnapshotVoteSignType = (
   proposalType: string,
-):
-  | "basic"
-  | "single-choice"
-  | "approval"
-  | "ranked-choice"
-  | "weighted"
-  | "quadratic" => {
-  if (RANKED_BALLOT_TYPES.has(proposalType)) {
-    return "ranked-choice";
-  }
-  const uiType = getOffchainVoteUiType(proposalType);
-  if (uiType) {
-    return uiType;
-  }
-  return "single-choice";
-};
+): OffchainVoteUiType => getOffchainVoteUiType(proposalType) ?? "single-choice";
 
 export const usesRankedBallot = (proposalType: string): boolean =>
-  RANKED_BALLOT_TYPES.has(proposalType);
+  getOffchainVoteUiType(proposalType) === "ranked-choice";

--- a/apps/dashboard/features/governance/utils/offchainVotingType.ts
+++ b/apps/dashboard/features/governance/utils/offchainVotingType.ts
@@ -1,0 +1,59 @@
+/**
+ * Snapshot proposal `type` strings we receive from the API/indexer.
+ * Some types (e.g. copeland) use ranked ballots but are not listed in @snapshot-labs/snapshot.js types.
+ */
+
+const RANKED_BALLOT_TYPES = new Set(["ranked-choice", "copeland"]);
+
+/** UI + validation: which vote-options component to render. */
+export type OffchainVoteUiType =
+  | "basic"
+  | "single-choice"
+  | "approval"
+  | "ranked-choice"
+  | "weighted"
+  | "quadratic";
+
+const UI_TYPE_ALIASES: Record<string, OffchainVoteUiType> = {
+  copeland: "ranked-choice",
+};
+
+export const getOffchainVoteUiType = (
+  proposalType: string,
+): OffchainVoteUiType | null => {
+  const normalized = UI_TYPE_ALIASES[proposalType] ?? proposalType;
+  switch (normalized) {
+    case "basic":
+    case "single-choice":
+    case "approval":
+    case "ranked-choice":
+    case "weighted":
+    case "quadratic":
+      return normalized;
+    default:
+      return null;
+  }
+};
+
+/** EIP-712 signing: snapshot.js only uses voteArrayTypes for approval + ranked-choice. */
+export const getSnapshotVoteSignType = (
+  proposalType: string,
+):
+  | "basic"
+  | "single-choice"
+  | "approval"
+  | "ranked-choice"
+  | "weighted"
+  | "quadratic" => {
+  if (RANKED_BALLOT_TYPES.has(proposalType)) {
+    return "ranked-choice";
+  }
+  const uiType = getOffchainVoteUiType(proposalType);
+  if (uiType) {
+    return uiType;
+  }
+  return "single-choice";
+};
+
+export const usesRankedBallot = (proposalType: string): boolean =>
+  RANKED_BALLOT_TYPES.has(proposalType);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes DEV-734 for ENS proposal **[6.44] Path forward on Working Groups for Term 7**.

## Root cause

1. **Empty vote modal** — The proposal uses Snapshot voting type **`copeland`** (Condorcet ranked ballot). `OffchainVotingModal` only handled standard Snapshot types, so `copeland` hit the `default` branch and rendered **no vote options**.
2. **Truncated labels** — Current Results used a fixed `w-[100px]` column with `truncate`, cutting ~32-character Snapshot labels.

Verified on Snapshot Hub: proposal `0xe4e1c052b2ea4f640cab27ddec326df6290d8996a9219b60cda4c4d4509f5f9a` has `type: "copeland"` and five choices. Votes use ranked arrays (e.g. `[5,4,3,2,1]`).

## Fix

- Map `copeland` to ranked-choice UI and sign votes as `ranked-choice` (required by snapshot.js for array payloads).
- Widen offchain result labels with tooltip for full text.
- Snapshot fallback link for unsupported types.

## Testing

- `offchainVotingType.test.ts`
- Dashboard typecheck (pre-push)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://blockful.slack.com/archives/C08SL8B3GUF/p1779848782788729?thread_ts=1779848782.788729&cid=C08SL8B3GUF)

<div><a href="https://cursor.com/agents/bc-5a385556-b0c3-5d37-8986-c9028ab4f3ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a385556-b0c3-5d37-8986-c9028ab4f3ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

