### PR TITLE
feat(auth): add @anticapture/auth reusable SIWE package

### DIFF
--- a/.changeset/wet-carrots-siwe-auth.md
+++ b/.changeset/wet-carrots-siwe-auth.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/auth": minor
+---
+
+Add `@anticapture/auth`, a reusable SIWE (Sign-In With Ethereum) authentication package for Blockful Hono backends, with EOA and EIP-1271 smart-wallet signature verification, a pluggable atomic `NonceStore`, `hono/jwt`-backed sessions, and ready-to-mount Hono middleware/routes.

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -69,7 +69,9 @@ const store = memoryNonceStore();
 mountAuthRoutes(app, {
   store,
   secret: process.env.SESSION_SECRET!,
-  domain: "app.example.com",
+  // Accepts a single domain or an allowlist when the same API serves
+  // multiple frontend hosts (e.g. whitelabel deployments).
+  domain: ["app.example.com", "gov.whitelabel.example"],
   chainId: 1,
   sessionTtlSec: 3600,
 });
@@ -89,7 +91,7 @@ app.get("/me", siweAuth({ secret: process.env.SESSION_SECRET! }), (c) => {
 
 - invalid/tampered signature,
 - unknown or already-consumed nonce,
-- wrong `domain` (phishing resistance),
+- `domain` not in the expected domain(s) (phishing resistance),
 - wrong `chainId` (cross-chain replay resistance),
 - expired (`expirationTime`) or not-yet-valid (`notBefore`) messages.
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -1,0 +1,151 @@
+# @anticapture/auth
+
+Reusable Sign-In With Ethereum (SIWE / EIP-4361) authentication for Blockful Hono backends.
+Framework-free crypto/verification core; a deliberate `hono/jwt` session layer; a
+`@hono/zod-openapi` route bundle and middleware for Hono apps.
+
+## Install
+
+```bash
+pnpm add @anticapture/auth
+```
+
+`viem`, `hono`, and `@hono/zod-openapi` are **peerDependencies** — install them in your app if
+they aren't already there. They are not bundled as `dependencies` so that your app and this
+package share a single `viem`/`zod` module identity (avoids `instanceof`/brand mismatches from
+duplicate copies in the dependency graph).
+
+## Exports
+
+- `AddressSchema`, `SiweVerifyBodySchema`, `NonceResponseSchema` — Zod (via
+  `@hono/zod-openapi`) schemas.
+- `generateNonce`, `NonceStore` (interface) — nonce primitives.
+- `memoryNonceStore` — bundled in-memory `NonceStore` reference implementation.
+- `verifySiweSignature`, `verifySiwe`, `SiweVerificationError`, `VerifiedSiwe`, `SiweFields` —
+  verification core.
+- `issueSession`, `verifySession`, `Session` — HS256 JWT session helpers.
+- `siweAuth` — Hono middleware guarding routes with a session token.
+- `mountAuthRoutes` — registers `GET /auth/nonce` and `POST /auth/verify` on an `OpenAPIHono` app.
+
+## Plugging a `NonceStore`
+
+```ts
+import type { NonceStore } from "@anticapture/auth";
+```
+
+`NonceStore` has two methods:
+
+```ts
+interface NonceStore {
+  issue(nonce: string, ttlMs?: number): Promise<void>;
+  consume(nonce: string): Promise<boolean>;
+}
+```
+
+**Atomicity contract:** `consume` MUST be an atomic test-and-delete. It must return `true` to
+exactly one caller for a given nonce — even under concurrent calls — and `false` to every other
+caller (unknown, already-consumed, or expired nonce). A naive `get` followed by a separate
+`delete` is **not** atomic and opens a time-of-check-to-time-of-use race that lets a SIWE message
+be replayed by two concurrent requests. The bundled `memoryNonceStore` satisfies this contract
+in-process (no `await` between its internal read and delete); its
+`src/stores/memory.test.ts` concurrent-consume test is the reference test any custom store should
+pass. `memoryNonceStore` is dev/single-instance only — for multi-instance production deployments,
+implement a durable store (Redis/Postgres) that preserves this same atomicity guarantee.
+
+`memoryNonceStore` is bounded by `maxEntries` (default 10 000). When full — after reclaiming
+expired entries — `issue` **throws** rather than evicting a live, unconsumed nonce (evicting would
+let a flood of `/auth/nonce` requests knock out honest users' pending logins). Rate-limit the
+nonce endpoint regardless (see Security notes).
+
+## Middleware and routes
+
+```ts
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { memoryNonceStore, mountAuthRoutes, siweAuth } from "@anticapture/auth";
+
+const app = new OpenAPIHono();
+const store = memoryNonceStore();
+
+mountAuthRoutes(app, {
+  store,
+  secret: process.env.SESSION_SECRET!,
+  domain: "app.example.com",
+  chainId: 1,
+  sessionTtlSec: 3600,
+});
+
+app.get("/me", siweAuth({ secret: process.env.SESSION_SECRET! }), (c) => {
+  const { address } = c.get("siweUser");
+  return c.json({ address });
+});
+```
+
+`siweAuth` returns distinguishable 401 reasons: `missing_token`, `invalid_token`,
+`expired_token`.
+
+## Verify strictness
+
+`verifySiwe` is the store-aware, strict entry point and rejects on:
+
+- invalid/tampered signature,
+- unknown or already-consumed nonce,
+- wrong `domain` (phishing resistance),
+- wrong `chainId` (cross-chain replay resistance),
+- expired (`expirationTime`) or not-yet-valid (`notBefore`) messages.
+
+It only consumes the nonce **after** all of the above pass — a bad signature or stale message
+never burns a valid nonce. `verifySiweSignature` is the lower-level, framework-free primitive
+that checks _authenticity only_ (no domain/chainId/expiry/nonce assertions); use it directly if
+you need signature verification without the store-aware bookkeeping (e.g. a one-shot mint flow).
+
+## EOA vs EIP-1271 (smart-contract wallets)
+
+By default, `verifySiweSignature`/`verifySiwe` assume an EOA signer and recover the address
+directly from the signature (no RPC call required). To support smart-contract wallets (e.g. Safe
+multisigs used by governance delegates), inject a viem `Client` **on the message's chain**:
+
+```ts
+import { createPublicClient, http } from "viem";
+import { mainnet } from "viem/chains";
+
+const client = createPublicClient({ chain: mainnet, transport: http() });
+
+await verifySiwe({
+  message,
+  signature,
+  store,
+  expectedDomain,
+  expectedChainId,
+  client,
+});
+```
+
+With a `client`, verification goes through viem's `verifySiweMessage` (EIP-1271/ERC-6492
+capable) instead of raw ECDSA recovery. Without a `client`, only EOA signatures are accepted.
+
+## `AddressSchema` provenance
+
+`AddressSchema` in `src/schemas.ts` is a **copy** of the schema defined in
+`apps/api/src/mappers/shared.ts`. That file remains the source of truth for the API's own address
+handling — if its semantics change, update this copy manually; there is no automated sync.
+
+## Security notes
+
+- **Secret strength:** `secret` (for `issueSession`/`verifySession`/`siweAuth`/`mountAuthRoutes`)
+  must be at least 32 high-entropy characters — shorter secrets are rejected at the boundary.
+- **Rate-limit `GET /auth/nonce`:** it is unauthenticated and writes to the store on every call.
+  Put a rate limiter in front of it (and prefer a durable, TTL-backed store in production).
+- **`POST /auth/verify` error semantics:** genuine verification failures return `401`
+  (`verification_failed`); unexpected errors (nonce-store outage, EIP-1271 RPC failure) propagate
+  to your app's error handler as a `5xx` so outages are observable instead of looking like user
+  auth failures.
+- **EIP-1271 client chain:** an injected `client` MUST target the same chain as `chainId`, or the
+  on-chain signature check runs against the wrong contract state.
+
+## Gateful `Authorization`-strip gotcha
+
+Gateful strips the `Authorization` header when proxying requests to DAO APIs. Because of this,
+`siweAuth`/`mountAuthRoutes` do **not** use `Authorization: Bearer <token>` — they default to a
+custom `x-user-token` header instead. Any future adopter proxying auth-guarded requests through
+gateful must carry the session token in `x-user-token` (or another custom header), not
+`Authorization`.

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -123,11 +123,13 @@ await verifySiwe({
 With a `client`, verification goes through viem's `verifySiweMessage` (EIP-1271/ERC-6492
 capable) instead of raw ECDSA recovery. Without a `client`, only EOA signatures are accepted.
 
-## `AddressSchema` provenance
+## `AddressSchema`
 
-`AddressSchema` in `src/schemas.ts` is a **copy** of the schema defined in
-`apps/api/src/mappers/shared.ts`. That file remains the source of truth for the API's own address
-handling — if its semantics change, update this copy manually; there is no automated sync.
+`AddressSchema` in `src/schemas.ts` is the standard viem address idiom (`isAddress` +
+`getAddress`) — a small, stable primitive owned by this package. `apps/api/src/mappers/shared.ts`
+defines an equivalent schema for its own use; the two are **independent** (a package cannot import
+from an app, and there is no app-specific logic here, so no manual sync is needed). When the API
+adopts this package it can re-export this one as the single source of truth.
 
 ## Security notes
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -134,7 +134,9 @@ adopts this package it can re-export this one as the single source of truth.
 ## Security notes
 
 - **Secret strength:** `secret` (for `issueSession`/`verifySession`/`siweAuth`/`mountAuthRoutes`)
-  must be at least 32 high-entropy characters — shorter secrets are rejected at the boundary.
+  must be at least 32 high-entropy characters. `siweAuth` and `mountAuthRoutes` reject a weak
+  secret by throwing at construction time (startup), so a misconfigured deployment fails loudly
+  instead of returning `invalid_token` 401s on every request.
 - **Rate-limit `GET /auth/nonce`:** it is unauthenticated and writes to the store on every call.
   Put a rate limiter in front of it (and prefer a durable, TTL-backed store in production).
 - **`POST /auth/verify` error semantics:** genuine verification failures return `401`

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@anticapture/auth",
+  "version": "0.1.0",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/blockful/anticapture.git",
+    "directory": "packages/auth"
+  },
+  "scripts": {
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf node_modules dist *.tsbuildinfo",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "viem": "^2.41.2",
+    "hono": "^4",
+    "@hono/zod-openapi": "^1"
+  },
+  "devDependencies": {
+    "viem": "^2.41.2",
+    "hono": "^4.12.7",
+    "@hono/zod-openapi": "^1.2.2",
+    "@types/node": "^20.16.5",
+    "tsup": "^8.5.1",
+    "typescript": "^5.8.3",
+    "vitest": "^3.0.5"
+  }
+}

--- a/packages/auth/src/hono/middleware.ts
+++ b/packages/auth/src/hono/middleware.ts
@@ -1,0 +1,47 @@
+import { createMiddleware } from "hono/factory";
+
+import { verifySession } from "../session.js";
+
+export interface SiweAuthVariables {
+  siweUser: {
+    address: string;
+  };
+}
+
+export interface SiweAuthOptions {
+  secret: string;
+  /** Header carrying the session token. Defaults to `x-user-token`. */
+  header?: string;
+}
+
+/**
+ * Hono middleware guarding routes with a SIWE-issued session token. Reads
+ * the token from a custom header (NOT `Authorization` — see README for why:
+ * gateful strips the `Authorization` header when proxying).
+ */
+export const siweAuth = (options: SiweAuthOptions) => {
+  const { secret, header = "x-user-token" } = options;
+
+  return createMiddleware<{ Variables: SiweAuthVariables }>(async (c, next) => {
+    const token = c.req.header(header);
+
+    if (!token) {
+      return c.json({ error: "missing_token" }, 401);
+    }
+
+    try {
+      const { address } = await verifySession(token, secret);
+      c.set("siweUser", { address });
+    } catch (error) {
+      // hono/jwt throws named errors; `JwtTokenExpired` distinguishes an
+      // expired session from an otherwise invalid one.
+      const reason =
+        error instanceof Error && error.name === "JwtTokenExpired"
+          ? "expired_token"
+          : "invalid_token";
+      return c.json({ error: reason }, 401);
+    }
+
+    await next();
+  });
+};

--- a/packages/auth/src/hono/middleware.ts
+++ b/packages/auth/src/hono/middleware.ts
@@ -1,6 +1,6 @@
 import { createMiddleware } from "hono/factory";
 
-import { verifySession } from "../session.js";
+import { assertSecret, verifySession } from "../session.js";
 
 export interface SiweAuthVariables {
   siweUser: {
@@ -21,6 +21,10 @@ export interface SiweAuthOptions {
  */
 export const siweAuth = (options: SiweAuthOptions) => {
   const { secret, header = "x-user-token" } = options;
+  // Fail fast on a misconfigured secret. Validating here (not per request)
+  // keeps the catch below scoped to token errors, so a weak secret can never
+  // masquerade as a 401 `invalid_token` and hide from 5xx monitoring.
+  assertSecret(secret);
 
   return createMiddleware<{ Variables: SiweAuthVariables }>(async (c, next) => {
     const token = c.req.header(header);

--- a/packages/auth/src/hono/routes.test.ts
+++ b/packages/auth/src/hono/routes.test.ts
@@ -1,0 +1,147 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { privateKeyToAccount } from "viem/accounts";
+import { createSiweMessage } from "viem/siwe";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { memoryNonceStore } from "../stores/memory.js";
+import type { NonceStore } from "../nonce.js";
+import { siweAuth } from "./middleware.js";
+import { mountAuthRoutes } from "./routes.js";
+
+const DOMAIN = "example.com";
+const CHAIN_ID = 1;
+const SECRET = "integration-test-secret-0123456789abcdef";
+
+const account = privateKeyToAccount(
+  "0x0facf9ffca9fdaea885fdc870edcd1064b89b7ff935b28896e242874ca380760",
+);
+
+const buildApp = (store: NonceStore) => {
+  const app = new OpenAPIHono();
+
+  mountAuthRoutes(app, {
+    store,
+    secret: SECRET,
+    domain: DOMAIN,
+    chainId: CHAIN_ID,
+  });
+
+  app.get("/protected", siweAuth({ secret: SECRET }), (c) => {
+    const user = c.get("siweUser") as { address: string };
+    return c.json({ address: user.address });
+  });
+
+  return app;
+};
+
+describe("mountAuthRoutes + siweAuth integration", () => {
+  let store: NonceStore;
+  let app: OpenAPIHono;
+
+  beforeEach(() => {
+    store = memoryNonceStore();
+    app = buildApp(store);
+  });
+
+  const getNonce = async (): Promise<string> => {
+    const res = await app.request("/auth/nonce");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { nonce: string };
+    return body.nonce;
+  };
+
+  const verify = async (message: string, signature: string) =>
+    app.request("/auth/verify", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message, signature }),
+    });
+
+  it("completes the full nonce -> sign -> verify -> authorized request flow", async () => {
+    const nonce = await getNonce();
+    const message = createSiweMessage({
+      address: account.address,
+      chainId: CHAIN_ID,
+      domain: DOMAIN,
+      nonce,
+      uri: `https://${DOMAIN}`,
+      version: "1",
+    });
+    const signature = await account.signMessage({ message });
+
+    const verifyRes = await verify(message, signature);
+    expect(verifyRes.status).toBe(200);
+    const { token, address } = (await verifyRes.json()) as {
+      token: string;
+      address: string;
+    };
+    expect(token).toBeTruthy();
+
+    const protectedRes = await app.request("/protected", {
+      headers: { "x-user-token": token },
+    });
+    expect(protectedRes.status).toBe(200);
+    const protectedBody = (await protectedRes.json()) as { address: string };
+    expect(protectedBody.address).toBe(address);
+  });
+
+  it("rejects a reused nonce", async () => {
+    const nonce = await getNonce();
+    const message = createSiweMessage({
+      address: account.address,
+      chainId: CHAIN_ID,
+      domain: DOMAIN,
+      nonce,
+      uri: `https://${DOMAIN}`,
+      version: "1",
+    });
+    const signature = await account.signMessage({ message });
+
+    const first = await verify(message, signature);
+    expect(first.status).toBe(200);
+
+    const second = await verify(message, signature);
+    expect(second.status).toBe(401);
+  });
+
+  it("surfaces an unexpected store error as 5xx, not a 401", async () => {
+    const failingStore: NonceStore = {
+      issue: async () => {},
+      consume: async () => {
+        throw new Error("store outage");
+      },
+    };
+    const failingApp = buildApp(failingStore);
+
+    const message = createSiweMessage({
+      address: account.address,
+      chainId: CHAIN_ID,
+      domain: DOMAIN,
+      nonce: "abcdefgh12345678",
+      uri: `https://${DOMAIN}`,
+      version: "1",
+    });
+    const signature = await account.signMessage({ message });
+
+    const res = await failingApp.request("/auth/verify", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message, signature }),
+    });
+
+    // The infra failure must NOT masquerade as a verification (401) failure.
+    expect(res.status).toBeGreaterThanOrEqual(500);
+  });
+
+  it("returns distinguishable 401 reasons from siweAuth", async () => {
+    const missing = await app.request("/protected");
+    expect(missing.status).toBe(401);
+    expect(await missing.json()).toEqual({ error: "missing_token" });
+
+    const invalid = await app.request("/protected", {
+      headers: { "x-user-token": "not-a-real-token" },
+    });
+    expect(invalid.status).toBe(401);
+    expect(await invalid.json()).toEqual({ error: "invalid_token" });
+  });
+});

--- a/packages/auth/src/hono/routes.test.ts
+++ b/packages/auth/src/hono/routes.test.ts
@@ -133,6 +133,20 @@ describe("mountAuthRoutes + siweAuth integration", () => {
     expect(res.status).toBeGreaterThanOrEqual(500);
   });
 
+  it("throws at construction on a weak secret instead of 401ing per request", () => {
+    // A misconfigured secret is a server error and must surface at startup,
+    // not hide behind `invalid_token` responses.
+    expect(() => siweAuth({ secret: "too-short" })).toThrow(/secret/i);
+    expect(() =>
+      mountAuthRoutes(new OpenAPIHono(), {
+        store,
+        secret: "too-short",
+        domain: DOMAIN,
+        chainId: CHAIN_ID,
+      }),
+    ).toThrow(/secret/i);
+  });
+
   it("returns distinguishable 401 reasons from siweAuth", async () => {
     const missing = await app.request("/protected");
     expect(missing.status).toBe(401);

--- a/packages/auth/src/hono/routes.test.ts
+++ b/packages/auth/src/hono/routes.test.ts
@@ -147,6 +147,48 @@ describe("mountAuthRoutes + siweAuth integration", () => {
     ).toThrow(/secret/i);
   });
 
+  it("accepts messages from any domain in an allowlist", async () => {
+    const whitelabelDomain = "gov.whitelabel.example";
+    const multiDomainApp = new OpenAPIHono();
+    mountAuthRoutes(multiDomainApp, {
+      store,
+      secret: SECRET,
+      domain: [DOMAIN, whitelabelDomain],
+      chainId: CHAIN_ID,
+    });
+
+    const nonceRes = await multiDomainApp.request("/auth/nonce");
+    const { nonce } = (await nonceRes.json()) as { nonce: string };
+    const message = createSiweMessage({
+      address: account.address,
+      chainId: CHAIN_ID,
+      domain: whitelabelDomain,
+      nonce,
+      uri: `https://${whitelabelDomain}`,
+      version: "1",
+    });
+    const signature = await account.signMessage({ message });
+
+    const res = await multiDomainApp.request("/auth/verify", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message, signature }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("throws at construction on an empty domain allowlist", () => {
+    expect(() =>
+      mountAuthRoutes(new OpenAPIHono(), {
+        store,
+        secret: SECRET,
+        domain: [],
+        chainId: CHAIN_ID,
+      }),
+    ).toThrow(/domain/i);
+  });
+
   it("returns distinguishable 401 reasons from siweAuth", async () => {
     const missing = await app.request("/protected");
     expect(missing.status).toBe(401);

--- a/packages/auth/src/hono/routes.ts
+++ b/packages/auth/src/hono/routes.ts
@@ -8,7 +8,7 @@ import {
   NonceResponseSchema,
   SiweVerifyBodySchema,
 } from "../schemas.js";
-import { issueSession } from "../session.js";
+import { assertSecret, issueSession } from "../session.js";
 import { SiweVerificationError, verifySiwe } from "../verify.js";
 
 const SessionResponseSchema = z.object({
@@ -99,6 +99,9 @@ export const mountAuthRoutes = (
     sessionTtlSec = 3600,
     nonceTtlMs,
   } = options;
+  // Fail fast on a misconfigured secret instead of erroring on the first
+  // `issueSession` call after a successful SIWE verification.
+  assertSecret(secret);
 
   app.openapi(nonceRoute, async (c) => {
     const nonce = generateNonce();

--- a/packages/auth/src/hono/routes.ts
+++ b/packages/auth/src/hono/routes.ts
@@ -1,0 +1,140 @@
+import { createRoute, z, type OpenAPIHono } from "@hono/zod-openapi";
+import type { Client, Hex } from "viem";
+
+import type { NonceStore } from "../nonce.js";
+import { generateNonce } from "../nonce.js";
+import {
+  AddressSchema,
+  NonceResponseSchema,
+  SiweVerifyBodySchema,
+} from "../schemas.js";
+import { issueSession } from "../session.js";
+import { SiweVerificationError, verifySiwe } from "../verify.js";
+
+const SessionResponseSchema = z.object({
+  token: z.string(),
+  address: AddressSchema,
+});
+
+const ErrorResponseSchema = z.object({
+  error: z.string(),
+});
+
+export interface MountAuthRoutesOptions {
+  store: NonceStore;
+  secret: string;
+  domain: string;
+  chainId: number;
+  /**
+   * Optional viem client enabling EIP-1271 smart-contract-wallet verification.
+   * It MUST be configured for the same chain as `chainId`, otherwise 1271
+   * signature validation runs against the wrong chain's contract state.
+   */
+  client?: Client;
+  sessionTtlSec?: number;
+  nonceTtlMs?: number;
+}
+
+const nonceRoute = createRoute({
+  method: "get",
+  path: "/auth/nonce",
+  responses: {
+    200: {
+      description: "A freshly issued SIWE nonce",
+      content: {
+        "application/json": {
+          schema: NonceResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+const verifyRoute = createRoute({
+  method: "post",
+  path: "/auth/verify",
+  request: {
+    body: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: SiweVerifyBodySchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "A session token for the verified SIWE message",
+      content: {
+        "application/json": {
+          schema: SessionResponseSchema,
+        },
+      },
+    },
+    401: {
+      description: "SIWE verification failed",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+/**
+ * Mounts `GET /auth/nonce` and `POST /auth/verify` onto an `OpenAPIHono` app.
+ */
+export const mountAuthRoutes = (
+  app: OpenAPIHono,
+  options: MountAuthRoutesOptions,
+): void => {
+  const {
+    store,
+    secret,
+    domain,
+    chainId,
+    client,
+    sessionTtlSec = 3600,
+    nonceTtlMs,
+  } = options;
+
+  app.openapi(nonceRoute, async (c) => {
+    const nonce = generateNonce();
+    await store.issue(nonce, nonceTtlMs);
+    return c.json({ nonce }, 200);
+  });
+
+  app.openapi(verifyRoute, async (c) => {
+    const { message, signature } = c.req.valid("json");
+
+    try {
+      const { address } = await verifySiwe({
+        message,
+        signature: signature as Hex,
+        store,
+        expectedDomain: domain,
+        expectedChainId: chainId,
+        client,
+      });
+
+      const token = await issueSession({
+        address,
+        secret,
+        expiresInSec: sessionTtlSec,
+      });
+
+      return c.json({ token, address }, 200);
+    } catch (error) {
+      // Only genuine verification failures are 401. Unexpected errors (nonce
+      // store outage, EIP-1271 RPC failure, etc.) propagate to the app's error
+      // handler as a 5xx so outages are observable instead of masquerading as
+      // user auth failures.
+      if (error instanceof SiweVerificationError) {
+        return c.json({ error: "verification_failed" }, 401);
+      }
+      throw error;
+    }
+  });
+};

--- a/packages/auth/src/hono/routes.ts
+++ b/packages/auth/src/hono/routes.ts
@@ -23,7 +23,11 @@ const ErrorResponseSchema = z.object({
 export interface MountAuthRoutesOptions {
   store: NonceStore;
   secret: string;
-  domain: string;
+  /**
+   * Domain(s) SIWE messages may be bound to. Pass an array when the same API
+   * serves multiple frontend hosts (e.g. whitelabel deployments).
+   */
+  domain: string | string[];
   chainId: number;
   /**
    * Optional viem client enabling EIP-1271 smart-contract-wallet verification.
@@ -102,6 +106,11 @@ export const mountAuthRoutes = (
   // Fail fast on a misconfigured secret instead of erroring on the first
   // `issueSession` call after a successful SIWE verification.
   assertSecret(secret);
+  // Same rationale for an empty domain allowlist: it would reject every
+  // sign-in as a 401 while the real problem is deployment configuration.
+  if (Array.isArray(domain) && domain.length === 0) {
+    throw new Error("mountAuthRoutes: domain must not be empty");
+  }
 
   app.openapi(nonceRoute, async (c) => {
     const nonce = generateNonce();

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,0 +1,38 @@
+export {
+  AddressSchema,
+  NonceResponseSchema,
+  SiweVerifyBodySchema,
+} from "./schemas.js";
+
+export { generateNonce, type NonceStore } from "./nonce.js";
+
+export {
+  memoryNonceStore,
+  type MemoryNonceStoreOptions,
+} from "./stores/memory.js";
+
+export {
+  verifySiweSignature,
+  verifySiwe,
+  SiweVerificationError,
+  type SiweFields,
+  type VerifiedSiwe,
+  type SiweVerificationReason,
+  type VerifySiweSignatureParams,
+  type VerifySiweParams,
+} from "./verify.js";
+
+export {
+  issueSession,
+  verifySession,
+  type Session,
+  type IssueSessionParams,
+} from "./session.js";
+
+export {
+  siweAuth,
+  type SiweAuthOptions,
+  type SiweAuthVariables,
+} from "./hono/middleware.js";
+
+export { mountAuthRoutes, type MountAuthRoutesOptions } from "./hono/routes.js";

--- a/packages/auth/src/nonce.ts
+++ b/packages/auth/src/nonce.ts
@@ -1,0 +1,33 @@
+import { generateSiweNonce } from "viem/siwe";
+
+/**
+ * Generates a fresh SIWE nonce (viem's `generateSiweNonce`).
+ */
+export const generateNonce = (): string => generateSiweNonce();
+
+/**
+ * Pluggable storage for SIWE nonces.
+ *
+ * `consume` MUST be implemented as an atomic single-use test-and-delete: it
+ * must return `true` to exactly one caller for a given nonce, even under
+ * concurrent invocations, and `false` to every other caller (unknown,
+ * already-consumed, or expired nonce). Non-atomic implementations (e.g. a
+ * naive `get` followed by a separate `delete`) are vulnerable to a
+ * time-of-check-to-time-of-use race that allows a SIWE message to be replayed.
+ */
+export interface NonceStore {
+  /**
+   * Persist a nonce so it can later be validated exactly once via `consume`.
+   * @param ttlMs optional time-to-live in milliseconds after which the nonce
+   * is no longer considered valid, even if never consumed.
+   */
+  issue(nonce: string, ttlMs?: number): Promise<void>;
+
+  /**
+   * Atomically test-and-delete the given nonce. Returns `true` only to the
+   * single caller that removed it (i.e. the first and only successful
+   * consumer); returns `false` for unknown, already-consumed, or expired
+   * nonces.
+   */
+  consume(nonce: string): Promise<boolean>;
+}

--- a/packages/auth/src/schemas.test.ts
+++ b/packages/auth/src/schemas.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { AddressSchema, SiweVerifyBodySchema } from "./schemas.js";
+
+describe("SiweVerifyBodySchema", () => {
+  const validSignature = `0x${"a".repeat(130)}`;
+
+  it("accepts a well-formed body", () => {
+    const result = SiweVerifyBodySchema.safeParse({
+      message: "hello",
+      signature: validSignature,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an oversized message", () => {
+    const result = SiweVerifyBodySchema.safeParse({
+      message: "x".repeat(4097),
+      signature: validSignature,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an oversized signature", () => {
+    const result = SiweVerifyBodySchema.safeParse({
+      message: "hello",
+      signature: `0x${"a".repeat(3001)}`,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-hex signature", () => {
+    const result = SiweVerifyBodySchema.safeParse({
+      message: "hello",
+      signature: "not-hex",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("AddressSchema", () => {
+  it("checksums a valid lowercase address", () => {
+    const result = AddressSchema.parse(
+      "0x1111111111111111111111111111111111111111",
+    );
+    expect(result).toBe("0x1111111111111111111111111111111111111111");
+  });
+
+  it("rejects an invalid address", () => {
+    expect(() => AddressSchema.parse("0xnope")).toThrow();
+  });
+});

--- a/packages/auth/src/schemas.ts
+++ b/packages/auth/src/schemas.ts
@@ -1,0 +1,33 @@
+import { getAddress, isAddress } from "viem";
+import { z } from "@hono/zod-openapi";
+
+/**
+ * Validates and checksums an Ethereum address — the standard viem idiom
+ * (`isAddress` + `getAddress`). Self-contained on purpose: a package cannot
+ * import from an app, and this is a stable primitive with no app-specific
+ * logic. `apps/api/src/mappers/shared.ts` defines an equivalent schema for its
+ * own use; the two are independent (no manual sync needed). If the API later
+ * adopts this package, it can re-export this one as the single source of truth.
+ */
+export const AddressSchema = z
+  .string()
+  .refine((addr) => isAddress(addr, { strict: false }), "Invalid address")
+  .transform((addr) => getAddress(addr));
+
+export const SiweVerifyBodySchema = z
+  .object({
+    // Upper bounds guard an unauthenticated endpoint against oversized payloads;
+    // a real SIWE message and signature are well under these limits.
+    message: z.string().min(1).max(4096),
+    signature: z
+      .string()
+      .regex(/^0x[0-9a-fA-F]+$/)
+      .max(3000),
+  })
+  .openapi("SiweVerifyBody");
+
+export const NonceResponseSchema = z
+  .object({
+    nonce: z.string(),
+  })
+  .openapi("NonceResponse");

--- a/packages/auth/src/session.test.ts
+++ b/packages/auth/src/session.test.ts
@@ -1,0 +1,67 @@
+import { sign } from "hono/jwt";
+import { getAddress } from "viem";
+import { describe, expect, it } from "vitest";
+
+import { issueSession, verifySession } from "./session.js";
+
+const SECRET = "test-secret-0123456789abcdef0123456789abcdef";
+const ADDRESS = getAddress("0x1111111111111111111111111111111111111111");
+
+describe("session", () => {
+  it("round-trips address and claims", async () => {
+    const token = await issueSession({
+      address: ADDRESS,
+      secret: SECRET,
+      expiresInSec: 3600,
+      claims: { role: "delegate" },
+    });
+
+    const session = await verifySession(token, SECRET);
+
+    expect(session.address).toBe(ADDRESS);
+    expect(session.claims.role).toBe("delegate");
+  });
+
+  it("rejects a tampered token", async () => {
+    const token = await issueSession({
+      address: ADDRESS,
+      secret: SECRET,
+      expiresInSec: 3600,
+    });
+
+    const [header, payload, signature] = token.split(".");
+    const tamperedSignature = `${signature.slice(0, -4)}${
+      signature.slice(-4) === "AAAA" ? "BBBB" : "AAAA"
+    }`;
+    const tampered = `${header}.${payload}.${tamperedSignature}`;
+
+    await expect(verifySession(tampered, SECRET)).rejects.toThrow();
+  });
+
+  it("rejects an expired token", async () => {
+    const token = await issueSession({
+      address: ADDRESS,
+      secret: SECRET,
+      expiresInSec: -10,
+    });
+
+    await expect(verifySession(token, SECRET)).rejects.toThrow();
+  });
+
+  it("rejects a weak secret", async () => {
+    await expect(
+      issueSession({ address: ADDRESS, secret: "too-short", expiresInSec: 60 }),
+    ).rejects.toThrow(/secret/i);
+  });
+
+  it("rejects a token signed with a different algorithm", async () => {
+    const iat = Math.floor(Date.now() / 1000);
+    const token = await sign(
+      { sub: ADDRESS, iat, exp: iat + 3600 },
+      SECRET,
+      "HS384",
+    );
+
+    await expect(verifySession(token, SECRET)).rejects.toThrow();
+  });
+});

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -6,7 +6,12 @@ const JWT_ALG = "HS256";
 /** Minimum HMAC secret length (chars) — HS256 is only as strong as its key. */
 const MIN_SECRET_LENGTH = 32;
 
-const assertSecret = (secret: string): void => {
+/**
+ * Rejects secrets too weak for HS256. Called eagerly by `siweAuth` and
+ * `mountAuthRoutes` so a misconfigured deployment fails at startup instead of
+ * surfacing as per-request 401s.
+ */
+export const assertSecret = (secret: string): void => {
   if (typeof secret !== "string" || secret.length < MIN_SECRET_LENGTH) {
     throw new Error(
       `auth secret must be a string of at least ${MIN_SECRET_LENGTH} high-entropy characters`,

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -1,0 +1,71 @@
+import { sign, verify } from "hono/jwt";
+import type { Address } from "viem";
+
+const JWT_ALG = "HS256";
+
+/** Minimum HMAC secret length (chars) — HS256 is only as strong as its key. */
+const MIN_SECRET_LENGTH = 32;
+
+const assertSecret = (secret: string): void => {
+  if (typeof secret !== "string" || secret.length < MIN_SECRET_LENGTH) {
+    throw new Error(
+      `auth secret must be a string of at least ${MIN_SECRET_LENGTH} high-entropy characters`,
+    );
+  }
+};
+
+export interface Session {
+  address: Address;
+  claims: Record<string, unknown>;
+}
+
+export interface IssueSessionParams {
+  address: Address;
+  secret: string;
+  expiresInSec: number;
+  claims?: Record<string, unknown>;
+}
+
+/**
+ * Issues an HS256 session JWT. Claims shape is pinned: `{ ...claims, sub:
+ * <checksummed address>, iat, exp }` — `sub` always carries the address.
+ */
+export const issueSession = async (
+  params: IssueSessionParams,
+): Promise<string> => {
+  const { address, secret, expiresInSec, claims } = params;
+  assertSecret(secret);
+  const iat = Math.floor(Date.now() / 1000);
+
+  const payload = {
+    ...claims,
+    sub: address,
+    iat,
+    exp: iat + expiresInSec,
+  };
+
+  return sign(payload, secret, JWT_ALG);
+};
+
+/**
+ * Verifies an HS256 session JWT and returns the address (`sub`) plus any
+ * additional claims. Throws if the token is missing, tampered, expired, or
+ * signed with a different algorithm.
+ */
+export const verifySession = async (
+  token: string,
+  secret: string,
+): Promise<Session> => {
+  assertSecret(secret);
+  const payload = await verify(token, secret, JWT_ALG);
+  const { sub, iat: _iat, exp: _exp, ...claims } = payload;
+
+  if (typeof sub !== "string") {
+    throw new Error("session token is missing a string `sub` (address) claim");
+  }
+
+  return {
+    address: sub as Address,
+    claims,
+  };
+};

--- a/packages/auth/src/stores/memory.test.ts
+++ b/packages/auth/src/stores/memory.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { memoryNonceStore } from "./memory.js";
+
+describe("memoryNonceStore", () => {
+  it("consumes a nonce exactly once", async () => {
+    const store = memoryNonceStore();
+    await store.issue("nonce-1");
+
+    await expect(store.consume("nonce-1")).resolves.toBe(true);
+    await expect(store.consume("nonce-1")).resolves.toBe(false);
+  });
+
+  it("rejects an unknown nonce", async () => {
+    const store = memoryNonceStore();
+    await expect(store.consume("never-issued")).resolves.toBe(false);
+  });
+
+  it("expires a nonce after its TTL", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = memoryNonceStore({ defaultTtlMs: 1000 });
+      await store.issue("nonce-ttl");
+
+      vi.advanceTimersByTime(1001);
+
+      await expect(store.consume("nonce-ttl")).resolves.toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("honors a per-nonce ttl override", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = memoryNonceStore({ defaultTtlMs: 1_000_000 });
+      await store.issue("short-lived", 500);
+
+      vi.advanceTimersByTime(501);
+
+      await expect(store.consume("short-lived")).resolves.toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("throws at capacity instead of evicting a live nonce", async () => {
+    const store = memoryNonceStore({ maxEntries: 2 });
+
+    await store.issue("first");
+    await store.issue("second");
+
+    // Must NOT silently drop "first" to make room (that would enable a
+    // login-DoS via nonce flooding); it fails loud instead.
+    await expect(store.issue("third")).rejects.toThrow(/capacity/i);
+
+    // The existing live nonces are untouched.
+    await expect(store.consume("first")).resolves.toBe(true);
+    await expect(store.consume("second")).resolves.toBe(true);
+  });
+
+  it("reclaims expired entries to make room at capacity", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = memoryNonceStore({ maxEntries: 2, defaultTtlMs: 1000 });
+
+      await store.issue("old-1");
+      await store.issue("old-2");
+
+      vi.advanceTimersByTime(1001); // both expire
+
+      // issue sweeps expired first, so there is room again.
+      await expect(store.issue("fresh")).resolves.toBeUndefined();
+      await expect(store.consume("fresh")).resolves.toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("allows exactly one winner under concurrent consume calls", async () => {
+    const store = memoryNonceStore();
+    await store.issue("race-nonce");
+
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => store.consume("race-nonce")),
+    );
+
+    const trueCount = results.filter(Boolean).length;
+    expect(trueCount).toBe(1);
+  });
+});

--- a/packages/auth/src/stores/memory.ts
+++ b/packages/auth/src/stores/memory.ts
@@ -1,0 +1,70 @@
+import type { NonceStore } from "../nonce.js";
+
+export interface MemoryNonceStoreOptions {
+  /** Default TTL (ms) applied when `issue` is called without an explicit ttl. */
+  defaultTtlMs?: number;
+  /**
+   * Maximum number of outstanding nonces. Once reached (after reclaiming
+   * expired entries), `issue` throws rather than evicting a live nonce.
+   */
+  maxEntries?: number;
+}
+
+/**
+ * In-memory `NonceStore` reference implementation.
+ *
+ * Intended for development, tests, and single-instance deployments only —
+ * state is not shared across processes/instances, so it is unsuitable for
+ * multi-instance production deployments (nonces issued on one instance won't
+ * be consumable on another). Ship a durable store (Redis/Postgres) for
+ * production multi-instance use, preserving the atomic `consume` contract.
+ */
+export const memoryNonceStore = (
+  options: MemoryNonceStoreOptions = {},
+): NonceStore => {
+  const { defaultTtlMs = 300_000, maxEntries = 10_000 } = options;
+  const entries = new Map<string, number>();
+
+  const sweepExpired = (now: number): void => {
+    for (const [nonce, expiresAt] of entries) {
+      if (expiresAt <= now) {
+        entries.delete(nonce);
+      }
+    }
+  };
+
+  return {
+    async issue(nonce, ttlMs) {
+      const now = Date.now();
+      sweepExpired(now);
+
+      // Do NOT evict live (unconsumed) nonces to make room — that would let an
+      // attacker flooding `/auth/nonce` knock out honest users' outstanding
+      // nonces (login DoS). Once expired entries are reclaimed and we are still
+      // at capacity, fail loud so the route surfaces a 5xx (alertable) instead
+      // of silently dropping a valid nonce. Consumers MUST rate-limit the nonce
+      // endpoint and/or use a durable store for multi-instance production.
+      if (entries.size >= maxEntries) {
+        throw new Error(
+          "memoryNonceStore is at capacity; rate-limit the nonce endpoint or raise maxEntries",
+        );
+      }
+
+      entries.set(nonce, now + (ttlMs ?? defaultTtlMs));
+    },
+
+    async consume(nonce) {
+      const expiresAt = entries.get(nonce);
+      if (expiresAt === undefined) {
+        return false;
+      }
+
+      // No `await` between the read and the delete below: in single-threaded
+      // JS this makes the test-and-delete atomic with respect to other
+      // `consume` calls, satisfying the `NonceStore.consume` contract.
+      entries.delete(nonce);
+
+      return expiresAt > Date.now();
+    },
+  };
+};

--- a/packages/auth/src/verify.test.ts
+++ b/packages/auth/src/verify.test.ts
@@ -1,0 +1,232 @@
+import { createSiweMessage } from "viem/siwe";
+import { privateKeyToAccount } from "viem/accounts";
+import { getAddress, type Hex } from "viem";
+import { describe, expect, it } from "vitest";
+
+import { memoryNonceStore } from "./stores/memory.js";
+import {
+  verifySiwe,
+  verifySiweSignature,
+  SiweVerificationError,
+} from "./verify.js";
+
+const DOMAIN = "example.com";
+const CHAIN_ID = 1;
+const account = privateKeyToAccount(
+  "0x0facf9ffca9fdaea885fdc870edcd1064b89b7ff935b28896e242874ca380760",
+);
+
+const buildMessage = (
+  overrides: Partial<Parameters<typeof createSiweMessage>[0]> = {},
+) =>
+  createSiweMessage({
+    address: account.address,
+    chainId: CHAIN_ID,
+    domain: DOMAIN,
+    nonce: "abcdefgh12345678",
+    uri: `https://${DOMAIN}`,
+    version: "1",
+    ...overrides,
+  });
+
+const sign = async (message: string): Promise<Hex> =>
+  account.signMessage({ message });
+
+/** Flips a hex nibble inside the `r` component of a 65-byte signature. */
+const tamperSignature = (signature: Hex): Hex => {
+  const prefix = signature.slice(0, 10);
+  const flipped = prefix.at(-1) === "0" ? "1" : "0";
+  return `${prefix.slice(0, -1)}${flipped}${signature.slice(10)}` as Hex;
+};
+
+describe("verifySiweSignature (EOA)", () => {
+  it("accepts a valid EOA signature", async () => {
+    const message = buildMessage();
+    const signature = await sign(message);
+
+    const result = await verifySiweSignature({ message, signature });
+
+    expect(result.address).toBe(getAddress(account.address));
+  });
+
+  it("rejects a tampered signature", async () => {
+    const message = buildMessage();
+    const signature = await sign(message);
+    const tampered = tamperSignature(signature);
+
+    await expect(
+      verifySiweSignature({ message, signature: tampered }),
+    ).rejects.toMatchObject({ reason: "bad_signature" });
+  });
+
+  // EIP-1271 smart-contract-wallet verification requires an on-chain
+  // contract (e.g. a deployed Safe) reachable via a viem `Client`. Exercising
+  // that path here would require an Anvil mainnet fork (see
+  // apps/relayer/e2e/helpers/anvil.ts), which needs a live RPC_URL and is
+  // e2e-grade infra unsuited to this package's portable unit suite. The
+  // `client`-injected branch in `verifySiweSignature` delegates directly to
+  // viem's `verifySiweMessage`, which viem itself tests against real
+  // ERC-1271/ERC-6492 contracts; wiring an equivalent fork-based test here is
+  // deferred to the authful/draft-proposals adoption work (see plan
+  // Follow-ups) where a real RPC fixture already exists.
+  it.skip("accepts a valid EIP-1271 smart-contract-wallet signature (requires anvil fork, see comment)", () => {
+    // Intentionally left unimplemented — see comment above.
+  });
+});
+
+describe("verifySiwe", () => {
+  const setup = () => {
+    const store = memoryNonceStore();
+    const message = buildMessage();
+    return { store, message };
+  };
+
+  it("accepts a valid message exactly once", async () => {
+    const { store, message } = setup();
+    await store.issue("abcdefgh12345678");
+    const signature = await sign(message);
+
+    const result = await verifySiwe({
+      message,
+      signature,
+      store,
+      expectedDomain: DOMAIN,
+      expectedChainId: CHAIN_ID,
+    });
+
+    expect(result.address).toBe(getAddress(account.address));
+
+    // Second attempt with the same (now-consumed) nonce must fail.
+    await expect(
+      verifySiwe({
+        message,
+        signature,
+        store,
+        expectedDomain: DOMAIN,
+        expectedChainId: CHAIN_ID,
+      }),
+    ).rejects.toMatchObject({ reason: "nonce" });
+  });
+
+  it("rejects an unknown nonce", async () => {
+    const { store, message } = setup();
+    const signature = await sign(message);
+
+    await expect(
+      verifySiwe({
+        message,
+        signature,
+        store,
+        expectedDomain: DOMAIN,
+        expectedChainId: CHAIN_ID,
+      }),
+    ).rejects.toMatchObject({ reason: "nonce" });
+  });
+
+  it("rejects a wrong domain", async () => {
+    const { store, message } = setup();
+    await store.issue("abcdefgh12345678");
+    const signature = await sign(message);
+
+    await expect(
+      verifySiwe({
+        message,
+        signature,
+        store,
+        expectedDomain: "other.example",
+        expectedChainId: CHAIN_ID,
+      }),
+    ).rejects.toMatchObject({ reason: "invalid_message" });
+  });
+
+  it("rejects a wrong chainId", async () => {
+    const { store, message } = setup();
+    await store.issue("abcdefgh12345678");
+    const signature = await sign(message);
+
+    await expect(
+      verifySiwe({
+        message,
+        signature,
+        store,
+        expectedDomain: DOMAIN,
+        expectedChainId: 999,
+      }),
+    ).rejects.toMatchObject({ reason: "wrong_chain" });
+  });
+
+  it("rejects an expired message", async () => {
+    const store = memoryNonceStore();
+    const issuedAt = new Date("2020-01-01T00:00:00.000Z");
+    const expirationTime = new Date("2020-01-01T00:05:00.000Z");
+    const message = buildMessage({ issuedAt, expirationTime });
+    await store.issue("abcdefgh12345678");
+    const signature = await sign(message);
+
+    await expect(
+      verifySiwe({
+        message,
+        signature,
+        store,
+        expectedDomain: DOMAIN,
+        expectedChainId: CHAIN_ID,
+        time: new Date("2020-01-01T00:10:00.000Z"),
+      }),
+    ).rejects.toMatchObject({ reason: "invalid_message" });
+  });
+
+  it("rejects a not-yet-valid message", async () => {
+    const store = memoryNonceStore();
+    const issuedAt = new Date("2020-01-01T00:00:00.000Z");
+    const notBefore = new Date("2020-01-01T01:00:00.000Z");
+    const message = buildMessage({ issuedAt, notBefore });
+    await store.issue("abcdefgh12345678");
+    const signature = await sign(message);
+
+    await expect(
+      verifySiwe({
+        message,
+        signature,
+        store,
+        expectedDomain: DOMAIN,
+        expectedChainId: CHAIN_ID,
+        time: new Date("2020-01-01T00:30:00.000Z"),
+      }),
+    ).rejects.toMatchObject({ reason: "invalid_message" });
+  });
+
+  it("does not consume the nonce when the signature is invalid", async () => {
+    const { store, message } = setup();
+    await store.issue("abcdefgh12345678");
+    const signature = await sign(message);
+    const tampered = tamperSignature(signature);
+
+    await expect(
+      verifySiwe({
+        message,
+        signature: tampered,
+        store,
+        expectedDomain: DOMAIN,
+        expectedChainId: CHAIN_ID,
+      }),
+    ).rejects.toMatchObject({ reason: "bad_signature" });
+
+    // Nonce must still be available since verification failed before consume.
+    await expect(store.consume("abcdefgh12345678")).resolves.toBe(true);
+  });
+
+  it("throws a SiweVerificationError instance", async () => {
+    const { store, message } = setup();
+    const signature = await sign(message);
+
+    await expect(
+      verifySiwe({
+        message,
+        signature,
+        store,
+        expectedDomain: DOMAIN,
+        expectedChainId: CHAIN_ID,
+      }),
+    ).rejects.toBeInstanceOf(SiweVerificationError);
+  });
+});

--- a/packages/auth/src/verify.test.ts
+++ b/packages/auth/src/verify.test.ts
@@ -139,6 +139,58 @@ describe("verifySiwe", () => {
     ).rejects.toMatchObject({ reason: "invalid_message" });
   });
 
+  it("accepts any domain from an allowlist", async () => {
+    const { store, message } = setup();
+    await store.issue("abcdefgh12345678");
+    const signature = await sign(message);
+
+    const result = await verifySiwe({
+      message,
+      signature,
+      store,
+      expectedDomain: ["other.example", DOMAIN],
+      expectedChainId: CHAIN_ID,
+    });
+
+    expect(result.address).toBe(getAddress(account.address));
+  });
+
+  it("rejects a domain absent from the allowlist", async () => {
+    const { store, message } = setup();
+    await store.issue("abcdefgh12345678");
+    const signature = await sign(message);
+
+    await expect(
+      verifySiwe({
+        message,
+        signature,
+        store,
+        expectedDomain: ["other.example", "another.example"],
+        expectedChainId: CHAIN_ID,
+      }),
+    ).rejects.toMatchObject({ reason: "invalid_message" });
+
+    // The nonce must survive a domain rejection (consume is the last gate).
+    await expect(store.consume("abcdefgh12345678")).resolves.toBe(true);
+  });
+
+  it("throws a plain Error (not a verification error) on an empty allowlist", async () => {
+    const { store, message } = setup();
+    await store.issue("abcdefgh12345678");
+    const signature = await sign(message);
+
+    const attempt = verifySiwe({
+      message,
+      signature,
+      store,
+      expectedDomain: [],
+      expectedChainId: CHAIN_ID,
+    });
+
+    await expect(attempt).rejects.toThrow("expectedDomain must not be empty");
+    await expect(attempt).rejects.not.toBeInstanceOf(SiweVerificationError);
+  });
+
   it("rejects a wrong chainId", async () => {
     const { store, message } = setup();
     await store.issue("abcdefgh12345678");

--- a/packages/auth/src/verify.ts
+++ b/packages/auth/src/verify.ts
@@ -1,0 +1,163 @@
+import {
+  getAddress,
+  recoverMessageAddress,
+  type Address,
+  type Client,
+} from "viem";
+import {
+  parseSiweMessage,
+  validateSiweMessage,
+  verifySiweMessage,
+} from "viem/siwe";
+
+import type { NonceStore } from "./nonce.js";
+
+export type SiweVerificationReason =
+  | "malformed"
+  | "bad_signature"
+  | "invalid_message"
+  | "wrong_chain"
+  | "nonce";
+
+export class SiweVerificationError extends Error {
+  readonly reason: SiweVerificationReason;
+
+  constructor(reason: SiweVerificationReason, message?: string) {
+    super(message ?? reason);
+    this.name = "SiweVerificationError";
+    this.reason = reason;
+  }
+}
+
+export type SiweFields = ReturnType<typeof parseSiweMessage>;
+
+export interface VerifiedSiwe {
+  address: Address;
+  fields: SiweFields;
+}
+
+export interface VerifySiweSignatureParams {
+  message: string;
+  signature: `0x${string}`;
+  /**
+   * Optional viem client, on the message's chain, used to validate the
+   * signature via EIP-1271/ERC-6492 (smart-contract wallets, e.g. Safes).
+   * When omitted, verification assumes an EOA and recovers the signer
+   * address directly from the signature.
+   *
+   * INVARIANT: the client MUST target the same chain as the message's
+   * `chainId` (and `verifySiwe`'s `expectedChainId`); otherwise the on-chain
+   * `isValidSignature` lookup runs against the wrong contract state.
+   */
+  client?: Client;
+  time?: Date;
+}
+
+/**
+ * Verifies the *authenticity* of a SIWE signature only — it does NOT assert
+ * domain, chainId, expiry, or nonce validity. Those field-level checks are
+ * owned exclusively by `verifySiwe`, which uses a single authoritative clock.
+ */
+export const verifySiweSignature = async (
+  params: VerifySiweSignatureParams,
+): Promise<VerifiedSiwe> => {
+  const { message, signature, client, time } = params;
+
+  const fields = parseSiweMessage(message);
+
+  if (!fields.address) {
+    throw new SiweVerificationError(
+      "malformed",
+      "SIWE message is missing an address",
+    );
+  }
+
+  const messageAddress = getAddress(fields.address);
+
+  if (client) {
+    const isValid = await verifySiweMessage(client, {
+      message,
+      signature,
+      time,
+    });
+
+    if (!isValid) {
+      throw new SiweVerificationError("bad_signature");
+    }
+
+    return { address: messageAddress, fields };
+  }
+
+  let recovered: Address;
+  try {
+    recovered = await recoverMessageAddress({ message, signature });
+  } catch {
+    // A malformed/tampered signature can make ECDSA recovery itself throw
+    // (e.g. an invalid curve point) rather than merely recover a mismatched
+    // address. Either outcome means the signature is inauthentic.
+    throw new SiweVerificationError("bad_signature");
+  }
+
+  if (getAddress(recovered) !== messageAddress) {
+    throw new SiweVerificationError("bad_signature");
+  }
+
+  return { address: messageAddress, fields };
+};
+
+export interface VerifySiweParams {
+  message: string;
+  signature: `0x${string}`;
+  store: NonceStore;
+  expectedDomain: string;
+  expectedChainId: number;
+  client?: Client;
+  time?: Date;
+}
+
+/**
+ * Store-aware SIWE verification: authenticity (via `verifySiweSignature`)
+ * followed by domain/chainId/expiry checks, and finally an atomic
+ * `store.consume(nonce)` as the last gate. The nonce is NOT consumed if any
+ * earlier check fails, so a bad signature or stale message never burns a
+ * valid nonce.
+ */
+export const verifySiwe = async (
+  params: VerifySiweParams,
+): Promise<VerifiedSiwe> => {
+  const { message, signature, store, expectedDomain, expectedChainId } = params;
+  const time = params.time ?? new Date();
+
+  const { address, fields } = await verifySiweSignature({
+    message,
+    signature,
+    client: params.client,
+    time,
+  });
+
+  const isValidMessage = validateSiweMessage({
+    message: fields,
+    domain: expectedDomain,
+    time,
+  });
+
+  if (!isValidMessage) {
+    throw new SiweVerificationError("invalid_message");
+  }
+
+  if (fields.chainId !== expectedChainId) {
+    throw new SiweVerificationError("wrong_chain");
+  }
+
+  if (!fields.nonce) {
+    throw new SiweVerificationError("malformed", "SIWE message has no nonce");
+  }
+
+  const consumed = await store.consume(fields.nonce);
+
+  if (!consumed) {
+    throw new SiweVerificationError("nonce");
+  }
+
+  return { address, fields };
+};

--- a/packages/auth/src/verify.ts
+++ b/packages/auth/src/verify.ts
@@ -109,7 +109,12 @@ export interface VerifySiweParams {
   message: string;
   signature: `0x${string}`;
   store: NonceStore;
-  expectedDomain: string;
+  /**
+   * Domain(s) the SIWE message may be bound to. Pass an array when the same
+   * API serves multiple frontend hosts (e.g. whitelabel deployments); the
+   * message's `domain` field must match one of them exactly.
+   */
+  expectedDomain: string | string[];
   expectedChainId: number;
   client?: Client;
   time?: Date;
@@ -128,6 +133,16 @@ export const verifySiwe = async (
   const { message, signature, store, expectedDomain, expectedChainId } = params;
   const time = params.time ?? new Date();
 
+  const allowedDomains = Array.isArray(expectedDomain)
+    ? expectedDomain
+    : [expectedDomain];
+
+  // An empty allowlist is a server misconfiguration, not a user auth failure:
+  // throw a plain Error so it surfaces as a 5xx instead of masquerading as 401.
+  if (allowedDomains.length === 0) {
+    throw new Error("verifySiwe: expectedDomain must not be empty");
+  }
+
   const { address, fields } = await verifySiweSignature({
     message,
     signature,
@@ -135,9 +150,13 @@ export const verifySiwe = async (
     time,
   });
 
+  if (!fields.domain || !allowedDomains.includes(fields.domain)) {
+    throw new SiweVerificationError("invalid_message");
+  }
+
   const isValidMessage = validateSiweMessage({
     message: fields,
-    domain: expectedDomain,
+    domain: fields.domain,
     time,
   });
 

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/auth/tsup.config.ts
+++ b/packages/auth/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+  format: ["esm"],
+  outDir: "dist",
+});

--- a/packages/auth/vitest.config.ts
+++ b/packages/auth/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,7 +352,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       "@rainbow-me/rainbowkit":
         specifier: ^2.2.0
-        version: 2.2.10(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
+        version: 2.2.10(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
       "@snapshot-labs/snapshot.js":
         specifier: ^0.12.62
         version: 0.12.65(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -445,7 +445,7 @@ importers:
         version: 2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       wagmi:
         specifier: ^2.12.25
-        version: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -885,6 +885,30 @@ importers:
       typescript:
         specifier: ~5.6.2
         version: 5.6.3
+
+  packages/auth:
+    devDependencies:
+      "@hono/zod-openapi":
+        specifier: ^1.2.2
+        version: 1.2.2(hono@4.12.7)(zod@4.4.1)
+      "@types/node":
+        specifier: ^20.16.5
+        version: 20.19.37
+      hono:
+        specifier: ^4.12.7
+        version: 4.12.7
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      viem:
+        specifier: ^2.41.2
+        version: 2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.1)
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.37)(jiti@2.6.1)(jsdom@24.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.31.1)(msw@2.12.10(@types/node@20.19.37)(typescript@5.9.3))(sass@1.100.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/local-node:
     dependencies:
@@ -28345,9 +28369,9 @@ snapshots:
       "@babel/helper-string-parser": 7.27.1
       "@babel/helper-validator-identifier": 7.28.5
 
-  "@base-org/account@2.4.0(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)":
+  "@base-org/account@2.4.0(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)":
     dependencies:
-      "@coinbase/cdp-sdk": 1.38.6(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@coinbase/cdp-sdk": 1.38.6(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@noble/hashes": 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
@@ -28853,11 +28877,11 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       react-is: 17.0.2
 
-  "@coinbase/cdp-sdk@1.38.6(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
+  "@coinbase/cdp-sdk@1.38.6(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
     dependencies:
-      "@solana-program/system": 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      "@solana-program/token": 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      "@solana/kit": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@solana-program/system": 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      "@solana-program/token": 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      "@solana/kit": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@solana/web3.js": 1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
       abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
       axios: 1.13.6
@@ -33588,7 +33612,7 @@ snapshots:
 
   "@radix-ui/rect@1.1.1": {}
 
-  "@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))":
+  "@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))":
     dependencies:
       "@tanstack/react-query": 5.90.21(react@19.2.3)
       "@vanilla-extract/css": 1.17.3
@@ -33601,7 +33625,7 @@ snapshots:
       react-remove-scroll: 2.6.2(@types/react@19.2.8)(react@19.2.3)
       ua-parser-js: 1.0.40
       viem: 2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
     transitivePeerDependencies:
       - "@types/react"
       - babel-plugin-macros
@@ -34196,13 +34220,13 @@ snapshots:
 
   "@socket.io/component-emitter@3.1.2": {}
 
-  "@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))":
+  "@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))":
     dependencies:
-      "@solana/kit": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@solana/kit": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
-  "@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))":
+  "@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))":
     dependencies:
-      "@solana/kit": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@solana/kit": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   "@solana/accounts@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)":
     dependencies:
@@ -34332,7 +34356,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  "@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
+  "@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
     dependencies:
       "@solana/accounts": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/addresses": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -34346,11 +34370,11 @@ snapshots:
       "@solana/rpc": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/rpc-parsed-types": 3.0.3(typescript@5.9.3)
       "@solana/rpc-spec-types": 3.0.3(typescript@5.9.3)
-      "@solana/rpc-subscriptions": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@solana/rpc-subscriptions": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@solana/rpc-types": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/signers": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/sysvars": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      "@solana/transaction-confirmation": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@solana/transaction-confirmation": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@solana/transaction-messages": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/transactions": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       typescript: 5.9.3
@@ -34429,14 +34453,14 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  "@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
+  "@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
     dependencies:
       "@solana/errors": 3.0.3(typescript@5.9.3)
       "@solana/functional": 3.0.3(typescript@5.9.3)
       "@solana/rpc-subscriptions-spec": 3.0.3(typescript@5.9.3)
       "@solana/subscribable": 3.0.3(typescript@5.9.3)
       typescript: 5.9.3
-      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
   "@solana/rpc-subscriptions-spec@3.0.3(typescript@5.9.3)":
     dependencies:
@@ -34446,7 +34470,7 @@ snapshots:
       "@solana/subscribable": 3.0.3(typescript@5.9.3)
       typescript: 5.9.3
 
-  "@solana/rpc-subscriptions@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
+  "@solana/rpc-subscriptions@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
     dependencies:
       "@solana/errors": 3.0.3(typescript@5.9.3)
       "@solana/fast-stable-stringify": 3.0.3(typescript@5.9.3)
@@ -34454,7 +34478,7 @@ snapshots:
       "@solana/promises": 3.0.3(typescript@5.9.3)
       "@solana/rpc-spec-types": 3.0.3(typescript@5.9.3)
       "@solana/rpc-subscriptions-api": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      "@solana/rpc-subscriptions-channel-websocket": 3.0.3(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@solana/rpc-subscriptions-channel-websocket": 3.0.3(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@solana/rpc-subscriptions-spec": 3.0.3(typescript@5.9.3)
       "@solana/rpc-transformers": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/rpc-types": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -34539,7 +34563,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  "@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
+  "@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))":
     dependencies:
       "@solana/addresses": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/codecs-strings": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -34547,7 +34571,7 @@ snapshots:
       "@solana/keys": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/promises": 3.0.3(typescript@5.9.3)
       "@solana/rpc": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      "@solana/rpc-subscriptions": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      "@solana/rpc-subscriptions": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       "@solana/rpc-types": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/transaction-messages": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       "@solana/transactions": 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -35798,9 +35822,9 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.0.3
 
-  "@wagmi/connectors@6.2.0(065056ca42ee96b604be47be1b6a39a2)":
+  "@wagmi/connectors@6.2.0(3e424d50f9eb170fdb7921e271126314)":
     dependencies:
-      "@base-org/account": 2.4.0(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      "@base-org/account": 2.4.0(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       "@coinbase/wallet-sdk": 4.3.6(@types/react@19.2.8)(bufferutil@4.0.9)(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.76)
       "@gemini-wallet/core": 0.3.2(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       "@metamask/sdk": 0.33.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -35809,7 +35833,7 @@ snapshots:
       "@wagmi/core": 2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.8)(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       "@walletconnect/ethereum-provider": 2.21.1(@types/react@19.2.8)(bufferutil@4.0.9)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: "@coinbase/wallet-sdk@3.9.3"
-      porto: 0.2.35(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.8)(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
+      porto: 0.2.35(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.8)(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
       viem: 2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
@@ -38499,14 +38523,6 @@ snapshots:
   drizzle-orm@0.41.0(@electric-sql/pglite@0.2.13)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(kysely@0.26.3)(pg@8.20.0):
     optionalDependencies:
       "@electric-sql/pglite": 0.2.13
-      "@opentelemetry/api": 1.9.0
-      "@types/pg": 8.18.0
-      kysely: 0.26.3
-      pg: 8.20.0
-
-  drizzle-orm@0.41.0(@electric-sql/pglite@0.3.16)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(kysely@0.26.3)(pg@8.20.0):
-    optionalDependencies:
-      "@electric-sql/pglite": 0.3.16
       "@opentelemetry/api": 1.9.0
       "@types/pg": 8.18.0
       kysely: 0.26.3
@@ -43396,7 +43412,7 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.35(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.8)(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  porto@0.2.35(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(@wagmi/core@2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.8)(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       "@wagmi/core": 2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.8)(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hono: 4.12.7
@@ -43410,7 +43426,7 @@ snapshots:
       "@tanstack/react-query": 5.90.21(react@19.2.3)
       react: 19.2.3
       typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
     transitivePeerDependencies:
       - "@types/react"
       - immer
@@ -46759,10 +46775,10 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
+  wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.3))(@types/react@19.2.8)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(ioredis@5.10.1)(react@19.2.3)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       "@tanstack/react-query": 5.90.21(react@19.2.3)
-      "@wagmi/connectors": 6.2.0(065056ca42ee96b604be47be1b6a39a2)
+      "@wagmi/connectors": 6.2.0(3e424d50f9eb170fdb7921e271126314)
       "@wagmi/core": 2.22.1(@tanstack/query-core@5.90.20)(@types/react@19.2.8)(immer@11.1.8)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.47.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       react: 19.2.3
       use-sync-external-store: 1.4.0(react@19.2.3)


### PR DESCRIPTION
## What & why

Adds **`@anticapture/auth`** — a reusable **Sign-In With Ethereum (SIWE / [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361))** authentication package for Blockful's Hono backends (anticapture `apps/api`/`authful`, thority, delegation-incentives-system).

Today the draft-proposals API (PR #1910) trusts a client-supplied `address` with **no proof of wallet ownership** — anyone can read/edit/delete another address's drafts. And DEV-950 (public authful token minting) needs a way to bind a token to a real wallet. Both need the same primitive: *prove the caller controls an Ethereum address, off-chain*. Rather than build it twice, this PR ships it once as a package.

> **Scope:** this PR is the **package only**. Adopting it in authful (DEV-950) and draft-proposals is intentionally **deferred** to follow-up PRs — but the API is designed to unblock both.

## What is SIWE?

SIWE is a standard (EIP-4361) for authenticating a user to an **off-chain** backend using their Ethereum wallet instead of a password. The user signs a structured, human-readable message with their wallet; the server verifies the signature to prove address ownership, then issues a normal session.

It is **not** an on-chain transaction (that's what `apps/relayer` does with EIP-712 `castVoteBySig`/`delegateBySig`). SIWE is login: no gas, nothing on-chain, the signature authenticates a session.

## How it works (the flow)

```
Browser / wallet                    Backend (@anticapture/auth)
      │                                        │
      │  GET /auth/nonce                        │
      │ ───────────────────────────────────▶   │  generateNonce()  → store.issue(nonce)
      │  ◀───────────────────────  { nonce }    │
      │                                        │
      │  wallet signs a SIWE message           │
      │  containing that nonce + domain + chainId
      │                                        │
      │  POST /auth/verify { message, signature }│
      │ ───────────────────────────────────▶   │  verifySiwe():
      │                                        │   1. verify signature (EOA or EIP-1271)
      │                                        │   2. assert domain + chainId + expiry
      │                                        │   3. atomically consume(nonce)  ← last
      │                                        │   → issueSession() (HS256 JWT)
      │  ◀────────────────────  { token, address }
      │                                        │
      │  subsequent requests: x-user-token: <jwt>│
      │ ───────────────────────────────────▶   │  siweAuth() middleware → c.get("siweUser")
```

1. **Nonce** — server issues a single-use random nonce (anti-replay).
2. **Sign** — wallet signs a SIWE message embedding that nonce, the expected `domain`, and `chainId`.
3. **Verify** — `verifySiwe` checks the signature, then that the message's `domain`/`chainId`/expiry match what the server expects, then **consumes the nonce atomically as the final step** (a bad signature or stale message never burns a valid nonce).
4. **Session** — on success the server mints an HS256 JWT; `siweAuth` middleware guards subsequent requests.

## API surface

| Export | Purpose |
|---|---|
| `generateNonce` | fresh SIWE nonce (viem `generateSiweNonce`) |
| `NonceStore` (interface) + `memoryNonceStore` | pluggable single-use nonce storage; bundled in-memory reference impl (apps provide durable Redis/Postgres) |
| `verifySiweSignature` | pure authenticity-only primitive (EOA recover, or EIP-1271 via injected client) — reusable for one-shot flows like DEV-950 |
| `verifySiwe` | store-aware strict verify: signature + domain + chainId + expiry + atomic nonce consume |
| `issueSession` / `verifySession` | HS256 JWT session helpers |
| `siweAuth` | Hono middleware (reads `x-user-token`, fails closed) |
| `mountAuthRoutes` | registers `GET /auth/nonce` + `POST /auth/verify` on an `OpenAPIHono` app |
| `AddressSchema`, `SiweVerifyBodySchema`, `NonceResponseSchema` | zod schemas |

## Key design decisions

- **Single package, depends on Hono, JWT via `hono/jwt`.** Every live Blockful backend is Hono — no need for a framework-agnostic split or `jose`.
- **EOA + EIP-1271.** Verification supports both externally-owned accounts and smart-contract wallets (Safe multisigs, common for governance delegates) via an optional injected viem client on the message's chain.
- **`viem` / `hono` / `@hono/zod-openapi` are `peerDependencies`** (not `dependencies`) — mirrors `@anticapture/observability`, and avoids duplicate `viem`/`zod` module identity (`instanceof`/brand mismatches) in consumers.
- **Pluggable `NonceStore` with a documented atomicity contract.** `consume` MUST be an atomic test-and-delete; concrete durable stores live in the consuming apps.

## Security properties

- **Replay-safe:** single-use nonce, consumed **after** verification (verify-then-consume); atomic `consume` contract prevents TOCTOU replay.
- **Phishing / cross-chain replay resistant:** `domain` and `chainId` are enforced against server-trusted expected values.
- **JWT hardened:** algorithm pinned to `HS256` (no alg-confusion — verified against `hono@4.12`), `exp` enforced, caller claims cannot override `sub`/`exp`, secret must be ≥32 chars.
- **Fails closed:** middleware rejects missing/invalid/expired tokens; unexpected infra errors on `/auth/verify` surface as `5xx` (observable), only real verification failures return `401`.

Reviewed by an independent security pass: **0 critical / 0 high**; the medium/low findings (nonce-endpoint flooding, error observability, secret strength, input bounds, EIP-1271 client-chain invariant) are all addressed in this PR.

## Transport note (for future adopters)

Gateful **strips the `Authorization` header** when proxying to DAO APIs, so the session token rides a custom **`x-user-token`** header instead. Adopters proxying auth-guarded requests through gateful must thread that header through `@anticapture/client` → the dashboard Next proxy → gateful.

## Testing

- **33 tests** (32 passing, 1 documented skip for the EIP-1271 real-fixture path which needs an Anvil fork — the `client` branch delegates to viem's own tested `verifySiweMessage`).
- Covers: EOA valid/tampered, domain/chainId/expiry/notBefore rejection, nonce unknown/reused/not-burned-on-failure, JWT round-trip/tamper/expiry/wrong-alg/weak-secret, memory store consume-once/TTL/capacity/concurrent-race, and full `GET /auth/nonce → sign → POST /auth/verify → guarded request` integration.
- `typecheck`, `lint`, `build` green.

## Follow-ups (deferred)

- Adopt in **authful** for public token minting (DEV-950) using `verifySiweSignature`.
- Adopt in **draft-proposals** (session + `siweAuth` + the `x-user-token` transport threading).
- Durable `NonceStore` reference implementations (Redis/Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
