### PR TITLE
fix(dashboard): stub fs for browser bundles so Turbopack can build sh…

### DIFF
--- a/.changeset/dashboard-shutter-fs-stub.md
+++ b/.changeset/dashboard-shutter-fs-stub.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Fix dashboard production build: stub Node's `fs` module for browser bundles so Turbopack can bundle `@shutter-network/shutter-crypto` used by Shutter offchain voting

--- a/apps/dashboard/empty-module.ts
+++ b/apps/dashboard/empty-module.ts
@@ -1,0 +1,3 @@
+// Browser stub for Node built-ins referenced by dependencies that only use
+// them outside the browser (see turbopack.resolveAlias in next.config.ts).
+export default {};

--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -66,6 +66,14 @@ const nextConfig = {
     ];
   },
   serverExternalPackages: ["pino-pretty"],
+  turbopack: {
+    resolveAlias: {
+      // @shutter-network/shutter-crypto's Go wasm_exec glue requires "fs" at
+      // runtime only outside the browser; stub it so Turbopack can bundle the
+      // package for client components.
+      fs: { browser: "./empty-module.ts" },
+    },
+  },
   experimental: {
     optimizePackageImports: [
       "lucide-react",


### PR DESCRIPTION
…utter-crypto

@shutter-network/shutter-crypto's dist bundle (Go wasm_exec glue) references Node's fs, which it only uses outside the browser. Turbopack fails the production build with "Module not found: Can't resolve 'fs'" when bundling it for client components, breaking every dashboard deploy since #2013 merged. Alias fs to an empty stub in browser bundles only.