### PR TITLE
[codex] Clean up alert channel cards

### DIFF
--- a/.changeset/clean-alert-channel-cards.md
+++ b/.changeset/clean-alert-channel-cards.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Remove redundant alert channel card descriptions from the alerts page.

--- a/apps/dashboard/features/alerts/AlertsSection.tsx
+++ b/apps/dashboard/features/alerts/AlertsSection.tsx
@@ -3,7 +3,7 @@ import { Bell } from "lucide-react";
 import { AlertCard } from "@/features/alerts/components";
 import type { AlertItem } from "@/features/alerts/utils/alerts-constants";
 import { ALERTS_ITEMS } from "@/features/alerts/utils/alerts-constants";
-import { TheSectionLayout } from "@/shared/components";
+import { TheSectionLayout } from "@/shared/components/containers/TheSectionLayout";
 
 export const AlertsSection = () => {
   return (
@@ -21,7 +21,6 @@ export const AlertsSection = () => {
             <AlertCard
               key={alert.title}
               title={alert.title}
-              description={alert.description}
               icon={alert.icon}
               availability={alert.availability}
               link={alert.link}

--- a/apps/dashboard/features/alerts/components/AlertCard.tsx
+++ b/apps/dashboard/features/alerts/components/AlertCard.tsx
@@ -2,13 +2,12 @@ import Link from "next/link";
 
 import type { AlertItem } from "@/features/alerts/utils/alerts-constants";
 import { AlertAvailability } from "@/features/alerts/utils/alerts-constants";
-import { Badge } from "@/shared/components";
+import { Badge } from "@/shared/components/badges/Badge";
 import { Card, CardContent } from "@/shared/components/ui/card";
-import { cn } from "@/shared/utils";
+import { cn } from "@/shared/utils/cn";
 
 export const AlertCard = ({
   title,
-  description,
   icon: Icon,
   availability,
   link,
@@ -17,36 +16,31 @@ export const AlertCard = ({
   const cardContent = (
     <Card
       className={cn(
-        "bg-surface-default border-border-default hover:bg-surface-contrast rounded-base w-full border transition-colors duration-300",
+        "bg-surface-default border-border-default hover:bg-surface-contrast rounded-base h-full w-full border transition-colors duration-300",
         !active && "pointer-events-none opacity-65",
       )}
     >
-      <CardContent className="p-3">
-        <div className="flex flex-col items-start gap-2">
-          <div className="flex w-full items-center justify-between gap-2">
-            <div className="flex items-center justify-center gap-2">
-              <div className="shrink-0">
-                <Icon className="size-6" />
-              </div>
-              <div className="flex items-center gap-2">
-                <h3 className="text-primary text-sm font-medium">{title}</h3>
-              </div>
+      <CardContent className="p-4">
+        <div className="flex w-full items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <div className="shrink-0">
+              <Icon className="size-6" />
             </div>
-
-            <Badge
-              variant={
-                availability === AlertAvailability.AVAILABLE
-                  ? "success"
-                  : "default"
-              }
-            >
-              {availability}
-            </Badge>
+            <h3 className="text-primary truncate text-sm font-medium">
+              {title}
+            </h3>
           </div>
 
-          <div className="text-secondary text-sm leading-relaxed">
-            {description}
-          </div>
+          <Badge
+            className="shrink-0"
+            variant={
+              availability === AlertAvailability.AVAILABLE
+                ? "success"
+                : "default"
+            }
+          >
+            {availability}
+          </Badge>
         </div>
       </CardContent>
     </Card>

--- a/apps/dashboard/features/alerts/utils/alerts-constants.tsx
+++ b/apps/dashboard/features/alerts/utils/alerts-constants.tsx
@@ -1,4 +1,4 @@
-import type { JSX, ReactNode, SVGProps } from "react";
+import type { JSX, SVGProps } from "react";
 
 import {
   DiscordColorIcon,
@@ -17,7 +17,6 @@ export enum AlertAvailability {
 
 export interface AlertItem {
   title: string;
-  description: ReactNode;
   icon: (props: SVGProps<SVGSVGElement>) => JSX.Element;
   availability: AlertAvailability;
   link: string;
@@ -27,7 +26,6 @@ export interface AlertItem {
 export const ALERTS_ITEMS: AlertItem[] = [
   {
     title: "Telegram",
-    description: "You're in crypto, so real-time governance alerts is a must.",
     icon: TelegramColorIcon,
     availability: AlertAvailability.AVAILABLE,
     link: ANTICAPTURE_TELEGRAM_BOT,
@@ -35,8 +33,6 @@ export const ALERTS_ITEMS: AlertItem[] = [
   },
   {
     title: "Slack",
-    description:
-      "Receive direct messages of your preferred DAOs governance updates.",
     icon: SlackColorIcon,
     availability: AlertAvailability.AVAILABLE,
     link: ANTICAPTURE_SLACK_BOT,
@@ -44,8 +40,6 @@ export const ALERTS_ITEMS: AlertItem[] = [
   },
   {
     title: "Discord",
-    description:
-      "Beyond that 2021 NFT server, you can get real-time governance alerts that actually matter.",
     icon: DiscordColorIcon,
     availability: AlertAvailability.COMING_SOON,
     link: "/",


### PR DESCRIPTION
## Summary
- Remove redundant descriptions from the Telegram, Slack, and Discord alert channel cards.
- Keep the card UI focused on icon, channel name, and availability badge.
- Add a dashboard patch changeset for the visible UI cleanup.

## Impact
The shared `AlertsSection` powers both the Anticapture alerts page and whitelabel notifications pages, so this applies to `/alerts` and ENS `/notifications` after deployment.

ClickUp: https://app.clickup.com/t/86aj5chct

## Validation
- `NEXT_PUBLIC_GATEFUL_URL=https://dev-gateful.up.railway.app pnpm dashboard typecheck`
- `pnpm dashboard lint` (passes with existing warnings)
- Local render checks for `/alerts` on desktop and mobile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to alert channel cards with no auth, data, or API behavior changes.
> 
> **Overview**
> **Alert channel cards** on the alerts/notifications UI are simplified: Telegram, Slack, and Discord no longer show per-channel copy—only **icon**, **channel name**, and **availability badge** in a single horizontal row.
> 
> `AlertItem` and `ALERTS_ITEMS` drop the `description` field; `AlertsSection` stops passing it into `AlertCard`, which is refactored for the tighter layout (`truncate` on titles, `h-full` cards). Shared `AlertsSection` means this affects `/alerts` and whitelabel routes like ENS `/notifications`. A **patch changeset** records the dashboard release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83e97d844a442d63e4bd0ecf1f935799c1c71141. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->