### PR TITLE
chore(client): sync package.json with manually published 1.2.0

### DIFF
--- a/.changeset/balance-history-from-to-filters.md
+++ b/.changeset/balance-history-from-to-filters.md
@@ -2,7 +2,6 @@
 "@anticapture/api": minor
 "@anticapture/gateful": patch
 "@anticapture/api-gateway": patch
-"@anticapture/client": patch
 "@anticapture/dashboard": patch
 ---
 

--- a/packages/anticapture-client/CHANGELOG.md
+++ b/packages/anticapture-client/CHANGELOG.md
@@ -1,0 +1,25 @@
+# @anticapture/client
+
+## 1.2.0
+
+Regenerated from the Gateful OpenAPI contract to catch up with API changes accumulated since 1.1.0. This version was published manually to npm; this entry backfills the release notes that changesets would normally generate.
+
+### Minor Changes
+
+- [#1919](https://github.com/blockful/anticapture/pull/1919) [`8c1abdf`](https://github.com/blockful/anticapture/commit/8c1abdf1294f28ffe686823b6db44ca5454e0b45) Thanks [@pikonha](https://github.com/pikonha)! - Add generated clients, hooks, and MSW handlers for ENS `/revenue/*` endpoints: `getRevenueActions`, `getRevenueActiveNames`, `getRevenueNewWallets`, `getRevenueRenewalFunnel`, `getRevenueTotals`, `getRevenueByCategory`, and `getRevenueRenewalTenure`.
+
+### Patch Changes
+
+- [#1875](https://github.com/blockful/anticapture/pull/1875) [`cb90c89`](https://github.com/blockful/anticapture/commit/cb90c8941e32c352ef84eb3b3e45298c1233f4ff) Thanks [@PedroBinotto](https://github.com/PedroBinotto)! - Replace the untyped `FeedMetadata` blob with discriminated metadata schemas (`FeedVoteMetadata`, `FeedProposalMetadata`, `FeedTransferMetadata`, `FeedDelegationMetadata`, and related variants). `/feed/events` now accepts multi-value `type` filters in the generated query params.
+
+- [#1888](https://github.com/blockful/anticapture/pull/1888) [`ac56ee9`](https://github.com/blockful/anticapture/commit/ac56ee949df21ebd7bb0789f2571468b2452ab96) Thanks [@PedroBinotto](https://github.com/PedroBinotto)! - Drop the dedicated lean proposal routes from the SDK and surface a `lean` query param on the existing on-chain and off-chain proposal endpoints instead. `OnchainProposal.calldatas`, `values`, and `targets`, plus `OffchainProposal.body`, are now optional in the generated types.
+
+- [#1888](https://github.com/blockful/anticapture/pull/1888) [`298cc75`](https://github.com/blockful/anticapture/commit/298cc755cd5d62658d5f97294a61c3c66d886362) Thanks [@PedroBinotto](https://github.com/PedroBinotto)! - Migrate `getAggregationsAverageDelegationPercentage` from cursor params (`after`/`before`) to `skip`/`limit`, matching the upstream DAO API pagination contract.
+
+- [#1888](https://github.com/blockful/anticapture/pull/1888) [`298cc755`](https://github.com/blockful/anticapture/commit/298cc755cd5d62658d5f97294a61c3c66d886362) Thanks [@PedroBinotto](https://github.com/PedroBinotto)! - Regenerate types so `percentageChange` on `AccountBalanceVariation` and `VotingPowerVariation` is a plain `string` instead of a mis-typed `bigint`.
+
+- [`156219e`](https://github.com/blockful/anticapture/commit/156219eb109011237bd2957332f092e98ec48cde) Thanks [@lucaspicolloo](https://github.com/lucaspicolloo)! - Add `from` and `to` query params to `historicalBalances` for server-side filtering by transfer sender/recipient.
+
+- [`30dc32c`](https://github.com/blockful/anticapture/commit/30dc32c61) Thanks [@lucaspicolloo](https://github.com/lucaspicolloo)! - Remove the deprecated `transactions` client and its types; use `transfers` instead.
+
+- Regenerate relayer helpers (`getConfig`, `getRateLimit`, `getRelayerBalance`) and bundle MCP server entrypoints in the published `dist/` output.

--- a/packages/anticapture-client/package.json
+++ b/packages/anticapture-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anticapture/client",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "repository": {
     "url": "git+https://github.com/blockful/anticapture.git"
   },


### PR DESCRIPTION
The @anticapture/client npm package was manually published as 1.2.0 to catch up with API contract changes that accumulated since 1.1.0 (added revenue endpoints, schema reshapes from PRs #1853, #1903, #1930) but were never versioned via changesets.

Removes the @anticapture/client bump from the balance-history-from-to changeset since those query params are already included in 1.2.0.