### PR TITLE
fix(api): floor NFT price rolling average to keep wei strings BigInt-safe

### DIFF
--- a/.changeset/nouns-nft-price-bigint.md
+++ b/.changeset/nouns-nft-price-bigint.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/api": patch
+---
+
+Fix `/token/historical-data` returning 500 for NFT-priced DAOs (Nouns, Lil Nouns): the rolling-average SQL emitted decimal strings that crashed the wei-to-USD conversion, which in turn tripped the gateway circuit breaker and made the whole DAO unavailable.

--- a/apps/api/src/repositories/token/nft.ts
+++ b/apps/api/src/repositories/token/nft.ts
@@ -16,11 +16,15 @@ export class NFTPriceRepository {
   ): Promise<TokenHistoricalPriceResponse> {
     return await this.db
       .select({
+        // FLOOR keeps the value an integer wei string: AVG over NUMERIC emits
+        // decimal text (e.g. "200.5000000000000000"), which BigInt() rejects.
         price: sql<string>`
       CAST(
-        AVG(CAST(${tokenPrice.price} AS NUMERIC)) OVER (
-          ORDER BY ${tokenPrice.timestamp}
-          RANGE BETWEEN 2505600 PRECEDING AND CURRENT ROW
+        FLOOR(
+          AVG(CAST(${tokenPrice.price} AS NUMERIC)) OVER (
+            ORDER BY ${tokenPrice.timestamp}
+            RANGE BETWEEN 2505600 PRECEDING AND CURRENT ROW
+          )
         ) AS TEXT
       )
     `,

--- a/apps/api/src/repositories/token/nft.unit.test.ts
+++ b/apps/api/src/repositories/token/nft.unit.test.ts
@@ -110,6 +110,26 @@ describe("NFTPriceRepository", () => {
 
       expect(result).toEqual([]);
     });
+
+    it("should return integer wei strings convertible to BigInt", async () => {
+      // AVG() over NUMERIC yields decimal text like "200.50000000000000000000";
+      // consumers convert this straight to BigInt, which rejects decimals.
+      await db
+        .insert(tokenPrice)
+        .values([
+          createTokenPrice({ timestamp: 1700000000n, price: 100n }),
+          createTokenPrice({ timestamp: 1700000100n, price: 301n }),
+        ]);
+
+      const result = await repository.getHistoricalNFTPrice(10, 0);
+
+      expect(result).toHaveLength(2);
+      for (const { price } of result) {
+        expect(() => BigInt(price)).not.toThrow();
+      }
+      expect(result[0]!.price).toBe("200");
+      expect(result[1]!.price).toBe("100");
+    });
   });
 
   describe("getTokenPrice", () => {


### PR DESCRIPTION
## Summary

Hotfix for the production outage where every Nouns request through Gateful returned `{"error":"DAO service temporarily unavailable"}`. Root cause: `GET /token/historical-data` on NFT-priced DAOs (NOUNS, LIL_NOUNS) crashed with `SyntaxError: Cannot convert 0.00000000000000000000 to a BigInt` on every call, and five consecutive 500s open the per-DAO gateway circuit breaker, taking the whole DAO offline for 5–40 min.

## Context

- 🔥 **Hotfix** branched from `main` (no ticket — found live-debugging prod; Railway logs confirmed the crash in `nouns-api` production)
- 🌿 **Branch**: `hotfix/nouns-nft-price-bigint`

## What changed

- **API**: `NFTPriceRepository.getHistoricalNFTPrice` now wraps the rolling-average window in `FLOOR(...)` before `CAST(... AS TEXT)`. Postgres `AVG()` over `NUMERIC` always emits decimal text (e.g. `"200.5000000000000000"`), which `BigInt()` rejects in `NFTPriceService` — so the endpoint failed on *any* data. Flooring keeps the contract (integer wei string); precision loss is <1 wei.
- **Tests**: PGlite-backed regression test inserts prices 100 and 301 (rolling avg 200.5) and asserts every returned price string is `BigInt`-parseable and floored (`"200"`).

## Self-review summary

- ✅ QA pass: 6 scenarios verified (decimal avg, integer avg exactness, empty table, offset/limit vs window, `getTokenPrice` path, huge wei values — no scientific notation)
- ✅ Engineer pass: fix at the right layer (repairs the repo's `sql<string>` wei contract for all consumers); `FLOOR(numeric)` is standard Postgres and PGlite exercises identical semantics
- ✅ Verification: 705 unit tests pass, typecheck + lint clean
- ⚠️ Known limitations (deferred, out of hotfix scope):
  - No defensive parse around `BigInt(price)` in `NFTPriceService` — a future repo regression would re-trigger the circuit-breaker failure mode
  - Pre-existing: `timestamp` is `sql<number>` but cast to TEXT at runtime (string typed as number) — follow-up candidate
  - Related but separate bug: `/fluid/token/historical-data` 500s with a CoinGecko 404 (coin id), same breaker-opening effect

## Changeset

- `@anticapture/api`: patch — endpoint bugfix, response schema unchanged (no gateful cascade needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)