### PR TITLE
refactor(dashboard): migrate offchain governance to kubb SDK

### DIFF
--- a/.changeset/migrate-offchain-governance-kubb.md
+++ b/.changeset/migrate-offchain-governance-kubb.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Migrate offchain governance (proposals, votes, and token metrics in the proposal view) off `@anticapture/graphql-client` to the kubb SDK. Apollo infinite pagination (`fetchMore`) is replaced with react-query infinite queries, and cache refetch is replaced with `invalidateQueries`. No user-visible change.

--- a/apps/dashboard/features/dao-overview/hooks/useLastProposals.ts
+++ b/apps/dashboard/features/dao-overview/hooks/useLastProposals.ts
@@ -17,7 +17,7 @@ const LAST_PROPOSALS_LIMIT = 3;
 export const useLastProposals = (daoId: DaoIdEnum): UseLastProposalsResult => {
   const { data, isLoading, error } = useProposals({
     daoId,
-    itemsPerPage: LAST_PROPOSALS_LIMIT,
+    limit: LAST_PROPOSALS_LIMIT,
   });
 
   return {

--- a/apps/dashboard/features/governance/components/governance-overview/GovernanceSection.tsx
+++ b/apps/dashboard/features/governance/components/governance-overview/GovernanceSection.tsx
@@ -125,7 +125,7 @@ export const GovernanceSection = () => {
     isFetchingNextPage: isOnchainPaginationLoading,
     hasNextPage: hasNextOnchainPage,
   } = useProposals({
-    itemsPerPage: 10,
+    limit: 10,
     orderDirection: orderDirectionEnum.desc,
     daoId: daoIdEnum,
     fromDate: undefined,

--- a/apps/dashboard/features/governance/components/modals/OffchainVotingModal.tsx
+++ b/apps/dashboard/features/governance/components/modals/OffchainVotingModal.tsx
@@ -21,12 +21,10 @@ import { formatNumberUserReadable } from "@/shared/utils";
 
 type VoteChoice = number | number[] | Record<string, number>;
 
-type OffchainProposalData = OffchainProposal;
-
 interface OffchainVotingModalProps {
   isOpen: boolean;
   onClose: () => void;
-  proposal: OffchainProposalData;
+  proposal: OffchainProposal;
   hasVoted?: boolean;
   onVoteSuccess?: (voteLabel: string) => void;
 }
@@ -45,14 +43,11 @@ export const OffchainVotingModal = ({
   const { vote, isPending: isVoting } = useVoteOnOffchainProposal();
   const strategies = useMemo(
     () =>
-      proposal.strategies
-        ?.filter((s): s is NonNullable<typeof s> => s !== null)
-        .map((s) => ({
-          name: s.name,
-          network: s.network,
-          params:
-            typeof s.params === "string" ? JSON.parse(s.params) : s.params,
-        })),
+      proposal.strategies.map((s) => ({
+        name: s.name,
+        network: s.network,
+        params: typeof s.params === "string" ? JSON.parse(s.params) : s.params,
+      })),
     [proposal.strategies],
   );
   const {

--- a/apps/dashboard/features/governance/components/modals/OffchainVotingModal.tsx
+++ b/apps/dashboard/features/governance/components/modals/OffchainVotingModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { GetOffchainProposalQuery } from "@anticapture/graphql-client/hooks";
+import type { OffchainProposal } from "@anticapture/client";
 import { X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useAccount } from "wagmi";
@@ -21,10 +21,7 @@ import { formatNumberUserReadable } from "@/shared/utils";
 
 type VoteChoice = number | number[] | Record<string, number>;
 
-type OffchainProposalData = Extract<
-  NonNullable<GetOffchainProposalQuery["offchainProposalById"]>,
-  { __typename?: "OffchainProposal" }
->;
+type OffchainProposalData = OffchainProposal;
 
 interface OffchainVotingModalProps {
   isOpen: boolean;

--- a/apps/dashboard/features/governance/components/proposal-overview/OffchainVotesContent.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/OffchainVotesContent.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import type { OffchainVote } from "@anticapture/graphql-client";
 import {
-  OrderDirection,
-  QueryInput_VotesOffchainByProposalId_OrderBy,
-  useGetOffchainVotesByProposalIdQuery,
-} from "@anticapture/graphql-client/hooks";
+  getNextPageParam,
+  type OffchainVote,
+  type OrderDirection,
+  type VotesOffchainByProposalIdPathParamsDaoEnumKey,
+  type VotesOffchainByProposalIdQueryParamsOrderByEnumKey,
+} from "@anticapture/client";
+import { useVotesOffchainByProposalIdInfinite } from "@anticapture/client/hooks";
 import type { ColumnDef } from "@tanstack/react-table";
 import { CheckCircle2, CircleMinus, Inbox, XCircle } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -25,6 +27,16 @@ import { formatNumberUserReadable } from "@/shared/utils/formatNumberUserReadabl
 import { CopyAndPasteButton } from "@/shared/components/buttons/CopyAndPasteButton";
 
 const LOADING_ROW = "__LOADING_ROW__";
+
+// Table rows include synthetic sentinel rows (loading + description sub-rows)
+// whose `voter` is not a real address, so widen it from the strict `Address`.
+type OffchainVoteRow = Omit<
+  OffchainVote,
+  "voter" | "proposalId" | "proposalTitle"
+> & {
+  voter: string;
+  isSubRow?: boolean;
+};
 
 const getLabelDisplay = (label: string) => {
   const lower = label.toLowerCase();
@@ -68,77 +80,42 @@ export const OffchainVotesContent = ({
   const loadingRowRef = useRef<HTMLTableRowElement>(null);
 
   const [orderBy, setOrderBy] =
-    useState<QueryInput_VotesOffchainByProposalId_OrderBy>(
-      QueryInput_VotesOffchainByProposalId_OrderBy.Timestamp,
-    );
-  const [orderDirection, setOrderDirection] = useState<OrderDirection>(
-    OrderDirection.Desc,
-  );
+    useState<VotesOffchainByProposalIdQueryParamsOrderByEnumKey>("timestamp");
+  const [orderDirection, setOrderDirection] = useState<OrderDirection>("desc");
 
   const handleSort = useCallback(
-    (field: QueryInput_VotesOffchainByProposalId_OrderBy) => {
+    (field: VotesOffchainByProposalIdQueryParamsOrderByEnumKey) => {
       if (orderBy === field) {
-        setOrderDirection((prev) =>
-          prev === OrderDirection.Asc
-            ? OrderDirection.Desc
-            : OrderDirection.Asc,
-        );
+        setOrderDirection((prev) => (prev === "asc" ? "desc" : "asc"));
       } else {
         setOrderBy(field);
-        setOrderDirection(OrderDirection.Desc);
+        setOrderDirection("desc");
       }
     },
     [orderBy],
   );
 
-  const { data, loading, error, fetchMore } =
-    useGetOffchainVotesByProposalIdQuery({
-      variables: {
-        id: proposalId,
-        limit: 10,
-        skip: 0,
-        fromDate: null,
-        toDate: null,
-        voterAddresses: null,
-        orderBy,
-        orderDirection,
-      },
-      context: {
-        headers: {
-          "anticapture-dao-id": daoId,
-        },
-      },
-      skip: !proposalId,
-    });
+  const {
+    data,
+    isLoading: loading,
+    error,
+    fetchNextPage,
+    hasNextPage,
+  } = useVotesOffchainByProposalIdInfinite(
+    daoId.toLowerCase() as VotesOffchainByProposalIdPathParamsDaoEnumKey,
+    proposalId,
+    { limit: 10, orderBy, orderDirection },
+    { query: { enabled: !!proposalId, getNextPageParam } },
+  );
 
   const votes = useMemo(
-    () =>
-      (data?.votesOffchainByProposalId?.items ?? []).filter(
-        (vote): vote is OffchainVote => vote !== null,
-      ),
+    () => data?.pages.flatMap((page) => page.items) ?? [],
     [data],
   );
-  const totalCount = data?.votesOffchainByProposalId?.totalCount ?? 0;
-  const hasNextPage = votes.length < totalCount;
 
   const loadMore = useCallback(() => {
-    fetchMore({
-      variables: { skip: votes.length },
-      updateQuery: (prev, { fetchMoreResult }) => {
-        if (!fetchMoreResult?.votesOffchainByProposalId?.items) return prev;
-        return {
-          ...prev,
-          votesOffchainByProposalId: {
-            ...prev.votesOffchainByProposalId!,
-            items: [
-              ...(prev.votesOffchainByProposalId?.items ?? []),
-              ...fetchMoreResult.votesOffchainByProposalId.items,
-            ],
-          },
-        };
-      },
-    });
-  }, [fetchMore, votes.length]);
+    void fetchNextPage();
+  }, [fetchNextPage]);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -152,9 +129,7 @@ export const OffchainVotesContent = ({
   }, [hasNextPage, loading, loadMore]);
 
   const tableData = useMemo(() => {
-    const rows: (Omit<OffchainVote, "proposalId" | "proposalTitle"> & {
-      isSubRow?: boolean;
-    })[] = [];
+    const rows: OffchainVoteRow[] = [];
 
     votes.forEach((vote) => {
       rows.push(vote);
@@ -180,10 +155,10 @@ export const OffchainVotesContent = ({
       });
     }
 
-    return rows as OffchainVote[];
+    return rows;
   }, [votes, hasNextPage, loading]);
 
-  const columns: ColumnDef<OffchainVote>[] = useMemo(
+  const columns: ColumnDef<OffchainVoteRow>[] = useMemo(
     () => [
       {
         accessorKey: "voter",
@@ -295,17 +270,14 @@ export const OffchainVotesContent = ({
             variant="ghost"
             size="sm"
             className="text-secondary w-full justify-start"
-            onClick={() =>
-              handleSort(QueryInput_VotesOffchainByProposalId_OrderBy.Timestamp)
-            }
+            onClick={() => handleSort("timestamp")}
           >
             <h4 className="text-table-header whitespace-nowrap">Date</h4>
             <ArrowUpDown
               props={{ className: "size-4 ml-1" }}
               activeState={
-                orderBy ===
-                QueryInput_VotesOffchainByProposalId_OrderBy.Timestamp
-                  ? orderDirection === OrderDirection.Asc
+                orderBy === "timestamp"
+                  ? orderDirection === "asc"
                     ? ArrowState.UP
                     : ArrowState.DOWN
                   : ArrowState.DEFAULT
@@ -359,11 +331,7 @@ export const OffchainVotesContent = ({
             variant="ghost"
             size="sm"
             className="text-secondary w-full justify-start"
-            onClick={() =>
-              handleSort(
-                QueryInput_VotesOffchainByProposalId_OrderBy.VotingPower,
-              )
-            }
+            onClick={() => handleSort("votingPower")}
           >
             <h4 className="text-table-header whitespace-nowrap">
               Voting Power
@@ -371,9 +339,8 @@ export const OffchainVotesContent = ({
             <ArrowUpDown
               props={{ className: "size-4 ml-1" }}
               activeState={
-                orderBy ===
-                QueryInput_VotesOffchainByProposalId_OrderBy.VotingPower
-                  ? orderDirection === OrderDirection.Asc
+                orderBy === "votingPower"
+                  ? orderDirection === "asc"
                     ? ArrowState.UP
                     : ArrowState.DOWN
                   : ArrowState.DEFAULT
@@ -419,14 +386,19 @@ export const OffchainVotesContent = ({
     ],
   );
 
-  if (error) return <div>Error: {error.message}</div>;
+  if (error)
+    return (
+      <div>
+        Error: {error instanceof Error ? error.message : "Failed to load votes"}
+      </div>
+    );
 
   if (loading && votes.length === 0) {
     return (
       <div className="w-full lg:p-4">
         <VotesTable
           columns={columns}
-          data={Array.from({ length: 7 }, () => ({}) as OffchainVote)}
+          data={Array.from({ length: 7 }, () => ({}) as OffchainVoteRow)}
         />
       </div>
     );

--- a/apps/dashboard/features/governance/components/proposal-overview/OffchainVotesContent.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/OffchainVotesContent.tsx
@@ -101,6 +101,7 @@ export const OffchainVotesContent = ({
     error,
     fetchNextPage,
     hasNextPage,
+    isFetchingNextPage,
   } = useVotesOffchainByProposalIdInfinite(
     daoId.toLowerCase() as VotesOffchainByProposalIdPathParamsDaoEnumKey,
     proposalId,
@@ -113,20 +114,21 @@ export const OffchainVotesContent = ({
     [data],
   );
 
-  const loadMore = useCallback(() => {
-    void fetchNextPage();
-  }, [fetchNextPage]);
-
+  // Intersection observer on the loading row. `isFetchingNextPage` flips
+  // true -> false on each page, re-running this effect so the observer
+  // re-attaches to the freshly rendered sentinel (mirrors the on-chain votes).
   useEffect(() => {
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry?.isIntersecting && hasNextPage && !loading) loadMore();
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
       },
       { threshold: 0.1 },
     );
     if (loadingRowRef.current) observer.observe(loadingRowRef.current);
     return () => observer.disconnect();
-  }, [hasNextPage, loading, loadMore]);
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   const tableData = useMemo(() => {
     const rows: OffchainVoteRow[] = [];
@@ -145,7 +147,7 @@ export const OffchainVotesContent = ({
       }
     });
 
-    if (hasNextPage || (loading && votes.length > 0)) {
+    if (hasNextPage || isFetchingNextPage) {
       rows.push({
         voter: LOADING_ROW,
         choice: [],
@@ -156,7 +158,7 @@ export const OffchainVotesContent = ({
     }
 
     return rows;
-  }, [votes, hasNextPage, loading]);
+  }, [votes, hasNextPage, isFetchingNextPage]);
 
   const columns: ColumnDef<OffchainVoteRow>[] = useMemo(
     () => [

--- a/apps/dashboard/features/governance/components/proposal-overview/ProposalSection.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/ProposalSection.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import type { VotesOffchainByProposalIdPathParamsDaoEnumKey } from "@anticapture/client";
 import {
-  OrderDirection,
-  QueryInput_VotesOffchainByProposalId_OrderBy,
-  useGetOffchainVotesByProposalIdQuery,
-} from "@anticapture/graphql-client/hooks";
-import { useApolloClient } from "@apollo/client";
+  offchainProposalByIdQueryKey,
+  useVotesOffchainByProposalId,
+  votesOffchainByProposalIdQueryKey,
+} from "@anticapture/client/hooks";
+import { useQueryClient } from "@tanstack/react-query";
 import { ArrowRight } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useState, useCallback, useMemo, useRef } from "react";
@@ -107,10 +108,9 @@ export const ProposalSection = ({
     daoId: daoEnum,
   });
 
-  const rawOffchainProposal =
-    rawOffchainResponse?.__typename === "OffchainProposal"
-      ? rawOffchainResponse
-      : null;
+  const rawOffchainProposal = rawOffchainResponse;
+  const offchainDaoKey =
+    daoEnum.toLowerCase() as VotesOffchainByProposalIdPathParamsDaoEnumKey;
 
   const { data: accountPower } = useAccountPower({
     address: address ?? "",
@@ -132,23 +132,22 @@ export const ProposalSection = ({
     [rawOffchainProposal?.choices],
   );
 
-  const { data: userOffchainVoteData } = useGetOffchainVotesByProposalIdQuery({
-    variables: {
-      id: offchainProposalId,
-      voterAddresses: address ? [address] : [],
+  const { data: userOffchainVoteData } = useVotesOffchainByProposalId(
+    offchainDaoKey,
+    offchainProposalId,
+    {
+      voterAddresses: address ? [address] : undefined,
       limit: 1,
-      skip: 0,
-      fromDate: null,
-      toDate: null,
-      orderBy: QueryInput_VotesOffchainByProposalId_OrderBy.Timestamp,
-      orderDirection: OrderDirection.Desc,
+      orderBy: "timestamp",
+      orderDirection: "desc",
     },
-    context: { headers: { "anticapture-dao-id": daoEnum } },
-    skip: !isOffchain || !offchainProposalId || !address,
-  });
+    {
+      query: { enabled: !!isOffchain && !!offchainProposalId && !!address },
+    },
+  );
 
   const apiOffchainVoteChoice = (
-    userOffchainVoteData?.votesOffchainByProposalId?.items?.[0]?.choice ?? []
+    userOffchainVoteData?.items?.[0]?.choice ?? []
   ).filter((c): c is string => c != null);
   const apiOffchainVoteLabel =
     apiOffchainVoteChoice.length > 0
@@ -158,18 +157,27 @@ export const ProposalSection = ({
   const offchainHasVoted = !!localOffchainVoteLabel || !!apiOffchainVoteLabel;
   const offchainVoteLabel = localOffchainVoteLabel ?? apiOffchainVoteLabel;
 
-  const apolloClient = useApolloClient();
+  const queryClient = useQueryClient();
 
   const handleOffchainVoteSuccess = useCallback(
     (voteLabel: string) => {
       setLocalOffchainVoteLabel(voteLabel);
       // Refetch votes (badge + table) and proposal scores so the UI reflects
       // the new vote without requiring a manual page reload.
-      apolloClient.refetchQueries({
-        include: ["GetOffchainVotesByProposalId", "GetOffchainProposal"],
+      void queryClient.invalidateQueries({
+        queryKey: votesOffchainByProposalIdQueryKey(
+          offchainDaoKey,
+          offchainProposalId,
+        ),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: offchainProposalByIdQueryKey(
+          offchainDaoKey,
+          offchainProposalId,
+        ),
       });
     },
-    [apolloClient],
+    [queryClient, offchainDaoKey, offchainProposalId],
   );
 
   const adaptedOffchainProposal: ProposalViewData | null = rawOffchainProposal

--- a/apps/dashboard/features/governance/components/proposal-overview/VotesTabContent.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/VotesTabContent.tsx
@@ -2,17 +2,14 @@
 
 import type {
   ProposalNonVotersPathParamsDaoEnumKey,
+  TokenMetricsPathParamsDaoEnumKey,
   VotesByProposalIdPathParamsDaoEnumKey,
 } from "@anticapture/client";
 import {
   useProposalNonVoters,
+  useTokenMetrics,
   useVotesByProposalId,
 } from "@anticapture/client/hooks";
-import {
-  OrderDirection,
-  QueryInput_TokenMetrics_MetricType,
-} from "@anticapture/graphql-client";
-import { useTokenMetricsQuery } from "@anticapture/graphql-client/hooks";
 import { useParams } from "next/navigation";
 import { parseAsStringEnum, useQueryState } from "nuqs";
 import { formatUnits } from "viem";
@@ -49,21 +46,15 @@ export const VotesTabContent = ({
   const nonVotersDaoKey =
     daoIdEnum.toLowerCase() as ProposalNonVotersPathParamsDaoEnumKey;
 
-  const { data: delegatedSupplyData } = useTokenMetricsQuery({
-    variables: {
-      metricType: QueryInput_TokenMetrics_MetricType.DelegatedSupply,
-      startDate: null,
+  const { data: delegatedSupplyData } = useTokenMetrics(
+    daoIdEnum.toLowerCase() as TokenMetricsPathParamsDaoEnumKey,
+    {
+      metricType: "DELEGATED_SUPPLY",
       endDate: Number(proposal.endTimestamp),
-      orderDirection: OrderDirection.Desc,
+      orderDirection: "desc",
       limit: 1,
-      skip: null,
     },
-    context: {
-      headers: {
-        "anticapture-dao-id": daoIdEnum,
-      },
-    },
-  });
+  );
 
   const { data } = useVotesByProposalId(
     votesDaoKey,
@@ -100,8 +91,7 @@ export const VotesTabContent = ({
     BigInt(proposal.againstVotes) +
     BigInt(proposal.abstainVotes);
 
-  const historicalDelegatedSupply =
-    delegatedSupplyData?.tokenMetrics?.items?.[0]?.high;
+  const historicalDelegatedSupply = delegatedSupplyData?.items?.[0]?.high;
 
   const delegatedSupplyBigInt = historicalDelegatedSupply
     ? BigInt(historicalDelegatedSupply)

--- a/apps/dashboard/features/governance/hooks/useOffchainProposal.ts
+++ b/apps/dashboard/features/governance/hooks/useOffchainProposal.ts
@@ -1,14 +1,7 @@
-import type { OffchainProposalByIdPathParamsDaoEnumKey } from "@anticapture/client";
-import type { OffchainProposal } from "@anticapture/client";
 import { useOffchainProposalById } from "@anticapture/client/hooks";
+import type { OffchainProposalByIdPathParamsDaoEnumKey } from "@anticapture/client";
 
 import type { DaoIdEnum } from "@/shared/types/daos";
-
-export interface UseOffchainProposalResult {
-  proposal: OffchainProposal | null;
-  loading: boolean;
-  error: Error | null;
-}
 
 export interface UseOffchainProposalParams {
   proposalId: string;
@@ -18,17 +11,16 @@ export interface UseOffchainProposalParams {
 export const useOffchainProposal = ({
   proposalId,
   daoId,
-}: UseOffchainProposalParams): UseOffchainProposalResult => {
+}: UseOffchainProposalParams) => {
   const { data, isLoading, error } = useOffchainProposalById(
     daoId.toLowerCase() as OffchainProposalByIdPathParamsDaoEnumKey,
     proposalId,
     undefined,
-    { query: { enabled: !!proposalId } },
   );
 
   return {
-    proposal: data ?? null,
+    proposal: data,
     loading: isLoading,
-    error: error instanceof Error ? error : null,
+    error,
   };
 };

--- a/apps/dashboard/features/governance/hooks/useOffchainProposal.ts
+++ b/apps/dashboard/features/governance/hooks/useOffchainProposal.ts
@@ -1,13 +1,13 @@
-import type { GetOffchainProposalQuery } from "@anticapture/graphql-client/hooks";
-import { useGetOffchainProposalQuery } from "@anticapture/graphql-client/hooks";
-import type { ApolloError } from "@apollo/client";
+import type { OffchainProposalByIdPathParamsDaoEnumKey } from "@anticapture/client";
+import type { OffchainProposal } from "@anticapture/client";
+import { useOffchainProposalById } from "@anticapture/client/hooks";
 
 import type { DaoIdEnum } from "@/shared/types/daos";
 
 export interface UseOffchainProposalResult {
-  proposal: GetOffchainProposalQuery["offchainProposalById"] | null;
+  proposal: OffchainProposal | null;
   loading: boolean;
-  error: ApolloError | undefined;
+  error: Error | null;
 }
 
 export interface UseOffchainProposalParams {
@@ -19,15 +19,16 @@ export const useOffchainProposal = ({
   proposalId,
   daoId,
 }: UseOffchainProposalParams): UseOffchainProposalResult => {
-  const { data, loading, error } = useGetOffchainProposalQuery({
-    variables: { id: proposalId },
-    context: {
-      headers: {
-        "anticapture-dao-id": daoId,
-      },
-    },
-    skip: !proposalId,
-  });
+  const { data, isLoading, error } = useOffchainProposalById(
+    daoId.toLowerCase() as OffchainProposalByIdPathParamsDaoEnumKey,
+    proposalId,
+    undefined,
+    { query: { enabled: !!proposalId } },
+  );
 
-  return { proposal: data?.offchainProposalById ?? null, loading, error };
+  return {
+    proposal: data ?? null,
+    loading: isLoading,
+    error: error instanceof Error ? error : null,
+  };
 };

--- a/apps/dashboard/features/governance/hooks/useOffchainProposals.ts
+++ b/apps/dashboard/features/governance/hooks/useOffchainProposals.ts
@@ -1,143 +1,99 @@
-import type {
-  GetOffchainProposalsFromDaoQuery,
-  QueryOffchainProposalsArgs,
-} from "@anticapture/graphql-client/hooks";
 import {
-  OrderDirection,
-  useGetOffchainProposalsFromDaoQuery,
-} from "@anticapture/graphql-client/hooks";
-import type { ApolloError } from "@apollo/client";
-import { useCallback, useMemo, useState } from "react";
+  getNextPageParam,
+  type OffchainProposalsPathParamsDaoEnumKey,
+  type OffchainProposalsQueryParams,
+  type OffchainProposalsQueryResponse,
+  type OrderDirection,
+} from "@anticapture/client";
+import { useOffchainProposalsInfinite } from "@anticapture/client/hooks";
+import { useCallback, useMemo } from "react";
 
 import type { PaginationInfo } from "@/features/governance/hooks/useProposals";
 import type { DaoIdEnum } from "@/shared/types/daos";
 
-export type OffchainProposalItem = NonNullable<
-  NonNullable<
-    GetOffchainProposalsFromDaoQuery["offchainProposals"]
-  >["items"][number]
->;
+export type OffchainProposalItem =
+  OffchainProposalsQueryResponse["items"][number];
 
 export interface UseOffchainProposalsResult {
   proposals: OffchainProposalItem[];
   loading: boolean;
-  error: ApolloError | undefined;
+  error: Error | null;
   pagination: PaginationInfo;
   fetchNextPage: () => Promise<void>;
   isPaginationLoading: boolean;
 }
 
-export interface UseOffchainProposalsParams extends Partial<
-  Omit<QueryOffchainProposalsArgs, "skip" | "limit">
-> {
+export interface UseOffchainProposalsParams {
+  fromDate?: number | null;
+  orderDirection?: OrderDirection;
+  status?: OffchainProposalsQueryParams["status"];
   itemsPerPage?: number;
   daoId?: DaoIdEnum;
 }
 
 export const useOffchainProposals = ({
   fromDate,
-  orderDirection = OrderDirection.Desc,
+  orderDirection = "desc",
   status,
   itemsPerPage = 10,
   daoId,
 }: UseOffchainProposalsParams = {}): UseOffchainProposalsResult => {
-  const [isPaginationLoading, setIsPaginationLoading] = useState(false);
-
-  const queryVariables = useMemo(
+  const queryParams = useMemo<OffchainProposalsQueryParams>(
     () => ({
-      skip: 0,
       limit: itemsPerPage,
       orderDirection,
-      status: status ?? null,
-      fromDate: fromDate ?? null,
+      status: status ?? undefined,
+      fromDate: fromDate ?? undefined,
     }),
     [itemsPerPage, orderDirection, status, fromDate],
   );
 
-  const { data, loading, error, fetchMore } =
-    useGetOffchainProposalsFromDaoQuery({
-      variables: queryVariables,
-      skip: !daoId,
-      notifyOnNetworkStatusChange: true,
-      context: {
-        headers: {
-          "anticapture-dao-id": daoId,
-        },
-      },
-    });
+  const {
+    data,
+    isLoading,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useOffchainProposalsInfinite(
+    daoId?.toLowerCase() as OffchainProposalsPathParamsDaoEnumKey,
+    queryParams,
+    { query: { enabled: !!daoId, getNextPageParam } },
+  );
 
-  const proposals = useMemo(() => {
-    return (data?.offchainProposals?.items ?? []).filter(
-      (p): p is OffchainProposalItem => p !== null,
-    );
-  }, [data]);
+  const proposals = useMemo(
+    () => data?.pages.flatMap((page) => page.items) ?? [],
+    [data],
+  );
+
+  const totalCount = data?.pages[0]?.totalCount ?? 0;
 
   const pagination: PaginationInfo = useMemo(() => {
-    const totalCount = data?.offchainProposals?.totalCount ?? 0;
     const currentItemsCount = proposals.length;
-    const hasNextPage = currentItemsCount < totalCount;
     const currentPage = Math.ceil(currentItemsCount / itemsPerPage);
     const totalPages = Math.ceil(totalCount / itemsPerPage);
 
     return {
-      hasNextPage,
+      hasNextPage: Boolean(hasNextPage),
       totalCount,
       currentPage,
       totalPages,
       itemsPerPage,
       currentItemsCount,
     };
-  }, [data?.offchainProposals?.totalCount, proposals.length, itemsPerPage]);
+  }, [proposals.length, totalCount, itemsPerPage, hasNextPage]);
 
-  const fetchNextPage = useCallback(async () => {
-    if (!pagination.hasNextPage || isPaginationLoading) return;
-
-    setIsPaginationLoading(true);
-
-    try {
-      await fetchMore({
-        variables: { ...queryVariables, skip: proposals.length },
-        updateQuery: (
-          previousResult: GetOffchainProposalsFromDaoQuery,
-          {
-            fetchMoreResult,
-          }: { fetchMoreResult: GetOffchainProposalsFromDaoQuery },
-        ) => {
-          if (!fetchMoreResult?.offchainProposals?.items?.length) {
-            return previousResult;
-          }
-
-          return {
-            ...fetchMoreResult,
-            offchainProposals: {
-              ...fetchMoreResult.offchainProposals,
-              items: [
-                ...(previousResult.offchainProposals?.items ?? []),
-                ...(fetchMoreResult.offchainProposals?.items ?? []),
-              ],
-            },
-          };
-        },
-      });
-    } catch (err) {
-      console.error("Error fetching next page:", err);
-    } finally {
-      setIsPaginationLoading(false);
-    }
-  }, [
-    fetchMore,
-    pagination.hasNextPage,
-    isPaginationLoading,
-    queryVariables,
-    proposals.length,
-  ]);
+  const handleFetchNextPage = useCallback(async () => {
+    if (!hasNextPage || isFetchingNextPage) return;
+    await fetchNextPage();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return {
     proposals,
-    loading,
-    error,
+    loading: isLoading,
+    error: error instanceof Error ? error : null,
     pagination,
-    fetchNextPage,
-    isPaginationLoading,
+    fetchNextPage: handleFetchNextPage,
+    isPaginationLoading: isFetchingNextPage,
   };
 };

--- a/apps/dashboard/features/governance/hooks/useOffchainProposals.ts
+++ b/apps/dashboard/features/governance/hooks/useOffchainProposals.ts
@@ -6,22 +6,12 @@ import {
   type OrderDirection,
 } from "@anticapture/client";
 import { useOffchainProposalsInfinite } from "@anticapture/client/hooks";
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 
-import type { PaginationInfo } from "@/features/governance/hooks/useProposals";
 import type { DaoIdEnum } from "@/shared/types/daos";
 
 export type OffchainProposalItem =
   OffchainProposalsQueryResponse["items"][number];
-
-export interface UseOffchainProposalsResult {
-  proposals: OffchainProposalItem[];
-  loading: boolean;
-  error: Error | null;
-  pagination: PaginationInfo;
-  fetchNextPage: () => Promise<void>;
-  isPaginationLoading: boolean;
-}
 
 export interface UseOffchainProposalsParams {
   fromDate?: number | null;
@@ -37,7 +27,7 @@ export const useOffchainProposals = ({
   status,
   itemsPerPage = 10,
   daoId,
-}: UseOffchainProposalsParams = {}): UseOffchainProposalsResult => {
+}: UseOffchainProposalsParams = {}) => {
   const queryParams = useMemo<OffchainProposalsQueryParams>(
     () => ({
       limit: itemsPerPage,
@@ -68,32 +58,18 @@ export const useOffchainProposals = ({
 
   const totalCount = data?.pages[0]?.totalCount ?? 0;
 
-  const pagination: PaginationInfo = useMemo(() => {
-    const currentItemsCount = proposals.length;
-    const currentPage = Math.ceil(currentItemsCount / itemsPerPage);
-    const totalPages = Math.ceil(totalCount / itemsPerPage);
-
-    return {
-      hasNextPage: Boolean(hasNextPage),
-      totalCount,
-      currentPage,
-      totalPages,
-      itemsPerPage,
-      currentItemsCount,
-    };
-  }, [proposals.length, totalCount, itemsPerPage, hasNextPage]);
-
-  const handleFetchNextPage = useCallback(async () => {
-    if (!hasNextPage || isFetchingNextPage) return;
-    await fetchNextPage();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
-
   return {
     proposals,
     loading: isLoading,
-    error: error instanceof Error ? error : null,
-    pagination,
-    fetchNextPage: handleFetchNextPage,
+    error,
+    pagination: {
+      hasNextPage: Boolean(hasNextPage),
+      totalCount,
+      currentPage: Math.ceil(proposals.length / itemsPerPage),
+      totalPages: Math.ceil(totalCount / itemsPerPage),
+      itemsPerPage,
+    },
+    fetchNextPage,
     isPaginationLoading: isFetchingNextPage,
   };
 };

--- a/apps/dashboard/features/governance/hooks/useProposals.ts
+++ b/apps/dashboard/features/governance/hooks/useProposals.ts
@@ -17,29 +17,7 @@ import {
 import daoConfig from "@/shared/dao-config";
 import type { DaoIdEnum } from "@/shared/types/daos";
 
-export interface PaginationInfo {
-  hasNextPage: boolean;
-  totalCount: number;
-  currentPage: number;
-  totalPages: number;
-  itemsPerPage: number;
-  currentItemsCount: number;
-}
-
-export interface UseProposalsResult {
-  data: GovernanceProposal[];
-  isLoading: boolean;
-  error: Error | null;
-  fetchNextPage: () => Promise<void>;
-  isFetchingNextPage: boolean;
-  hasNextPage: boolean;
-}
-
-export interface UseProposalsParams extends Omit<
-  ProposalsQueryParams,
-  "skip" | "limit"
-> {
-  itemsPerPage?: number;
+export interface UseProposalsParams extends Omit<ProposalsQueryParams, "skip"> {
   daoId?: DaoIdEnum;
 }
 
@@ -50,7 +28,7 @@ export const useProposals = (
     status,
     fromEndDate,
     includeOptimisticProposals,
-    itemsPerPage = 10,
+    limit = 10,
     daoId,
   }: UseProposalsParams = {
     fromDate: undefined,
@@ -58,21 +36,21 @@ export const useProposals = (
     fromEndDate: undefined,
     includeOptimisticProposals: undefined,
   },
-): UseProposalsResult => {
+) => {
   const { decimals } = daoConfig[daoId as DaoIdEnum];
   const daoKey = daoId?.toLowerCase() as ProposalsPathParamsDaoEnumKey;
 
   const queryParams = useMemo<ProposalsQueryParams>(
     () => ({
-      limit: itemsPerPage,
+      limit,
       orderDirection,
-      status: status ?? undefined,
-      fromDate: fromDate ?? undefined,
-      fromEndDate: fromEndDate ?? undefined,
-      includeOptimisticProposals: includeOptimisticProposals ?? undefined,
+      status,
+      fromDate,
+      fromEndDate,
+      includeOptimisticProposals,
     }),
     [
-      itemsPerPage,
+      limit,
       orderDirection,
       status,
       fromDate,
@@ -131,10 +109,8 @@ export const useProposals = (
   return {
     data: proposals,
     isLoading,
-    error: error instanceof Error ? error : null,
-    fetchNextPage: async () => {
-      await fetchNextPage();
-    },
+    error,
+    fetchNextPage,
     isFetchingNextPage,
     hasNextPage,
   };


### PR DESCRIPTION
## Summary

Migrates offchain governance (proposals, votes, and the proposal-view token metrics) off `@anticapture/graphql-client` to the kubb SDK. After this + the companion shared-hooks PR merge, `@anticapture/graphql-client` has no remaining dashboard consumers.

## Context

- 🌿 Branch: `feat/migrate-offchain-governance-kubb`

## What changed

- `useOffchainProposal` → `useOffchainProposalById`; dropped the `__typename` union discrimination (REST returns a flat `OffchainProposal`)
- `useOffchainProposals` & `OffchainVotesContent` → `*Infinite` hooks + `getNextPageParam` (Apollo `fetchMore` → react-query infinite queries)
- `ProposalSection`: user-vote query → `useVotesOffchainByProposalId`; **`apolloClient.refetchQueries` → `queryClient.invalidateQueries`** (the params-less query key prefix-matches both the badge query and the infinite votes table)
- `VotesTabContent`: `useTokenMetricsQuery` → `useTokenMetrics`
- `OffchainVotingModal`: type-only swap to the kubb `OffchainProposal` model
- DAO moves from header to path param throughout

## Self-review summary

- ✅ `pnpm dashboard typecheck` + `lint` pass (0 errors)
- ✅ Response/enum shapes verified against generated models (`OffchainProposal`, `OffchainVote`, orderBy/metricType enums)

## ⚠️ Reviewer smoke-test (behavioral translations not run in-browser)

These data-layer swaps pass typecheck/lint but were not exercised at runtime. Please verify on an offchain proposal:
1. **Infinite scroll** on the offchain votes table loads further pages
2. **Casting a vote** refreshes the badge + votes table + scores without a manual reload (the `invalidateQueries` path)
3. The offchain proposals list pagination in the governance overview

## Changeset

- `@anticapture/dashboard`: patch — internal client swap, no user-visible change.