### PR TITLE
refactor(dashboard): migrate panel to kubb SDK (DEV-628)

### DIFF
--- a/.changeset/panel-delegation-kubb.md
+++ b/.changeset/panel-delegation-kubb.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Migrate the panel's delegated-supply history chart off `@anticapture/graphql-client` to the kubb SDK, using the `useAverageDelegationPercentage` aggregate endpoint. No user-visible change.

--- a/apps/dashboard/features/panel/components/DelegatedSupplyHistory.tsx
+++ b/apps/dashboard/features/panel/components/DelegatedSupplyHistory.tsx
@@ -29,14 +29,14 @@ export const DelegatedSupplyHistory = () => {
   const startDate = useMemo(() => {
     const oneYearAgo = new Date();
     oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
-    return Math.floor(oneYearAgo.getTime() / 1000).toString();
+    return Math.floor(oneYearAgo.getTime() / 1000);
   }, []);
 
   // Calculate endDate as today at midnight UTC in seconds (Unix timestamp)
   const endDate = useMemo(() => {
     const today = new Date();
     today.setUTCHours(0, 0, 0, 0);
-    return Math.floor(today.getTime() / 1000).toString();
+    return Math.floor(today.getTime() / 1000);
   }, []);
 
   const { data, loading, error } = useDelegationPercentageByDay(

--- a/apps/dashboard/shared/hooks/useDelegationPercentageByDay.ts
+++ b/apps/dashboard/shared/hooks/useDelegationPercentageByDay.ts
@@ -1,4 +1,4 @@
-import { useGetDelegatedSupplyHistoryQuery } from "@anticapture/graphql-client/hooks";
+import { useAverageDelegationPercentage } from "@anticapture/client/hooks";
 
 interface DelegationPercentageItem {
   date: string;
@@ -12,24 +12,24 @@ interface UseDelegationPercentageByDayResult {
   refetch: () => void;
 }
 
+const DELEGATION_HISTORY_LIMIT = 365;
+
 export const useDelegationPercentageByDay = (
-  startDate: string,
-  endDate?: string,
+  startDate: number,
+  endDate?: number,
 ): UseDelegationPercentageByDayResult => {
-  const { data, loading, error, refetch } = useGetDelegatedSupplyHistoryQuery({
-    variables: {
-      startDate,
-      endDate: endDate ?? null,
-    },
+  const { data, isLoading, error, refetch } = useAverageDelegationPercentage({
+    startDate,
+    endDate,
+    limit: DELEGATION_HISTORY_LIMIT,
   });
 
   return {
-    data:
-      (data?.averageDelegationPercentageByDay?.items as
-        | DelegationPercentageItem[]
-        | null) || null,
-    loading,
-    error: error || null,
-    refetch: () => refetch(),
+    data: data?.items ?? null,
+    loading: isLoading,
+    error: error instanceof Error ? error : null,
+    refetch: () => {
+      refetch();
+    },
   };
 };


### PR DESCRIPTION
## Summary

Completes the panel's migration off `@anticapture/graphql-client` to the generated kubb SDK (`@anticapture/client`). The remaining dependency was the delegated-supply history chart; the rest of the panel's hooks were already migrated on `dev`.

## Context

- 📋 Ticket: [DEV-628 — Migrate Panel to Kubb SDK](https://app.clickup.com/t/90132341641/DEV-628)
- 🌿 Branch: `feat/migrate-panel-kubb-sdk`

## What changed

- **UI/data:** `useDelegationPercentageByDay` now calls the kubb `useAverageDelegationPercentage` hook instead of the graphql `useGetDelegatedSupplyHistoryQuery`. The wrapper keeps its public contract (`{ data, loading, error, refetch }`); only the internals changed.
- Preserved the **cross-DAO mean aggregate** behavior (the endpoint `/aggregations/average-delegation-percentage`, no dao param) and the hardcoded **365-day window** (kubb default limit is 10).
- `DelegatedSupplyHistory` now passes `startDate`/`endDate` as numbers (Unix seconds) to match the kubb contract.

## Self-review summary

- ✅ Behavior-preserving: aggregate endpoint (not per-DAO), 365-day limit, shape `{date, high}` all confirmed against generated models.
- ✅ `pnpm dashboard typecheck` + `lint` pass (0 errors).
- ℹ️ No visual change → no screenshots; data-layer swap → no diagram.

## Changeset

- `@anticapture/dashboard`: patch — internal client swap, no user-visible change.