### PR TITLE
feat: adding back token seeding and setting up CI

### DIFF
--- a/.changeset/authful-ci-token-seeding.md
+++ b/.changeset/authful-ci-token-seeding.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/authful": minor
+---
+
+On Railway PR previews (`RAILWAY_ENVIRONMENT_NAME` other than `dev`/`production`) the service now seeds a fixed token from the required `SEED_TOKEN_PLAINTEXT` env var on boot — idempotently, so it survives restarts — giving the rest of the preview stack a known key to authenticate with. The seeding capability is internal only; the admin API still mints exclusively with server-generated values.

--- a/.changeset/authful-remove-token-seeding.md
+++ b/.changeset/authful-remove-token-seeding.md
@@ -1,5 +1,0 @@
----
-"@anticapture/authful": patch
----
-
-Remove the manual `mint` CLI script and the existing-credential seeding path. Tokens are now minted exclusively via `POST /tokens` with server-generated values; the `plaintext` request field and the `TOKEN_PLAINTEXT` env var are gone.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,11 +80,6 @@ jobs:
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
           GATEFUL_URL: ${{ steps.vercel-env.outputs.gateful_url }}
-          # Shared preview API token: the dashboard's /api/gateful/* proxy sends
-          # it as the Bearer to Gateful, which validates it against Authful. Must
-          # equal the value Authful seeds via SEED_TOKEN_PLAINTEXT on its Railway
-          # preview, or every dashboard request gets a 401.
-          SEED_API_TOKEN: ${{ secrets.PREVIEW_SEED_API_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -94,35 +89,20 @@ jobs:
           fi
 
           api_url="https://api.vercel.com/v10/projects/${VERCEL_PROJECT_ID}/env?upsert=true&teamId=${VERCEL_TEAM_ID}"
+          payload=$(jq -n \
+            --arg key "ANTICAPTURE_API_URL" \
+            --arg value "${GATEFUL_URL}" \
+            --arg gitBranch "${PR_BRANCH}" \
+            '{ key: $key, value: $value, type: "plain", target: ["preview"], gitBranch: $gitBranch }')
 
-          upsert_env() {
-            # $1=key  $2=value  $3=type (plain|encrypted)
-            local payload
-            payload=$(jq -n \
-              --arg key "$1" \
-              --arg value "$2" \
-              --arg type "$3" \
-              --arg gitBranch "${PR_BRANCH}" \
-              '{ key: $key, value: $value, type: $type, target: ["preview"], gitBranch: $gitBranch }')
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --url "${api_url}" \
+            --header "Authorization: Bearer ${VERCEL_TOKEN}" \
+            --header "Content-Type: application/json" \
+            --data "${payload}"
 
-            curl --fail-with-body --silent --show-error \
-              --request POST \
-              --url "${api_url}" \
-              --header "Authorization: Bearer ${VERCEL_TOKEN}" \
-              --header "Content-Type: application/json" \
-              --data "${payload}"
-          }
-
-          upsert_env "ANTICAPTURE_API_URL" "${GATEFUL_URL}" "plain"
           echo "Configured ANTICAPTURE_API_URL=${GATEFUL_URL} for Vercel preview branch ${PR_BRANCH}."
-
-          if [ -n "${SEED_API_TOKEN:-}" ]; then
-            upsert_env "BLOCKFUL_API_TOKEN" "${SEED_API_TOKEN}" "encrypted"
-            echo "Configured BLOCKFUL_API_TOKEN (Authful seed token) for Vercel preview branch ${PR_BRANCH}."
-          else
-            echo "::warning::PREVIEW_SEED_API_TOKEN not set; dashboard preview will call Gateful unauthenticated."
-          fi
-
           echo "configured=true" >> "${GITHUB_OUTPUT}"
 
   wait-for-gateful:
@@ -182,9 +162,6 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_TEAM_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           GATEFUL_URL: ${{ needs.configure-vercel-preview.outputs.gateful_url }}
-          # Bearer the dashboard proxy forwards to Gateful (validated by Authful).
-          # Must match Authful's SEED_TOKEN_PLAINTEXT on the Railway preview.
-          SEED_API_TOKEN: ${{ secrets.PREVIEW_SEED_API_TOKEN }}
           # Git metadata so Vercel attributes the deploy to the PR author (avatar +
           # "Created by"); a bare `vercel deploy` shows "No attribution data available".
           GIT_SHA: ${{ github.event.pull_request.head.sha }}
@@ -205,22 +182,9 @@ jobs:
         # process.env.ANTICAPTURE_API_URL at request time, so --build-env alone
         # would build against the right URL but serve a stale/missing one.
         run: |
-          # Runtime-only: the /api/gateful/* proxy reads BLOCKFUL_API_TOKEN at
-          # request time and forwards it as the Bearer to Gateful. Codegen needs
-          # no token (it reads the public /docs/json), so this is not a
-          # --build-env. Omitted when the secret is unset (proxy then sends no
-          # auth header) so external/secret-less runs still deploy.
-          token_env=()
-          if [ -n "${SEED_API_TOKEN:-}" ]; then
-            token_env+=(--env "BLOCKFUL_API_TOKEN=${SEED_API_TOKEN}")
-          else
-            echo "::warning::PREVIEW_SEED_API_TOKEN not set; dashboard preview will call Gateful unauthenticated."
-          fi
-
           npx --yes vercel@latest deploy --yes --token="${VERCEL_TOKEN}" \
             --build-env ANTICAPTURE_API_URL="${GATEFUL_URL}" \
             --env ANTICAPTURE_API_URL="${GATEFUL_URL}" \
-            "${token_env[@]}" \
             --meta githubCommitSha="${GIT_SHA}" \
             --meta githubCommitRef="${GIT_REF}" \
             --meta githubCommitMessage="${GIT_MSG}" \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,6 +80,11 @@ jobs:
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
           GATEFUL_URL: ${{ steps.vercel-env.outputs.gateful_url }}
+          # Shared preview API token: the dashboard's /api/gateful/* proxy sends
+          # it as the Bearer to Gateful, which validates it against Authful. Must
+          # equal the value Authful seeds via SEED_TOKEN_PLAINTEXT on its Railway
+          # preview, or every dashboard request gets a 401.
+          SEED_API_TOKEN: ${{ secrets.PREVIEW_SEED_API_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -89,20 +94,35 @@ jobs:
           fi
 
           api_url="https://api.vercel.com/v10/projects/${VERCEL_PROJECT_ID}/env?upsert=true&teamId=${VERCEL_TEAM_ID}"
-          payload=$(jq -n \
-            --arg key "ANTICAPTURE_API_URL" \
-            --arg value "${GATEFUL_URL}" \
-            --arg gitBranch "${PR_BRANCH}" \
-            '{ key: $key, value: $value, type: "plain", target: ["preview"], gitBranch: $gitBranch }')
 
-          curl --fail-with-body --silent --show-error \
-            --request POST \
-            --url "${api_url}" \
-            --header "Authorization: Bearer ${VERCEL_TOKEN}" \
-            --header "Content-Type: application/json" \
-            --data "${payload}"
+          upsert_env() {
+            # $1=key  $2=value  $3=type (plain|encrypted)
+            local payload
+            payload=$(jq -n \
+              --arg key "$1" \
+              --arg value "$2" \
+              --arg type "$3" \
+              --arg gitBranch "${PR_BRANCH}" \
+              '{ key: $key, value: $value, type: $type, target: ["preview"], gitBranch: $gitBranch }')
 
+            curl --fail-with-body --silent --show-error \
+              --request POST \
+              --url "${api_url}" \
+              --header "Authorization: Bearer ${VERCEL_TOKEN}" \
+              --header "Content-Type: application/json" \
+              --data "${payload}"
+          }
+
+          upsert_env "ANTICAPTURE_API_URL" "${GATEFUL_URL}" "plain"
           echo "Configured ANTICAPTURE_API_URL=${GATEFUL_URL} for Vercel preview branch ${PR_BRANCH}."
+
+          if [ -n "${SEED_API_TOKEN:-}" ]; then
+            upsert_env "BLOCKFUL_API_TOKEN" "${SEED_API_TOKEN}" "encrypted"
+            echo "Configured BLOCKFUL_API_TOKEN (Authful seed token) for Vercel preview branch ${PR_BRANCH}."
+          else
+            echo "::warning::PREVIEW_SEED_API_TOKEN not set; dashboard preview will call Gateful unauthenticated."
+          fi
+
           echo "configured=true" >> "${GITHUB_OUTPUT}"
 
   wait-for-gateful:
@@ -162,6 +182,9 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_TEAM_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           GATEFUL_URL: ${{ needs.configure-vercel-preview.outputs.gateful_url }}
+          # Bearer the dashboard proxy forwards to Gateful (validated by Authful).
+          # Must match Authful's SEED_TOKEN_PLAINTEXT on the Railway preview.
+          SEED_API_TOKEN: ${{ secrets.PREVIEW_SEED_API_TOKEN }}
           # Git metadata so Vercel attributes the deploy to the PR author (avatar +
           # "Created by"); a bare `vercel deploy` shows "No attribution data available".
           GIT_SHA: ${{ github.event.pull_request.head.sha }}
@@ -182,9 +205,22 @@ jobs:
         # process.env.ANTICAPTURE_API_URL at request time, so --build-env alone
         # would build against the right URL but serve a stale/missing one.
         run: |
+          # Runtime-only: the /api/gateful/* proxy reads BLOCKFUL_API_TOKEN at
+          # request time and forwards it as the Bearer to Gateful. Codegen needs
+          # no token (it reads the public /docs/json), so this is not a
+          # --build-env. Omitted when the secret is unset (proxy then sends no
+          # auth header) so external/secret-less runs still deploy.
+          token_env=()
+          if [ -n "${SEED_API_TOKEN:-}" ]; then
+            token_env+=(--env "BLOCKFUL_API_TOKEN=${SEED_API_TOKEN}")
+          else
+            echo "::warning::PREVIEW_SEED_API_TOKEN not set; dashboard preview will call Gateful unauthenticated."
+          fi
+
           npx --yes vercel@latest deploy --yes --token="${VERCEL_TOKEN}" \
             --build-env ANTICAPTURE_API_URL="${GATEFUL_URL}" \
             --env ANTICAPTURE_API_URL="${GATEFUL_URL}" \
+            "${token_env[@]}" \
             --meta githubCommitSha="${GIT_SHA}" \
             --meta githubCommitRef="${GIT_REF}" \
             --meta githubCommitMessage="${GIT_MSG}" \

--- a/apps/authful/README.md
+++ b/apps/authful/README.md
@@ -7,16 +7,13 @@ Plaintext tokens are **never stored or logged** — only their sha256 hash.
 
 ## Environment
 
-| Variable                | Required        | Description                                                       |
-| ----------------------- | --------------- | ----------------------------------------------------------------- |
-| `DATABASE_URL`          | yes             | Dedicated Postgres (schema `authful`)                             |
-| `ADMIN_API_KEY`         | yes             | Guards `/tokens` (mint/list/revoke), min 16 chars                 |
-| `INTERNAL_API_KEY`      | yes             | Guards `/validate`; shared with Gateful (`TOKEN_SERVICE_API_KEY`) |
-| `PORT`                  | no              | Default `4002`                                                    |
-| `SEED_TOKEN_PLAINTEXT`  | CI/preview only | Token seeded on boot in PR previews (min 16 chars) — see below    |
-| `SEED_TOKEN_TENANT`     | no              | Tenant for the seeded token (default `ci`)                        |
-| `SEED_TOKEN_NAME`       | no              | Name for the seeded token (default `ci seed token`)               |
-| `SEED_TOKEN_RATE_LIMIT` | no              | Rate limit for the seeded token (default `600`)                   |
+| Variable               | Required        | Description                                                       |
+| ---------------------- | --------------- | ----------------------------------------------------------------- |
+| `DATABASE_URL`         | yes             | Dedicated Postgres (schema `authful`)                             |
+| `ADMIN_API_KEY`        | yes             | Guards `/tokens` (mint/list/revoke), min 16 chars                 |
+| `INTERNAL_API_KEY`     | yes             | Guards `/validate`; shared with Gateful (`TOKEN_SERVICE_API_KEY`) |
+| `PORT`                 | no              | Default `4002`                                                    |
+| `SEED_TOKEN_PLAINTEXT` | CI/preview only | Token seeded on boot in PR previews (min 16 chars) — see below    |
 
 ## CI / preview seeding
 

--- a/apps/authful/README.md
+++ b/apps/authful/README.md
@@ -1,17 +1,31 @@
 # Authful
 
-Per-tenant API token issuance and validation for Gateful (DEV-758).
+Per-tenant API token issuance and validation for Gateful (DEV-758). Usage is
+observed via Gateful's Prometheus metrics, not persisted here.
 
 Plaintext tokens are **never stored or logged** — only their sha256 hash.
 
 ## Environment
 
-| Variable           | Required | Description                                                       |
-| ------------------ | -------- | ----------------------------------------------------------------- |
-| `DATABASE_URL`     | yes      | Dedicated Postgres (schema `authful`)                             |
-| `ADMIN_API_KEY`    | yes      | Guards `/tokens` (mint/list/revoke), min 16 chars                 |
-| `INTERNAL_API_KEY` | yes      | Guards `/validate`; shared with Gateful (`TOKEN_SERVICE_API_KEY`) |
-| `PORT`             | no       | Default `4002`                                                    |
+| Variable                | Required        | Description                                                       |
+| ----------------------- | --------------- | ----------------------------------------------------------------- |
+| `DATABASE_URL`          | yes             | Dedicated Postgres (schema `authful`)                             |
+| `ADMIN_API_KEY`         | yes             | Guards `/tokens` (mint/list/revoke), min 16 chars                 |
+| `INTERNAL_API_KEY`      | yes             | Guards `/validate`; shared with Gateful (`TOKEN_SERVICE_API_KEY`) |
+| `PORT`                  | no              | Default `4002`                                                    |
+| `SEED_TOKEN_PLAINTEXT`  | CI/preview only | Token seeded on boot in PR previews (min 16 chars) — see below    |
+| `SEED_TOKEN_TENANT`     | no              | Tenant for the seeded token (default `ci`)                        |
+| `SEED_TOKEN_NAME`       | no              | Name for the seeded token (default `ci seed token`)               |
+| `SEED_TOKEN_RATE_LIMIT` | no              | Rate limit for the seeded token (default `600`)                   |
+
+## CI / preview seeding
+
+On Railway PR previews (`RAILWAY_ENVIRONMENT_NAME` is neither `dev` nor
+`production`) the service seeds a fixed token from `SEED_TOKEN_PLAINTEXT` on
+boot, so the rest of the preview stack can authenticate with a known key.
+`SEED_TOKEN_PLAINTEXT` is **required** in those environments and ignored on
+`dev`/`production`. Seeding is idempotent — it survives restarts and re-deploys
+without creating duplicates.
 
 ## Endpoints
 

--- a/apps/authful/src/ci.ts
+++ b/apps/authful/src/ci.ts
@@ -4,8 +4,8 @@
  * anything that isn't `dev` or `production` is a transient preview deploy.
  */
 export function isRailwayPreviewEnv(): boolean {
-  // HACK: coupled to the Railway environment for now as we have no way to avoid it
   return !["dev", "production"].includes(
+    // HACK: coupled to the Railway environment for now as we have no way to avoid it
     process.env["RAILWAY_ENVIRONMENT_NAME"] || "dev",
   );
 }

--- a/apps/authful/src/ci.ts
+++ b/apps/authful/src/ci.ts
@@ -1,0 +1,11 @@
+/**
+ * Detects a Railway PR preview ("CI") environment, mirroring the API's
+ * `apps/api/cmd/ci.ts`. Railway sets RAILWAY_ENVIRONMENT_NAME per environment;
+ * anything that isn't `dev` or `production` is a transient preview deploy.
+ */
+export function isRailwayPreviewEnv(): boolean {
+  // HACK: coupled to the Railway environment for now as we have no way to avoid it
+  return !["dev", "production"].includes(
+    process.env["RAILWAY_ENVIRONMENT_NAME"] || "dev",
+  );
+}

--- a/apps/authful/src/controllers/authful.integration.test.ts
+++ b/apps/authful/src/controllers/authful.integration.test.ts
@@ -140,6 +140,47 @@ describe("authful app", () => {
     });
   });
 
+  describe("seed (CI/preview bootstrap)", () => {
+    it("seeds a known token, is idempotent, and validates", async () => {
+      const service = new TokensService(new TokensRepository(db));
+      const plaintext = "ci-seed-token-0123456789";
+
+      const first = await service.seed({
+        plaintext,
+        tenant: "ci",
+        name: "ci seed token",
+      });
+      expect(first.created).toBe(true);
+      expect(first.token.tenant).toBe("ci");
+
+      // Re-running (e.g. on restart) is a no-op, not a duplicate or a throw.
+      const second = await service.seed({
+        plaintext,
+        tenant: "ci",
+        name: "ci seed token",
+      });
+      expect(second.created).toBe(false);
+      expect(second.token.id).toBe(first.token.id);
+
+      // Exactly one row, stored as a hash only.
+      const rows = await db.select().from(tokens);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.tokenHash).toBe(hashToken(plaintext));
+
+      // The seeded plaintext authenticates through the validate surface.
+      const res = await app.request("/validate", {
+        method: "POST",
+        headers: internalHeaders,
+        body: JSON.stringify({ tokenHash: hashToken(plaintext) }),
+      });
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toMatchObject({
+        valid: true,
+        tenant: "ci",
+      });
+    });
+  });
+
   describe("GET /tokens", () => {
     it("lists metadata without hashes or plaintext", async () => {
       const minted = await mint({});

--- a/apps/authful/src/env.ts
+++ b/apps/authful/src/env.ts
@@ -1,16 +1,37 @@
 import dotenv from "dotenv";
 import { z } from "zod";
 
+import { isRailwayPreviewEnv } from "@/ci";
+
 dotenv.config();
 
-const envSchema = z.object({
-  PORT: z.coerce.number().default(4002),
-  DATABASE_URL: z.string(),
-  // Guards human-facing token management endpoints (mint/list/revoke).
-  ADMIN_API_KEY: z.string().min(16),
-  // Guards service-facing endpoints (/validate), shared with Gateful.
-  INTERNAL_API_KEY: z.string().min(16),
-});
+const CI = isRailwayPreviewEnv();
+
+const envSchema = z
+  .object({
+    PORT: z.coerce.number().default(4002),
+    DATABASE_URL: z.string(),
+    // Guards human-facing token management endpoints (mint/list/revoke).
+    ADMIN_API_KEY: z.string().min(16),
+    // Guards service-facing endpoints (/validate), shared with Gateful.
+    INTERNAL_API_KEY: z.string().min(16),
+    // CI/preview only: a fixed, known token seeded into the DB on boot so every
+    // service in the same Railway PR preview shares a working API key. Required
+    // in preview environments; ignored on dev/production.
+    SEED_TOKEN_PLAINTEXT: z.string().min(16).optional(),
+    SEED_TOKEN_TENANT: z.string().min(1).default("ci"),
+    SEED_TOKEN_NAME: z.string().min(1).default("ci seed token"),
+    SEED_TOKEN_RATE_LIMIT: z.coerce.number().int().positive().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (CI && !data.SEED_TOKEN_PLAINTEXT) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["SEED_TOKEN_PLAINTEXT"],
+        message: "SEED_TOKEN_PLAINTEXT is required in CI/preview environments",
+      });
+    }
+  });
 
 const _env = envSchema.safeParse(process.env);
 
@@ -20,3 +41,6 @@ if (_env.success === false) {
 }
 
 export const env = _env.data;
+
+/** True on Railway PR previews — gates the boot-time token seeding. */
+export const isPreview = CI;

--- a/apps/authful/src/env.ts
+++ b/apps/authful/src/env.ts
@@ -20,7 +20,12 @@ const envSchema = z
     // in preview environments; ignored on dev/production. The seeded token's
     // tenant/name/rate-limit are fixed constants (see index.ts) — not worth env
     // vars, since the value only matters to ephemeral previews.
-    SEED_TOKEN_PLAINTEXT: z.string().min(16).optional(),
+    // Empty string (a blank var defined outside previews) is treated as unset,
+    // so it's ignored on dev/production instead of failing the min(16) guard.
+    SEED_TOKEN_PLAINTEXT: z.preprocess(
+      (v) => (v === "" ? undefined : v),
+      z.string().min(16).optional(),
+    ),
   })
   .superRefine((data, ctx) => {
     if (CI && !data.SEED_TOKEN_PLAINTEXT) {

--- a/apps/authful/src/env.ts
+++ b/apps/authful/src/env.ts
@@ -17,11 +17,10 @@ const envSchema = z
     INTERNAL_API_KEY: z.string().min(16),
     // CI/preview only: a fixed, known token seeded into the DB on boot so every
     // service in the same Railway PR preview shares a working API key. Required
-    // in preview environments; ignored on dev/production.
+    // in preview environments; ignored on dev/production. The seeded token's
+    // tenant/name/rate-limit are fixed constants (see index.ts) — not worth env
+    // vars, since the value only matters to ephemeral previews.
     SEED_TOKEN_PLAINTEXT: z.string().min(16).optional(),
-    SEED_TOKEN_TENANT: z.string().min(1).default("ci"),
-    SEED_TOKEN_NAME: z.string().min(1).default("ci seed token"),
-    SEED_TOKEN_RATE_LIMIT: z.coerce.number().int().positive().optional(),
   })
   .superRefine((data, ctx) => {
     if (CI && !data.SEED_TOKEN_PLAINTEXT) {

--- a/apps/authful/src/index.ts
+++ b/apps/authful/src/index.ts
@@ -12,6 +12,12 @@ import { TokensService } from "@/services/tokens";
 const db = drizzle(env.DATABASE_URL, { schema });
 const service = new TokensService(new TokensRepository(db));
 
+// Fixed identity for the CI/preview seed token. Only the plaintext value varies
+// (and only across previews), so it's the lone env var; the rest are constants.
+// Rate limit is omitted so the DB default (600/min) applies.
+const SEED_TOKEN_TENANT = "ci";
+const SEED_TOKEN_NAME = "ci seed token";
+
 // CI/preview bootstrap: seed a fixed, env-provided token so the rest of the
 // preview stack can authenticate with a known key. `env` validation guarantees
 // SEED_TOKEN_PLAINTEXT is set when `isPreview`. Idempotent and non-fatal.
@@ -19,14 +25,11 @@ if (isPreview && env.SEED_TOKEN_PLAINTEXT) {
   try {
     const { created } = await service.seed({
       plaintext: env.SEED_TOKEN_PLAINTEXT,
-      tenant: env.SEED_TOKEN_TENANT,
-      name: env.SEED_TOKEN_NAME,
-      ...(env.SEED_TOKEN_RATE_LIMIT !== undefined
-        ? { rateLimitPerMin: env.SEED_TOKEN_RATE_LIMIT }
-        : {}),
+      tenant: SEED_TOKEN_TENANT,
+      name: SEED_TOKEN_NAME,
     });
     logger.info(
-      { tenant: env.SEED_TOKEN_TENANT, name: env.SEED_TOKEN_NAME, created },
+      { tenant: SEED_TOKEN_TENANT, name: SEED_TOKEN_NAME, created },
       created ? "Seeded CI token" : "CI token already present — skipped seed",
     );
   } catch (err) {

--- a/apps/authful/src/index.ts
+++ b/apps/authful/src/index.ts
@@ -4,13 +4,35 @@ import { drizzle } from "drizzle-orm/node-postgres";
 
 import { createApp } from "@/app";
 import * as schema from "@/database/schema";
-import { env } from "@/env";
+import { env, isPreview } from "@/env";
 import { logger } from "@/logger";
 import { TokensRepository } from "@/repositories/tokens";
 import { TokensService } from "@/services/tokens";
 
 const db = drizzle(env.DATABASE_URL, { schema });
 const service = new TokensService(new TokensRepository(db));
+
+// CI/preview bootstrap: seed a fixed, env-provided token so the rest of the
+// preview stack can authenticate with a known key. `env` validation guarantees
+// SEED_TOKEN_PLAINTEXT is set when `isPreview`. Idempotent and non-fatal.
+if (isPreview && env.SEED_TOKEN_PLAINTEXT) {
+  try {
+    const { created } = await service.seed({
+      plaintext: env.SEED_TOKEN_PLAINTEXT,
+      tenant: env.SEED_TOKEN_TENANT,
+      name: env.SEED_TOKEN_NAME,
+      ...(env.SEED_TOKEN_RATE_LIMIT !== undefined
+        ? { rateLimitPerMin: env.SEED_TOKEN_RATE_LIMIT }
+        : {}),
+    });
+    logger.info(
+      { tenant: env.SEED_TOKEN_TENANT, name: env.SEED_TOKEN_NAME, created },
+      created ? "Seeded CI token" : "CI token already present — skipped seed",
+    );
+  } catch (err) {
+    logger.error({ err }, "Failed to seed CI token");
+  }
+}
 
 const app = createApp({
   service,

--- a/apps/authful/src/services/tokens/index.ts
+++ b/apps/authful/src/services/tokens/index.ts
@@ -45,6 +45,30 @@ export class TokensService {
     return { token, plaintext };
   }
 
+  /**
+   * Register a token with a known plaintext (CI/preview bootstrap) so every
+   * service in the same environment shares a working key. Idempotent: a no-op
+   * when an active token with this value already exists, so it survives
+   * restarts and re-deploys. The plaintext capability is internal only — it is
+   * never exposed on the admin API.
+   */
+  async seed(
+    input: MintInput & { plaintext: string },
+  ): Promise<{ created: boolean; token: DBToken }> {
+    const tokenHash = hashToken(input.plaintext);
+    const existing = await this.repo.findActiveByHash(tokenHash);
+    if (existing) return { created: false, token: existing };
+    const token = await this.repo.create({
+      tenant: input.tenant,
+      name: input.name,
+      tokenHash,
+      ...(input.rateLimitPerMin !== undefined
+        ? { rateLimitPerMin: input.rateLimitPerMin }
+        : {}),
+    });
+    return { created: true, token };
+  }
+
   async list(): Promise<DBToken[]> {
     return this.repo.list();
   }

--- a/apps/authful/src/services/tokens/index.ts
+++ b/apps/authful/src/services/tokens/index.ts
@@ -52,19 +52,20 @@ export class TokensService {
    * restarts and re-deploys. The plaintext capability is internal only — it is
    * never exposed on the admin API.
    */
-  async seed(
-    input: MintInput & { plaintext: string },
-  ): Promise<{ created: boolean; token: DBToken }> {
+  async seed(input: {
+    tenant: string;
+    name: string;
+    plaintext: string;
+  }): Promise<{ created: boolean; token: DBToken }> {
     const tokenHash = hashToken(input.plaintext);
     const existing = await this.repo.findActiveByHash(tokenHash);
     if (existing) return { created: false, token: existing };
+    // rateLimitPerMin is omitted on purpose — the column defaults to 600 at the
+    // DB level, which is plenty for an ephemeral preview.
     const token = await this.repo.create({
       tenant: input.tenant,
       name: input.name,
       tokenHash,
-      ...(input.rateLimitPerMin !== undefined
-        ? { rateLimitPerMin: input.rateLimitPerMin }
-        : {}),
     });
     return { created: true, token };
   }


### PR DESCRIPTION
## Seed a known API token in preview environments

### Why
PR previews spin up a fresh, empty Authful DB, so the dashboard had no valid token to authenticate through Gateful — making preview-only issues impossible to exercise. This makes every preview come up with a known, working
token.

### What
- **Authful seeds a fixed token on boot in PR previews.** Gated by `RAILWAY_ENVIRONMENT_NAME` (anything other than `dev`/`production`, via a new `isRailwayPreviewEnv()` helper mirroring `apps/api/cmd/ci.ts`). The token value
comes from the required `SEED_TOKEN_PLAINTEXT`; tenant/name are fixed constants. Seeding is **idempotent** (no-op if it already exists, survives restarts) and **non-fatal**.
- **Internal-only.** The plaintext capability lives entirely in `TokensService.seed()` — never exposed on the admin API. `POST /tokens` still mints exclusively with server-generated values.
- **Dashboard preview wiring.** Extended `.github/workflows/tests.yaml` to inject `BLOCKFUL_API_TOKEN` into the dashboard's Vercel preview (from the `PREVIEW_SEED_API_TOKEN` secret), alongside the existing
`ANTICAPTURE_API_URL` injection. The dashboard proxy forwards it as the Bearer; Gateful validates it against Authful. Trusted PRs only; degrades gracefully when the secret is absent.

### Auth chain
`dashboard /api/gateful/* (Bearer BLOCKFUL_API_TOKEN)` → `Gateful (validate)` → `Authful` (token seeded above).

### Required config (one shared value)
`SEED_TOKEN_PLAINTEXT` (Railway, Authful) **must equal** `PREVIEW_SEED_API_TOKEN` (GitHub secret → dashboard's `BLOCKFUL_API_TOKEN`). Gateful previews also need `TOKEN_SERVICE_URL` + `TOKEN_SERVICE_API_KEY` (= Authful's
`INTERNAL_API_KEY`). `dev`/`production` are unaffected — they never seed.

### Notes
- Changeset: `@anticapture/authful` (minor).
- No public API/contract change.
