### PR TITLE
fix(client): resolve Gateful spec from PR's own preview on Vercel

### DIFF
--- a/.changeset/vercel-preview-codegen-gateful-url.md
+++ b/.changeset/vercel-preview-codegen-gateful-url.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/client": patch
+---
+
+Resolve the Gateful OpenAPI spec from the PR's own preview Gateful on Vercel PR previews (via `VERCEL_ENV` / `VERCEL_GIT_PULL_REQUEST_ID`), mirroring the dashboard's runtime URL logic, so codegen generates the client against the PR's contract instead of dev. Previously the codegen resolver only understood Railway env vars and silently fell back to the dev spec on Vercel, breaking previews for any PR that consumed a not-yet-on-dev field.

--- a/packages/anticapture-client/src/gateful-openapi-spec.ts
+++ b/packages/anticapture-client/src/gateful-openapi-spec.ts
@@ -3,6 +3,10 @@ export type GatefulOpenApiSpecEnv = {
   ANTICAPTURE_API_URL?: string;
   RAILWAY_SERVICE_GATEFUL_URL?: string;
   RAILWAY_ENVIRONMENT_NAME?: string;
+  // Vercel hosts the dashboard's PR previews; these are its git-context vars.
+  VERCEL_ENV?: string;
+  VERCEL_GIT_PULL_REQUEST_ID?: string;
+  VERCEL_GIT_COMMIT_REF?: string;
 };
 
 const GATEFUL_OPENAPI_PATH = "/docs/json";
@@ -14,6 +18,11 @@ const RAILWAY_GATEFUL_DOMAIN_SUFFIX = ".up.railway.app";
 // NEXT_PUBLIC_GATEFUL_URL; every other Railway environment is a PR preview whose
 // Gateful domain we derive from the environment name.
 const RAILWAY_DEPLOY_ENVIRONMENTS = new Set(["dev", "production"]);
+
+// On Vercel, preview deployments for the long-lived `dev`/`main` branches must
+// keep using the configured Gateful URL instead of a per-PR preview host. Mirrors
+// PERMANENT_BRANCHES in apps/dashboard/next.config.ts.
+const VERCEL_PERMANENT_BRANCHES = new Set(["dev", "main"]);
 
 const readNonEmptyValue = (value: string | undefined) => {
   const trimmed = value?.trim();
@@ -54,6 +63,24 @@ export const resolveGatefulOpenApiSpecUrl = (
     return buildPreviewGatefulSpecUrl(railwayEnvironmentName);
   }
 
+  // The dashboard's PR previews run on Vercel, where the Railway env vars above
+  // are absent. Detect them via Vercel's own git vars and point codegen at the
+  // PR's Gateful (Railway names that environment `anticapture-pr-<id>`), so the
+  // generated client matches the PR's contract — not dev's. This mirrors
+  // apps/dashboard/next.config.ts, which already does this for the runtime URL;
+  // keep the two in sync. Without it, codegen falls through to the static dev
+  // URL below and regenerates the client against the wrong contract on every
+  // PR preview.
+  const vercelPrId = readNonEmptyValue(env.VERCEL_GIT_PULL_REQUEST_ID);
+  const vercelBranch = readNonEmptyValue(env.VERCEL_GIT_COMMIT_REF);
+  if (
+    readNonEmptyValue(env.VERCEL_ENV) === "preview" &&
+    vercelPrId &&
+    !VERCEL_PERMANENT_BRANCHES.has(vercelBranch ?? "")
+  ) {
+    return buildPreviewGatefulSpecUrl(`anticapture-pr-${vercelPrId}`);
+  }
+
   // dev / production (and CI) read the Gateful URL from the environment. Sources,
   // in priority order:
   //   1. NEXT_PUBLIC_GATEFUL_URL    — set explicitly in CI and local dev.
@@ -71,6 +98,6 @@ export const resolveGatefulOpenApiSpecUrl = (
   }
 
   throw new Error(
-    "Unable to resolve Gateful OpenAPI spec. Set NEXT_PUBLIC_GATEFUL_URL / ANTICAPTURE_API_URL / RAILWAY_SERVICE_GATEFUL_URL (used on dev/production), or run inside a Railway PR preview with RAILWAY_ENVIRONMENT_NAME.",
+    "Unable to resolve Gateful OpenAPI spec. Set NEXT_PUBLIC_GATEFUL_URL / ANTICAPTURE_API_URL / RAILWAY_SERVICE_GATEFUL_URL (used on dev/production), or run inside a Railway PR preview with RAILWAY_ENVIRONMENT_NAME, or a Vercel PR preview with VERCEL_ENV=preview and VERCEL_GIT_PULL_REQUEST_ID.",
   );
 };

--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,10 @@
         "NEXT_PUBLIC_GATEFUL_URL",
         "ANTICAPTURE_API_URL",
         "RAILWAY_SERVICE_GATEFUL_URL",
-        "RAILWAY_ENVIRONMENT_NAME"
+        "RAILWAY_ENVIRONMENT_NAME",
+        "VERCEL_ENV",
+        "VERCEL_GIT_PULL_REQUEST_ID",
+        "VERCEL_GIT_COMMIT_REF"
       ]
     },
     "@anticapture/client#build": {


### PR DESCRIPTION
## Why

The Vercel preview for #1976 failed to build with:

```
./shared/hooks/useGaslessRelayer.ts:76:22
Type error: Property 'limits' does not exist on type 'RelayerConfigResponse'.
```

The dashboard in that PR consumes the new relayer `limits` contract, but the build-time client codegen generated `RelayerConfigResponse` **from the dev Gateful**, which still serves the old `maxRelayPerAddressPerDay` shape.

## Root cause

The Gateful spec URL is resolved in **two independent places that had drifted**:

| | Where | Reads | On a Vercel preview resolved to |
|---|---|---|---|
| Runtime | `apps/dashboard/next.config.ts` | `VERCEL_GIT_PULL_REQUEST_ID` | ✅ the PR's Gateful (`gateful-anticapture-pr-<id>`) |
| Build-time codegen | `packages/anticapture-client/src/gateful-openapi-spec.ts` | `RAILWAY_ENVIRONMENT_NAME` + static `NEXT_PUBLIC_GATEFUL_URL` | ❌ **dev** |

The codegen resolver only understood Railway PR previews. On Vercel, `RAILWAY_ENVIRONMENT_NAME` is unset, so it fell back to the static `NEXT_PUBLIC_GATEFUL_URL` (dev) and type-checked the dashboard against dev's contract. This stays invisible for PRs that don't change the contract, which is why other PRs build fine — #1976 is the first to consume a not-yet-on-dev field.

## Fix

- Teach `resolveGatefulOpenApiSpecUrl` to detect Vercel PR previews (`VERCEL_ENV=preview` + `VERCEL_GIT_PULL_REQUEST_ID`, excluding the `dev`/`main` branches) and point codegen at the PR's own Gateful — mirroring `next.config.ts`.
- Declare `VERCEL_ENV`, `VERCEL_GIT_PULL_REQUEST_ID`, `VERCEL_GIT_COMMIT_REF` on the `@anticapture/client#codegen` Turbo task. Under Turbo's strict env mode (default in v2) an undeclared var never reaches the task, so without this the resolver couldn't see them. It also keeps the cache key per-PR, so stale codegen output isn't reused across previews.

This fixes the whole class of combined backend+frontend PRs, not just #1976.

## Verification

- **Unit** — 7 scenarios for `resolveGatefulOpenApiSpecUrl` (Vercel PR → PR URL even with dev set; `dev`/`main` branch → fallback; no PR id → fallback; production → fallback; Railway preview regression; dev/CI fallback; throw when unset). All pass.
- **End-to-end** — `pnpm dashboard typecheck` simulating a Vercel preview (`VERCEL_ENV=preview`, PR `1976`) **with `NEXT_PUBLIC_GATEFUL_URL=dev` set on purpose**: codegen resolved to `gateful-anticapture-pr-1976`, `RelayerConfigResponse` came out **with `limits`**, and all 3 tasks (codegen → client build → dashboard `tsc --noEmit`) passed.
- `pnpm client lint` / `pnpm client typecheck` pass.

## Notes

- Base branch is `feat/relayer-monthly-rate-limits` so this stacks on top of #1976 and can be reviewed on its own.
- Follow-up (not done here to keep the change small): the PR-preview URL logic is now duplicated between `next.config.ts` and the codegen resolver. A shared helper would prevent future drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
