### PR TITLE
feat(torn): custom-governor write actions — vote + delegate

### DIFF
--- a/.changeset/late-eagles-pick.md
+++ b/.changeset/late-eagles-pick.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": minor
+---
+
+support Tornado Cash proposal creation

--- a/apps/dashboard/features/governance/utils/voteOnProposal.ts
+++ b/apps/dashboard/features/governance/utils/voteOnProposal.ts
@@ -83,6 +83,42 @@ const azoriusVoteHandler =
     return client.writeContract(request);
   };
 
+const TornGovernorVoteAbi = [
+  {
+    inputs: [
+      { internalType: "uint256", name: "proposalId", type: "uint256" },
+      { internalType: "bool", name: "support", type: "bool" },
+    ],
+    name: "castVote",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;
+
+/**
+ * Tornado Cash (custom stake-to-vote governor): castVote(uint256, bool) on the
+ * governor. Binary voting — for=true / against=false, no abstain, no reason.
+ * Voting power = lockedBalance, so the caller must have locked TORN.
+ */
+const tornVoteHandler =
+  (daoId: DaoIdEnum): VoteHandler =>
+  async (client, params) => {
+    const address = daoConfigByDaoId[daoId].daoOverview.contracts.governor;
+    if (!address) throw new Error("DAO governance address not found");
+    if (params.voteNumber === 2)
+      throw new Error("Tornado Cash does not support abstain votes");
+
+    const { request } = await client.simulateContract({
+      abi: TornGovernorVoteAbi,
+      address,
+      functionName: "castVote",
+      args: [BigInt(params.proposalId), params.voteNumber === 1],
+      account: params.account,
+    });
+    return client.writeContract(request);
+  };
+
 /**
  * OZ Governor: castVote / castVoteWithReason on governor contract.
  */
@@ -171,6 +207,8 @@ function getVoteHandler(
   switch (daoId) {
     case DaoIdEnum.SHU:
       return azoriusVoteHandler(daoId);
+    case DaoIdEnum.TORN:
+      return tornVoteHandler(daoId);
     default:
       return ozGovernorVoteHandler(daoId);
   }

--- a/apps/dashboard/features/holders-and-delegates/delegate/utils/delegateTo.ts
+++ b/apps/dashboard/features/holders-and-delegates/delegate/utils/delegateTo.ts
@@ -11,7 +11,7 @@ import { relayDelegate } from "@anticapture/client";
 import type { RelayDelegatePathParamsDaoEnumKey } from "@anticapture/client";
 
 import daoConfigByDaoId from "@/shared/dao-config";
-import type { DaoIdEnum } from "@/shared/types/daos";
+import { DaoIdEnum } from "@/shared/types/daos";
 
 const ERC20VotesAbi = [
   {
@@ -141,9 +141,17 @@ export const delegateTo = async (
     );
   }
 
+  // Tornado Cash delegates on the governor contract (its `delegatedTo` mapping),
+  // not on an ERC20Votes token. Same `delegate(address)` signature, different target.
+  const delegationTarget =
+    daoId === DaoIdEnum.TORN
+      ? ((daoConfigByDaoId[daoId].daoOverview.contracts.governor ??
+          tokenAddress) as Address)
+      : tokenAddress;
+
   const { request } = await client.simulateContract({
     abi: ERC20VotesAbi,
-    address: tokenAddress,
+    address: delegationTarget,
     functionName: "delegate",
     args: [delegateAddress],
     account,


### PR DESCRIPTION
## What

Enables Tornado Cash's custom-governor **write actions** in the dashboard, mirroring the existing **Shutter/Azorius** custom-governor pattern. Targets `feat/tornado-cash-integration`.

### Vote — `voteOnProposal.ts`
- New `tornVoteHandler` → `castVote(uint256 proposalId, bool support)` on the governor (for=`true` / against=`false`; no abstain → throws; no reason).
- Routed via `getVoteHandler` switch: `case DaoIdEnum.TORN` (same place SHU adds `azoriusVoteHandler`).

### Delegate — `delegateTo.ts`
- TORN delegation routes to the **governor's** `delegate(address)` (the `delegatedTo` mapping), not the ERC20Votes token. Same signature, different target.

### Proposal creation — intentionally left ENS-gated
Like SHU, `canCreateProposalForDao` stays ENS-only. Tornado's model is **contract-as-proposal** (`propose(address target, string description)` where the target is a pre-deployed contract with `executeProposal()`), which doesn't map to the OZ actions-builder form. A dedicated single-target TORN proposal form is a follow-up.

## Verification (mainnet fork, `forge`)
Simulated the exact txs the handlers send, `msg.sender` = a real TORN locker:

```
[PASS] test_castVote_bool_succeeds()          # new vote handler
[PASS] test_delegate_on_governor_succeeds()   # new delegate routing (+ delegatedTo recorded)
[PASS] test_old_oz_castVote_reverts()         # old castVote(uint8) reverts on TORN
[PASS] test_old_token_delegate_reverts()      # old token delegate reverts
4 passed; 0 failed
```
Plus `eth_call` dry-runs confirm the same, and `pnpm --filter ./apps/dashboard typecheck` passes. (Fork test source available — can be added to the dao-proposals sim repo.)

## Follow-ups (not blockers)
- `lockWithApproval` flow to acquire voting power for holders who haven't locked yet.
- TORN-specific proposal-creation form.
- Hide the abstain option in the vote modal for TORN (handler already rejects it).
- Gasless relayer support for the custom governor (relayer is OZ-only today).
