### PR TITLE
feat(dashboard): add error page and context

### DIFF
--- a/.changeset/heavy-pandas-repair.md
+++ b/.changeset/heavy-pandas-repair.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Add route error boundaries with a recovery UI to DAO and whitelabel pages so a render error no longer blanks the whole page, and surface failed votes-table loads and pagination with a visible error and retry

--- a/apps/dashboard/app/[daoId]/(main)/activity-feed/page.test.ts
+++ b/apps/dashboard/app/[daoId]/(main)/activity-feed/page.test.ts
@@ -20,6 +20,8 @@ describe("ActivityFeedPage", () => {
     });
 
     expect(redirect).not.toHaveBeenCalled();
-    expect(result.props.feedDaoId).toBe("torn");
+    // The page wraps the section in a fragment alongside the e2e-only
+    // ForceErrorTrigger; the section is the second child.
+    expect(result.props.children[1].props.feedDaoId).toBe("torn");
   });
 });

--- a/apps/dashboard/app/[daoId]/(main)/activity-feed/page.tsx
+++ b/apps/dashboard/app/[daoId]/(main)/activity-feed/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { ActivityFeedSection } from "@/features/feed";
+import { ForceErrorTrigger } from "@/shared/components/errors/ForceErrorTrigger";
 import daoConfigByDaoId from "@/shared/dao-config";
 import { toDaoIdEnum } from "@/shared/types/daos";
 
@@ -44,7 +45,12 @@ export default async function ActivityFeedPage({
     redirect(`/${daoId}`);
   }
 
-  return <ActivityFeedSection feedDaoId={feedDaoId} />;
+  return (
+    <>
+      <ForceErrorTrigger />
+      <ActivityFeedSection feedDaoId={feedDaoId} />
+    </>
+  );
 }
 
 type Props = {

--- a/apps/dashboard/app/[daoId]/(main)/error.tsx
+++ b/apps/dashboard/app/[daoId]/(main)/error.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+import { RouteErrorFallback } from "@/shared/components/errors/RouteErrorFallback";
+
+export default RouteErrorFallback;

--- a/apps/dashboard/app/[daoId]/(main)/proposals/[proposalId]/error.tsx
+++ b/apps/dashboard/app/[daoId]/(main)/proposals/[proposalId]/error.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+import { RouteErrorFallback } from "@/shared/components/errors/RouteErrorFallback";
+
+export default RouteErrorFallback;

--- a/apps/dashboard/app/whitelabel/[daoId]/error.tsx
+++ b/apps/dashboard/app/whitelabel/[daoId]/error.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+import { RouteErrorFallback } from "@/shared/components/errors/RouteErrorFallback";
+
+export default RouteErrorFallback;

--- a/apps/dashboard/e2e/error-boundary.spec.ts
+++ b/apps/dashboard/e2e/error-boundary.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "./fixtures";
+
+test.describe("Route error boundary", () => {
+  test("a render error shows the recovery UI and the shell survives", async ({
+    goto,
+    page,
+  }) => {
+    // ?forceError makes the page throw a client render error after hydration
+    // (see ForceErrorTrigger), which the segment error.tsx must catch.
+    await goto("/ens/activity-feed?forceError=1");
+
+    const fallback = page.getByTestId("route-error-fallback");
+    await expect(fallback).toBeVisible({ timeout: 15_000 });
+    await expect(
+      fallback.getByRole("button", { name: /try again/i }),
+    ).toBeVisible();
+
+    // The shell outside the boundary survives: desktop sidebar still rendered.
+    await expect(page.locator("header").first()).toBeVisible();
+    // The page content was replaced by the recovery UI, not a white screen.
+    await expect(page.locator("h4", { hasText: "Activity Feed" })).toHaveCount(
+      0,
+    );
+  });
+
+  test("pages render normally without the forceError param", async ({
+    goto,
+    page,
+  }) => {
+    await goto("/ens/activity-feed");
+    await expect(
+      page.locator("h4").filter({ hasText: "Activity Feed" }),
+    ).toBeVisible();
+    await expect(page.getByTestId("route-error-fallback")).toHaveCount(0);
+  });
+});

--- a/apps/dashboard/features/feed/ActivityFeedSection.tsx
+++ b/apps/dashboard/features/feed/ActivityFeedSection.tsx
@@ -14,6 +14,7 @@ import { HoldersAndDelegatesDrawer } from "@/features/holders-and-delegates/comp
 import { TheSectionLayout } from "@/shared/components/containers/TheSectionLayout";
 import { BlankSlate } from "@/shared/components/design-system/blank-slate/BlankSlate";
 import { Button } from "@/shared/components/design-system/buttons/button/Button";
+import { FetchErrorState } from "@/shared/components/errors/FetchErrorState";
 import {
   SubSectionsContainer,
   BulletDivider,
@@ -63,11 +64,12 @@ export const ActivityFeedSection = ({ feedDaoId }: { feedDaoId: string }) => {
   const handleIntersection = useCallback(
     (entries: IntersectionObserverEntry[]) => {
       const [entry] = entries;
-      if (entry.isIntersecting && hasNextPage && !loading) {
+      // No auto-fetch while errored; the user retries via the error UI.
+      if (entry.isIntersecting && hasNextPage && !loading && !error) {
         fetchNextPage();
       }
     },
-    [hasNextPage, loading, fetchNextPage],
+    [hasNextPage, loading, error, fetchNextPage],
   );
 
   useEffect(() => {
@@ -127,15 +129,10 @@ export const ActivityFeedSection = ({ feedDaoId }: { feedDaoId: string }) => {
       <div className={cn("flex flex-col gap-2")}>
         {error && (
           <SubSectionsContainer className="p-0">
-            <div className="flex flex-col items-center justify-center gap-2 px-4 py-8">
-              <p className="text-error text-sm">Failed to load activity feed</p>
-              <button
-                onClick={() => refetch()}
-                className="text-link hover:text-link-hover text-sm underline"
-              >
-                Try again
-              </button>
-            </div>
+            <FetchErrorState
+              message="Failed to load activity feed"
+              onRetry={() => refetch()}
+            />
           </SubSectionsContainer>
         )}
 

--- a/apps/dashboard/features/governance/components/proposal-overview/OffchainVotesContent.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/OffchainVotesContent.tsx
@@ -18,6 +18,7 @@ import { VotesTable } from "@/features/governance/components/proposal-overview/V
 import { getOffchainVoteFullLabel } from "@/features/governance/utils/offchainVoteLabel";
 import { BlankSlate } from "@/shared/components/design-system/blank-slate/BlankSlate";
 import { Button } from "@/shared/components/design-system/buttons/button/Button";
+import { FetchErrorState } from "@/shared/components/errors/FetchErrorState";
 import { SkeletonRow } from "@/shared/components/skeletons/SkeletonRow";
 import { EnsAvatar } from "@/shared/components/design-system/avatars/ens-avatar/EnsAvatar";
 import { ArrowState, ArrowUpDown } from "@/shared/components/icons";
@@ -100,6 +101,7 @@ export const OffchainVotesContent = ({
     isLoading: loading,
     error,
     fetchNextPage,
+    refetch,
     hasNextPage,
     isFetchingNextPage,
   } = useVotesOffchainByProposalIdInfinite(
@@ -118,6 +120,10 @@ export const OffchainVotesContent = ({
   // true -> false on each page, re-running this effect so the observer
   // re-attaches to the freshly rendered sentinel (mirrors the on-chain votes).
   useEffect(() => {
+    // Paused while errored so a failed page fetch doesn't auto-retry in a
+    // loop; the user retries instead.
+    if (error) return;
+
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
@@ -128,7 +134,7 @@ export const OffchainVotesContent = ({
     );
     if (loadingRowRef.current) observer.observe(loadingRowRef.current);
     return () => observer.disconnect();
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage, error]);
 
   const tableData = useMemo(() => {
     const rows: OffchainVoteRow[] = [];
@@ -147,7 +153,7 @@ export const OffchainVotesContent = ({
       }
     });
 
-    if (hasNextPage || isFetchingNextPage) {
+    if ((hasNextPage || isFetchingNextPage) && !error) {
       rows.push({
         voter: LOADING_ROW,
         choice: [],
@@ -158,7 +164,7 @@ export const OffchainVotesContent = ({
     }
 
     return rows;
-  }, [votes, hasNextPage, isFetchingNextPage]);
+  }, [votes, hasNextPage, isFetchingNextPage, error]);
 
   const columns: ColumnDef<OffchainVoteRow>[] = useMemo(
     () => [
@@ -388,12 +394,14 @@ export const OffchainVotesContent = ({
     ],
   );
 
-  if (error)
+  if (error && votes.length === 0) {
     return (
-      <div>
-        Error: {error instanceof Error ? error.message : "Failed to load votes"}
-      </div>
+      <FetchErrorState
+        message="Failed to load votes"
+        onRetry={() => refetch()}
+      />
     );
+  }
 
   if (loading && votes.length === 0) {
     return (
@@ -419,6 +427,13 @@ export const OffchainVotesContent = ({
           />
         }
       />
+      {error && (
+        <FetchErrorState
+          message="Failed to load more votes"
+          onRetry={() => fetchNextPage()}
+          className="py-4"
+        />
+      )}
     </div>
   );
 };

--- a/apps/dashboard/features/governance/components/proposal-overview/TabsVotedContent.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/TabsVotedContent.tsx
@@ -21,6 +21,7 @@ import type { VoteWithHistoricalPower } from "@/features/governance/hooks/useVot
 import { useVotes } from "@/features/governance/hooks/useVotes";
 import { useVotesParams } from "@/features/governance/hooks/useVotesParams";
 import { SkeletonRow, Button, BlankSlate } from "@/shared/components";
+import { FetchErrorState } from "@/shared/components/errors/FetchErrorState";
 import { CopyAndPasteButton } from "@/shared/components/buttons/CopyAndPasteButton";
 import { EnsAvatar } from "@/shared/components/design-system/avatars/ens-avatar/EnsAvatar";
 import { AddressFilter } from "@/shared/components/design-system/table/filters/AddressFilter";
@@ -82,6 +83,7 @@ export const TabsVotedContent = ({
     isLoading,
     error,
     fetchNextPage,
+    refetch,
     hasNextPage,
     isFetchingNextPage,
   } = useVotes({
@@ -97,8 +99,11 @@ export const TabsVotedContent = ({
     voterAddress: voterFilter ?? null,
   });
 
-  // Intersection observer on the loading row
+  // Intersection observer on the loading row. Paused while errored so a
+  // failed page fetch doesn't auto-retry in a loop; the user retries instead.
   useEffect(() => {
+    if (error) return;
+
     const observer = new IntersectionObserver(
       (entries) => {
         const [entry] = entries;
@@ -114,7 +119,7 @@ export const TabsVotedContent = ({
     }
 
     return () => observer.disconnect();
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage, error]);
 
   const columns: ColumnDef<VoteWithHistoricalPower>[] = useMemo(
     () => [
@@ -659,7 +664,7 @@ export const TabsVotedContent = ({
     });
 
     // Add loading row if there are more pages or currently loading
-    if (hasNextPage || isFetchingNextPage) {
+    if ((hasNextPage || isFetchingNextPage) && !error) {
       data.push({
         voterAddress: "__LOADING_ROW__",
         transactionHash: "",
@@ -673,7 +678,7 @@ export const TabsVotedContent = ({
     }
 
     return data;
-  }, [votes, hasNextPage, isFetchingNextPage]);
+  }, [votes, hasNextPage, isFetchingNextPage, error]);
 
   // Show skeleton table on initial load or when we have no valid data
   const hasValidData =
@@ -684,8 +689,13 @@ export const TabsVotedContent = ({
         (vote.voterAddress as string) !== "__LOADING_ROW__",
     );
 
-  if (error) {
-    return <div>Error: {error.message}</div>;
+  if (error && !hasValidData) {
+    return (
+      <FetchErrorState
+        message="Failed to load votes"
+        onRetry={() => refetch()}
+      />
+    );
   }
 
   if (isLoading && !hasValidData) {
@@ -715,6 +725,13 @@ export const TabsVotedContent = ({
           />
         }
       />
+      {error && (
+        <FetchErrorState
+          message="Failed to load more votes"
+          onRetry={() => fetchNextPage()}
+          className="py-4"
+        />
+      )}
     </div>
   );
 };

--- a/apps/dashboard/features/governance/hooks/useVotes.ts
+++ b/apps/dashboard/features/governance/hooks/useVotes.ts
@@ -30,6 +30,7 @@ export interface UseVotesResult {
   isLoading: boolean;
   error: Error | null;
   fetchNextPage: () => Promise<void>;
+  refetch: () => void;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
 }
@@ -80,6 +81,7 @@ export const useVotes = ({
     isLoading,
     error,
     fetchNextPage,
+    refetch,
     hasNextPage,
     isFetchingNextPage,
   } = useVotesByProposalIdInfinite(daoKey, proposalId ?? "", queryParams, {
@@ -162,6 +164,7 @@ export const useVotes = ({
     fetchNextPage: async () => {
       await fetchNextPage();
     },
+    refetch,
     hasNextPage,
     isFetchingNextPage,
   };

--- a/apps/dashboard/shared/components/errors/FetchErrorState.tsx
+++ b/apps/dashboard/shared/components/errors/FetchErrorState.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { cn } from "@/shared/utils/cn";
+
+interface FetchErrorStateProps {
+  message: string;
+  onRetry: () => void;
+  className?: string;
+}
+
+/** Inline error + retry affordance for failed data fetches (feeds, tables). */
+export const FetchErrorState = ({
+  message,
+  onRetry,
+  className,
+}: FetchErrorStateProps) => {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-2 px-4 py-8",
+        className,
+      )}
+    >
+      <p className="text-error text-sm">{message}</p>
+      <button
+        onClick={onRetry}
+        className="text-link hover:text-link-hover text-sm underline"
+      >
+        Try again
+      </button>
+    </div>
+  );
+};

--- a/apps/dashboard/shared/components/errors/FetchErrorState.tsx
+++ b/apps/dashboard/shared/components/errors/FetchErrorState.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { cn } from "@/shared/utils/cn";
+import { AlertOctagon } from "lucide-react";
+
+import { BlankSlate } from "@/shared/components/design-system/blank-slate/BlankSlate";
 
 interface FetchErrorStateProps {
   message: string;
@@ -15,19 +17,18 @@ export const FetchErrorState = ({
   className,
 }: FetchErrorStateProps) => {
   return (
-    <div
-      className={cn(
-        "flex flex-col items-center justify-center gap-2 px-4 py-8",
-        className,
-      )}
+    <BlankSlate
+      variant="default"
+      icon={AlertOctagon}
+      description={message}
+      className={className}
     >
-      <p className="text-error text-sm">{message}</p>
       <button
         onClick={onRetry}
         className="text-link hover:text-link-hover text-sm underline"
       >
         Try again
       </button>
-    </div>
+    </BlankSlate>
   );
 };

--- a/apps/dashboard/shared/components/errors/ForceErrorTrigger.tsx
+++ b/apps/dashboard/shared/components/errors/ForceErrorTrigger.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Throws a render error after hydration when `?forceError` is present in the
+ * URL. Exists solely so the error-boundary Playwright spec can exercise the
+ * route `error.tsx` recovery path deterministically; inert otherwise.
+ * Throwing post-hydration (instead of during SSR) keeps the document response
+ * a 200, which the e2e 5xx watcher would otherwise flag.
+ */
+export const ForceErrorTrigger = () => {
+  const [forced, setForced] = useState(false);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") return;
+    if (new URLSearchParams(window.location.search).has("forceError")) {
+      setForced(true);
+    }
+  }, []);
+
+  if (forced) {
+    throw new Error("Forced render error (?forceError e2e hook)");
+  }
+
+  return null;
+};

--- a/apps/dashboard/shared/components/errors/RouteErrorFallback.tsx
+++ b/apps/dashboard/shared/components/errors/RouteErrorFallback.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { RotateCcw } from "lucide-react";
+import { useEffect } from "react";
+
+import { Button } from "@/shared/components/design-system/buttons/button/Button";
+
+interface RouteErrorFallbackProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+/**
+ * Recovery UI for route segment `error.tsx` boundaries. Renders inside the
+ * segment's layout, so the surrounding shell (sidebars, header) survives.
+ */
+export const RouteErrorFallback = ({
+  error,
+  reset,
+}: RouteErrorFallbackProps) => {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div
+      data-testid="route-error-fallback"
+      className="animate-fade-in flex min-h-[60vh] w-full flex-col items-center justify-center gap-4 px-5 py-12"
+    >
+      <h3 className="text-primary text-center font-mono text-2xl font-normal uppercase leading-8">
+        [ERROR:something_WENT_WRONG]
+      </h3>
+      <p className="text-secondary text-center text-base font-normal leading-6">
+        This page hit an unexpected error. The rest of the dashboard is
+        unaffected.
+      </p>
+      <Button variant="primary" size="md" onClick={reset}>
+        <RotateCcw className="size-4" />
+        Try again
+      </Button>
+    </div>
+  );
+};

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -270,6 +270,7 @@ fi
 start_relayer
 
 # 6. Gateful
+export GATEFUL_AUTH_DISABLED=true
 start_gateful
 
 # 7. Clients — codegen + build watch


### PR DESCRIPTION
## What

Adds error UX to the dashboard:

- **Route error boundaries** — `error.tsx` for the DAO shell, proposal detail, and whitelabel routes, all rendering a shared `RouteErrorFallback` (recovery UI + retry) that keeps the surrounding shell/sidebar intact.
- **Inline fetch errors** — shared `FetchErrorState` (icon + message + retry, built on `BlankSlate`) for the activity feed and the votes tables. Pagination auto-fetch pauses while errored so it can't retry-loop; `useVotes` now exposes `refetch`.
- **`ForceErrorTrigger`** — dev/e2e-only hook that throws on `?forceError`, plus a Playwright spec covering the route boundary.

## How to test on the preview

Fetch error states (work on the remote preview — production build):
1. Open the preview → any DAO → **Activity Feed**.
2. DevTools → Network → block the feed request (or set offline), scroll to trigger a fetch.
3. Expect the inline error card with **Try again**; clicking it re-fetches. Same flow on a proposal's **Votes** tabs.

Route error boundary (`?forceError`):
- The `?forceError` trigger is **guarded off in production builds** (`NODE_ENV`), so it won't fire on the Vercel preview — that's by design (keeps the hook out of prod bundles). Verify it locally in dev: `pnpm dashboard dev` → `/ens/activity-feed?forceError=1` → recovery UI shows and the shell/header survive. CI covers this via `e2e/error-boundary.spec.ts`.
