### PR TITLE
feat(api): log all external RPC and HTTP calls

### DIFF
--- a/.changeset/api-external-call-logging.md
+++ b/.changeset/api-external-call-logging.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/api": patch
+---
+
+Add info logs to all external RPC and HTTP calls (governor contract reads, CoinGecko, Dune, DefiLlama, Compound) for better observability.

--- a/apps/api/src/clients/governor.base.ts
+++ b/apps/api/src/clients/governor.base.ts
@@ -17,6 +17,7 @@ import type {
   ReadContractReturnType,
 } from "viem/actions";
 
+import { logger } from "@/logger";
 import { rpcRequestTotal } from "@/metrics";
 
 import { ProposalStatus } from "../lib/constants";
@@ -216,11 +217,16 @@ export abstract class GovernorBase<
     params: ReadContractParameters<TAbi, TFunctionName, TArgs>,
   ): Promise<ReadContractReturnType<TAbi, TFunctionName, TArgs>> {
     rpcRequestTotal.add(1, { method: "eth_call" });
+    logger.info(
+      { functionName: params.functionName, address: params.address },
+      "RPC eth_call: reading contract",
+    );
     return readContract(this.client, params);
   }
 
   protected async getBlockNumber(): Promise<bigint> {
     rpcRequestTotal.add(1, { method: "eth_blockNumber" });
+    logger.info("RPC eth_blockNumber: fetching latest block number");
     const result = await this.client.request({ method: "eth_blockNumber" });
     return BigInt(result);
   }
@@ -235,6 +241,7 @@ export abstract class GovernorBase<
 
   async getCurrentBlockNumber(): Promise<number> {
     rpcRequestTotal.add(1, { method: "eth_blockNumber" });
+    logger.info("RPC eth_blockNumber: fetching current block number");
     const result = await this.client.request({
       method: "eth_blockNumber",
     });
@@ -243,6 +250,7 @@ export abstract class GovernorBase<
 
   async getBlockTime(blockNumber: number): Promise<number | null> {
     rpcRequestTotal.add(1, { method: "eth_getBlockByNumber" });
+    logger.info({ blockNumber }, "RPC eth_getBlockByNumber: fetching block");
     const block = await this.client.request({
       method: "eth_getBlockByNumber",
       params: [toHex(blockNumber), false],

--- a/apps/api/src/services/coingecko/index.ts
+++ b/apps/api/src/services/coingecko/index.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import { truncateTimestampToMidnight } from "@/lib/date-helpers";
 import { DaoIdEnum } from "@/lib/enums";
+import { logger } from "@/logger";
 import { TokenHistoricalPriceResponse } from "@/mappers";
 import { PriceProvider } from "@/services/treasury/types";
 
@@ -63,6 +64,10 @@ export class CoingeckoService implements PriceProvider {
       });
     }
 
+    logger.info(
+      { tokenId, days },
+      "fetching historical token prices from CoinGecko",
+    );
     const response = await this.client.get<CoingeckoHistoricalMarketData>(
       `/coins/${tokenId}/market_chart?vs_currency=usd&days=${days}&interval=daily`,
     );
@@ -92,6 +97,10 @@ export class CoingeckoService implements PriceProvider {
     const tokenId = CoingeckoTokenIdEnum[this.daoId];
     const assetPlatform = CoingeckoIdToAssetPlatformId[tokenId];
     const formattedAddress = tokenContractAddress.toLowerCase();
+    logger.info(
+      { assetPlatform, tokenContractAddress: formattedAddress, targetCurrency },
+      "fetching token price from CoinGecko",
+    );
     const response = await this.client.get(
       `/simple/token_price/${assetPlatform}?contract_addresses=${formattedAddress}&vs_currencies=${targetCurrency}`,
     );

--- a/apps/api/src/services/dune/service.ts
+++ b/apps/api/src/services/dune/service.ts
@@ -12,6 +12,7 @@ export class DuneService {
 
   async fetchLiquidTreasury(size: number): Promise<DuneResponse> {
     try {
+      logger.info({ size }, "fetching liquid treasury from Dune");
       const response = await fetch(this.apiUrl + `?limit=${size}`, {
         headers: {
           "X-Dune-API-Key": this.apiKey,

--- a/apps/api/src/services/nft-price/index.ts
+++ b/apps/api/src/services/nft-price/index.ts
@@ -6,6 +6,7 @@ import {
   calculateCutoffTimestamp,
 } from "@/lib/date-helpers";
 import { forwardFill, createDailyTimeline } from "@/lib/time-series";
+import { logger } from "@/logger";
 import { TokenHistoricalPriceResponse } from "@/mappers";
 import { PriceProvider } from "@/services/treasury/types";
 
@@ -46,6 +47,10 @@ export class NFTPriceService implements PriceProvider {
     const fromQuery = fromData.toISOString().split("T")[0];
     const toQuery = today.toISOString().split("T")[0];
 
+    logger.info(
+      { from: fromQuery, to: toQuery },
+      "fetching historical ETH prices from CoinGecko",
+    );
     const ethHistoricalPrices = await this.client.get<{
       prices: [number, number][];
     }>(
@@ -88,6 +93,7 @@ export class NFTPriceService implements PriceProvider {
     const price = await this.repo.getTokenPrice();
     const nftEthValue = Number(formatEther(BigInt(price)));
 
+    logger.info("fetching current ETH price from CoinGecko");
     const ethCurrentPrice = await this.client.get<{
       prices: [number, number][];
     }>(`/coins/ethereum/market_chart?vs_currency=usd&days=1`);

--- a/apps/api/src/services/treasury/providers/compound-provider.ts
+++ b/apps/api/src/services/treasury/providers/compound-provider.ts
@@ -43,6 +43,10 @@ export class CompoundProvider implements TreasuryProvider {
     if (cached !== null) return this.filterData(cached, cutoffTimestamp);
 
     try {
+      logger.info(
+        { cutoffTimestamp, limit: LIMIT },
+        "fetching treasury data from Compound API",
+      );
       const response = await this.client.get<CompoundResponse>(
         `/treasury?order=DESC&limit=${LIMIT}`,
       );

--- a/apps/api/src/services/treasury/providers/defillama-provider.ts
+++ b/apps/api/src/services/treasury/providers/defillama-provider.ts
@@ -39,6 +39,7 @@ export class DefiLlamaProvider implements TreasuryProvider {
     if (cached !== null) return filterWithFallback(cached, cutoffTimestamp);
 
     try {
+      logger.info({ cutoffTimestamp }, "fetching treasury data from DefiLlama");
       const response = await this.client.get<RawDefiLlamaResponse>("");
       const data = this.transformData(response.data);
       this.cache.set(data);

--- a/apps/api/src/services/treasury/providers/dune-provider.ts
+++ b/apps/api/src/services/treasury/providers/dune-provider.ts
@@ -44,6 +44,7 @@ export class DuneProvider implements TreasuryProvider {
     if (cached !== null) return filterWithFallback(cached, cutoffTimestamp);
 
     try {
+      logger.info({ cutoffTimestamp }, "fetching treasury data from Dune");
       const response = await this.client.get<DuneResponse>("/", {
         headers: {
           "X-Dune-API-Key": this.apiKey,


### PR DESCRIPTION
Add logger.info to every external call site in apps/api: governor contract reads (eth_call, eth_blockNumber, eth_getBlockByNumber) in governor.base.ts, and HTTP calls to CoinGecko, Dune, DefiLlama, and Compound in their respective services. Logs fire before each request with the relevant params for traceability.