### PR TITLE
Voting power historical query improved

### DIFF
--- a/.changeset/chilly-apples-lay.md
+++ b/.changeset/chilly-apples-lay.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/api": patch
+---
+
+improve performance of the voting power historical endpoint

--- a/.changeset/chilly-apples-lay.md
+++ b/.changeset/chilly-apples-lay.md
@@ -1,5 +1,6 @@
 ---
 "@anticapture/api": patch
+"@anticapture/indexer": patch
 ---
 
 improve performance of the voting power historical endpoint

--- a/apps/api/src/database/schema.ts
+++ b/apps/api/src/database/schema.ts
@@ -93,6 +93,8 @@ export const votingPowerHistory = pgTable(
       columns: [table.transactionHash, table.accountId, table.logIndex],
     }),
     index().on(table.accountId, table.timestamp),
+    index().on(table.timestamp),
+    index().on(table.deltaMod),
   ],
 );
 

--- a/apps/api/src/repositories/voting-power/aave.ts
+++ b/apps/api/src/repositories/voting-power/aave.ts
@@ -16,8 +16,6 @@ import { Address } from "viem";
 import {
   Drizzle,
   votingPowerHistory,
-  delegation,
-  transfer,
   accountPower,
   accountBalance,
 } from "@/database";
@@ -27,6 +25,8 @@ import {
   DBHistoricalVotingPowerWithRelations,
 } from "@/mappers";
 import { PERCENTAGE_NO_BASELINE } from "@/mappers/constants";
+
+import { getHistoricalVotingPowersWithRelations } from "./historical-query";
 
 export class AAVEVotingPowerRepository {
   constructor(private readonly db: Drizzle) {}
@@ -67,75 +67,17 @@ export class AAVEVotingPowerRepository {
     fromDate?: number,
     toDate?: number,
   ): Promise<DBHistoricalVotingPowerWithRelations[]> {
-    const result = await this.db
-      .select()
-      .from(votingPowerHistory)
-      .leftJoin(
-        delegation,
-        sql`${votingPowerHistory.transactionHash} = ${delegation.transactionHash}
-          AND ${delegation.logIndex} = (
-            SELECT MAX(${delegation.logIndex})
-            FROM ${delegation}
-            WHERE ${delegation.transactionHash} = ${votingPowerHistory.transactionHash}
-            AND ${delegation.logIndex} < ${votingPowerHistory.logIndex}
-        )`,
-      )
-      .leftJoin(
-        transfer,
-        sql`${votingPowerHistory.transactionHash} = ${transfer.transactionHash}
-          AND ${transfer.logIndex} = (
-            SELECT MAX(${transfer.logIndex})
-            FROM ${transfer}
-            WHERE ${transfer.transactionHash} = ${votingPowerHistory.transactionHash}
-            AND ${transfer.logIndex} < ${votingPowerHistory.logIndex}
-        )`,
-      )
-      .where(
-        and(
-          accountId ? eq(votingPowerHistory.accountId, accountId) : undefined,
-          minDelta
-            ? gte(votingPowerHistory.deltaMod, BigInt(minDelta))
-            : undefined,
-          maxDelta
-            ? lte(votingPowerHistory.deltaMod, BigInt(maxDelta))
-            : undefined,
-          fromDate
-            ? gte(votingPowerHistory.timestamp, BigInt(fromDate))
-            : undefined,
-          toDate
-            ? lte(votingPowerHistory.timestamp, BigInt(toDate))
-            : undefined,
-        ),
-      )
-      .orderBy(
-        orderDirection === "asc"
-          ? asc(
-              orderBy === "timestamp"
-                ? votingPowerHistory.timestamp
-                : votingPowerHistory.deltaMod,
-            )
-          : desc(
-              orderBy === "timestamp"
-                ? votingPowerHistory.timestamp
-                : votingPowerHistory.deltaMod,
-            ),
-      )
-      .limit(limit)
-      .offset(skip);
-
-    return result.map((row) => ({
-      ...row.voting_power_history,
-      delegations:
-        row.transfers &&
-        row.transfers?.logIndex > (row.delegations?.logIndex || 0)
-          ? null
-          : row.delegations,
-      transfers:
-        row.delegations &&
-        row.delegations?.logIndex > (row.transfers?.logIndex || 0)
-          ? null
-          : row.transfers,
-    }));
+    return await getHistoricalVotingPowersWithRelations(this.db, {
+      skip,
+      limit,
+      orderDirection,
+      orderBy,
+      accountId,
+      minDelta,
+      maxDelta,
+      fromDate,
+      toDate,
+    });
   }
 
   async getVotingPowers(

--- a/apps/api/src/repositories/voting-power/general.ts
+++ b/apps/api/src/repositories/voting-power/general.ts
@@ -13,13 +13,7 @@ import {
 } from "drizzle-orm";
 import { Address } from "viem";
 
-import {
-  Drizzle,
-  votingPowerHistory,
-  delegation,
-  transfer,
-  accountPower,
-} from "@/database";
+import { Drizzle, votingPowerHistory, accountPower } from "@/database";
 import {
   AmountFilter,
   DBAccountPowerWithVariation,
@@ -27,6 +21,8 @@ import {
   DBHistoricalVotingPowerWithRelations,
 } from "@/mappers";
 import { PERCENTAGE_NO_BASELINE } from "@/mappers/constants";
+
+import { getHistoricalVotingPowersWithRelations } from "./historical-query";
 
 export class VotingPowerRepository {
   constructor(private readonly db: Drizzle) {}
@@ -67,75 +63,17 @@ export class VotingPowerRepository {
     fromDate?: number,
     toDate?: number,
   ): Promise<DBHistoricalVotingPowerWithRelations[]> {
-    const result = await this.db
-      .select()
-      .from(votingPowerHistory)
-      .leftJoin(
-        delegation,
-        sql`${votingPowerHistory.transactionHash} = ${delegation.transactionHash} 
-          AND ${delegation.logIndex} = (
-            SELECT MAX(${delegation.logIndex}) 
-            FROM ${delegation} 
-            WHERE ${delegation.transactionHash} = ${votingPowerHistory.transactionHash} 
-            AND ${delegation.logIndex} < ${votingPowerHistory.logIndex}
-        )`,
-      )
-      .leftJoin(
-        transfer,
-        sql`${votingPowerHistory.transactionHash} = ${transfer.transactionHash} 
-          AND ${transfer.logIndex} = (
-            SELECT MAX(${transfer.logIndex}) 
-            FROM ${transfer}
-            WHERE ${transfer.transactionHash} = ${votingPowerHistory.transactionHash} 
-            AND ${transfer.logIndex} < ${votingPowerHistory.logIndex}
-        )`,
-      )
-      .where(
-        and(
-          accountId ? eq(votingPowerHistory.accountId, accountId) : undefined,
-          minDelta
-            ? gte(votingPowerHistory.deltaMod, BigInt(minDelta))
-            : undefined,
-          maxDelta
-            ? lte(votingPowerHistory.deltaMod, BigInt(maxDelta))
-            : undefined,
-          fromDate
-            ? gte(votingPowerHistory.timestamp, BigInt(fromDate))
-            : undefined,
-          toDate
-            ? lte(votingPowerHistory.timestamp, BigInt(toDate))
-            : undefined,
-        ),
-      )
-      .orderBy(
-        orderDirection === "asc"
-          ? asc(
-              orderBy === "timestamp"
-                ? votingPowerHistory.timestamp
-                : votingPowerHistory.deltaMod,
-            )
-          : desc(
-              orderBy === "timestamp"
-                ? votingPowerHistory.timestamp
-                : votingPowerHistory.deltaMod,
-            ),
-      )
-      .limit(limit)
-      .offset(skip);
-
-    return result.map((row) => ({
-      ...row.voting_power_history,
-      delegations:
-        row.transfers &&
-        row.transfers?.logIndex > (row.delegations?.logIndex || 0)
-          ? null
-          : row.delegations,
-      transfers:
-        row.delegations &&
-        row.delegations?.logIndex > (row.transfers?.logIndex || 0)
-          ? null
-          : row.transfers,
-    }));
+    return await getHistoricalVotingPowersWithRelations(this.db, {
+      skip,
+      limit,
+      orderDirection,
+      orderBy,
+      accountId,
+      minDelta,
+      maxDelta,
+      fromDate,
+      toDate,
+    });
   }
 
   async getVotingPowerVariations(

--- a/apps/api/src/repositories/voting-power/historical-query.ts
+++ b/apps/api/src/repositories/voting-power/historical-query.ts
@@ -131,7 +131,20 @@ export const getHistoricalVotingPowersWithRelations = async (
             AND ${delegationLogIndexCondition}
         )`,
     )
-    .leftJoin(transfer, transferJoinCondition);
+    .leftJoin(transfer, transferJoinCondition)
+    .orderBy(
+      orderDirection === "asc"
+        ? asc(
+            orderBy === "timestamp"
+              ? historyPage.timestamp
+              : historyPage.deltaMod,
+          )
+        : desc(
+            orderBy === "timestamp"
+              ? historyPage.timestamp
+              : historyPage.deltaMod,
+          ),
+    );
 
   return result.map((row) => ({
     ...row.history,

--- a/apps/api/src/repositories/voting-power/historical-query.ts
+++ b/apps/api/src/repositories/voting-power/historical-query.ts
@@ -1,0 +1,151 @@
+import { and, asc, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { Address } from "viem";
+
+import { delegation, Drizzle, transfer, votingPowerHistory } from "@/database";
+import { DBHistoricalVotingPowerWithRelations } from "@/mappers";
+
+type HistoricalVotingPowerOrderBy = "timestamp" | "delta";
+type HistoricalVotingPowerOrderDirection = "asc" | "desc";
+type TransferRelation = "previous" | "next";
+
+type HistoricalVotingPowerQuery = {
+  skip: number;
+  limit: number;
+  orderDirection: HistoricalVotingPowerOrderDirection;
+  orderBy: HistoricalVotingPowerOrderBy;
+  accountId?: Address;
+  minDelta?: string;
+  maxDelta?: string;
+  fromDate?: number;
+  toDate?: number;
+  includeSameLogIndex?: boolean;
+  transferRelation?: TransferRelation;
+};
+
+export const getHistoricalVotingPowersWithRelations = async (
+  db: Drizzle,
+  {
+    skip,
+    limit,
+    orderDirection,
+    orderBy,
+    accountId,
+    minDelta,
+    maxDelta,
+    fromDate,
+    toDate,
+    includeSameLogIndex = false,
+    transferRelation = "previous",
+  }: HistoricalVotingPowerQuery,
+): Promise<DBHistoricalVotingPowerWithRelations[]> => {
+  const historyPage = db
+    .select({
+      transactionHash: votingPowerHistory.transactionHash,
+      daoId: votingPowerHistory.daoId,
+      accountId: votingPowerHistory.accountId,
+      votingPower: votingPowerHistory.votingPower,
+      delta: votingPowerHistory.delta,
+      deltaMod: votingPowerHistory.deltaMod,
+      timestamp: votingPowerHistory.timestamp,
+      logIndex: votingPowerHistory.logIndex,
+    })
+    .from(votingPowerHistory)
+    .where(
+      and(
+        accountId ? eq(votingPowerHistory.accountId, accountId) : undefined,
+        minDelta
+          ? gte(votingPowerHistory.deltaMod, BigInt(minDelta))
+          : undefined,
+        maxDelta
+          ? lte(votingPowerHistory.deltaMod, BigInt(maxDelta))
+          : undefined,
+        fromDate
+          ? gte(votingPowerHistory.timestamp, BigInt(fromDate))
+          : undefined,
+        toDate ? lte(votingPowerHistory.timestamp, BigInt(toDate)) : undefined,
+      ),
+    )
+    .orderBy(
+      orderDirection === "asc"
+        ? asc(
+            orderBy === "timestamp"
+              ? votingPowerHistory.timestamp
+              : votingPowerHistory.deltaMod,
+          )
+        : desc(
+            orderBy === "timestamp"
+              ? votingPowerHistory.timestamp
+              : votingPowerHistory.deltaMod,
+          ),
+    )
+    .limit(limit)
+    .offset(skip)
+    .as("history_page");
+
+  const delegationLogIndexCondition = includeSameLogIndex
+    ? sql`d2.log_index <= ${historyPage.logIndex}`
+    : sql`d2.log_index < ${historyPage.logIndex}`;
+  const previousTransferLogIndexCondition = includeSameLogIndex
+    ? sql`t2.log_index <= ${historyPage.logIndex}`
+    : sql`t2.log_index < ${historyPage.logIndex}`;
+  const transferJoinCondition =
+    transferRelation === "next"
+      ? sql`${historyPage.transactionHash} = ${transfer.transactionHash}
+          AND ${transfer.logIndex} = (
+            SELECT MIN(t2.log_index)
+            FROM ${transfer} t2
+            WHERE t2.transaction_hash = ${historyPage.transactionHash}
+            AND t2.log_index > ${historyPage.logIndex}
+        )`
+      : sql`${historyPage.transactionHash} = ${transfer.transactionHash}
+          AND ${transfer.logIndex} = (
+            SELECT MAX(t2.log_index)
+            FROM ${transfer} t2
+            WHERE t2.transaction_hash = ${historyPage.transactionHash}
+            AND ${previousTransferLogIndexCondition}
+        )`;
+
+  const result = await db
+    .select({
+      history: {
+        transactionHash: historyPage.transactionHash,
+        daoId: historyPage.daoId,
+        accountId: historyPage.accountId,
+        votingPower: historyPage.votingPower,
+        delta: historyPage.delta,
+        deltaMod: historyPage.deltaMod,
+        timestamp: historyPage.timestamp,
+        logIndex: historyPage.logIndex,
+      },
+      delegations: delegation,
+      transfers: transfer,
+    })
+    .from(historyPage)
+    .leftJoin(
+      delegation,
+      sql`${historyPage.transactionHash} = ${delegation.transactionHash}
+          AND ${delegation.logIndex} = (
+            SELECT MAX(d2.log_index)
+            FROM ${delegation} d2
+            WHERE d2.transaction_hash = ${historyPage.transactionHash}
+            AND ${delegationLogIndexCondition}
+        )`,
+    )
+    .leftJoin(transfer, transferJoinCondition);
+
+  return result.map((row) => ({
+    ...row.history,
+    delegations:
+      row.transfers &&
+      (transferRelation === "next"
+        ? row.transfers.logIndex < (row.delegations?.logIndex || 0)
+        : row.transfers.logIndex > (row.delegations?.logIndex || 0))
+        ? null
+        : row.delegations,
+    transfers:
+      row.delegations &&
+      row.delegations.logIndex > (row.transfers?.logIndex || 0)
+        ? null
+        : row.transfers,
+  }));
+};

--- a/apps/api/src/repositories/voting-power/nouns.ts
+++ b/apps/api/src/repositories/voting-power/nouns.ts
@@ -1,8 +1,10 @@
-import { gte, and, lte, desc, eq, asc, sql } from "drizzle-orm";
+import { gte, and, lte, eq } from "drizzle-orm";
 import { Address } from "viem";
 
-import { Drizzle, votingPowerHistory, delegation, transfer } from "@/database";
+import { Drizzle, votingPowerHistory } from "@/database";
 import { DBHistoricalVotingPowerWithRelations } from "@/mappers";
+
+import { getHistoricalVotingPowersWithRelations } from "./historical-query";
 
 export class NounsVotingPowerRepository {
   constructor(private readonly db: Drizzle) {}
@@ -43,74 +45,17 @@ export class NounsVotingPowerRepository {
     fromDate?: number,
     toDate?: number,
   ): Promise<DBHistoricalVotingPowerWithRelations[]> {
-    const result = await this.db
-      .select()
-      .from(votingPowerHistory)
-      .where(
-        and(
-          accountId ? eq(votingPowerHistory.accountId, accountId) : undefined,
-          minDelta
-            ? gte(votingPowerHistory.deltaMod, BigInt(minDelta))
-            : undefined,
-          maxDelta
-            ? lte(votingPowerHistory.deltaMod, BigInt(maxDelta))
-            : undefined,
-          fromDate
-            ? gte(votingPowerHistory.timestamp, BigInt(fromDate))
-            : undefined,
-          toDate
-            ? lte(votingPowerHistory.timestamp, BigInt(toDate))
-            : undefined,
-        ),
-      )
-      .leftJoin(
-        delegation,
-        sql`${votingPowerHistory.transactionHash} = ${delegation.transactionHash} 
-          AND ${delegation.logIndex} = (
-            SELECT MAX(d2.log_index) 
-            FROM ${delegation} d2 
-            WHERE d2.transaction_hash = ${votingPowerHistory.transactionHash} 
-            AND d2.log_index < ${votingPowerHistory.logIndex}
-        )`,
-      )
-      .leftJoin(
-        transfer,
-        sql`${votingPowerHistory.transactionHash} = ${transfer.transactionHash} 
-          AND ${transfer.logIndex} = (
-            SELECT MIN(t2.log_index) 
-            FROM ${transfer} t2 
-            WHERE t2.transaction_hash = ${votingPowerHistory.transactionHash} 
-            AND t2.log_index > ${votingPowerHistory.logIndex}
-        )`,
-      )
-      .orderBy(
-        orderDirection === "asc"
-          ? asc(
-              orderBy === "timestamp"
-                ? votingPowerHistory.timestamp
-                : votingPowerHistory.deltaMod,
-            )
-          : desc(
-              orderBy === "timestamp"
-                ? votingPowerHistory.timestamp
-                : votingPowerHistory.deltaMod,
-            ),
-      )
-      .limit(limit)
-      .offset(skip);
-
-    return result.map((row) => ({
-      ...row.voting_power_history,
-      delegations:
-        row.transfers &&
-        row.transfers?.logIndex < (row.delegations?.logIndex || 0)
-          ? null
-          : row.delegations,
-      transfers:
-        row.delegations &&
-        row.delegations?.logIndex > (row.transfers?.logIndex || 0)
-          ? null
-          : row.transfers,
-    }));
+    return await getHistoricalVotingPowersWithRelations(this.db, {
+      skip,
+      limit,
+      orderDirection,
+      orderBy,
+      accountId,
+      minDelta,
+      maxDelta,
+      fromDate,
+      toDate,
+      transferRelation: "next",
+    });
   }
 }

--- a/apps/api/src/repositories/voting-power/torn.ts
+++ b/apps/api/src/repositories/voting-power/torn.ts
@@ -1,8 +1,10 @@
-import { gte, and, lte, desc, eq, asc, sql } from "drizzle-orm";
+import { gte, and, lte, eq } from "drizzle-orm";
 import { Address } from "viem";
 
-import { Drizzle, votingPowerHistory, delegation, transfer } from "@/database";
+import { Drizzle, votingPowerHistory } from "@/database";
 import { DBHistoricalVotingPowerWithRelations } from "@/mappers";
+
+import { getHistoricalVotingPowersWithRelations } from "./historical-query";
 
 /**
  * TORN derives per-account voting power directly from lock/unlock Transfers
@@ -54,76 +56,24 @@ export class TORNVotingPowerRepository {
     fromDate?: number,
     toDate?: number,
   ): Promise<DBHistoricalVotingPowerWithRelations[]> {
-    const result = await this.db
-      .select()
-      .from(votingPowerHistory)
-      .leftJoin(
-        delegation,
-        sql`${votingPowerHistory.transactionHash} = ${delegation.transactionHash}
-          AND ${delegation.logIndex} = (
-            SELECT MAX(${delegation.logIndex})
-            FROM ${delegation}
-            WHERE ${delegation.transactionHash} = ${votingPowerHistory.transactionHash}
-            AND ${delegation.logIndex} <= ${votingPowerHistory.logIndex}
-        )`,
-      )
-      .leftJoin(
-        transfer,
-        sql`${votingPowerHistory.transactionHash} = ${transfer.transactionHash}
-          AND ${transfer.logIndex} = (
-            SELECT MAX(${transfer.logIndex})
-            FROM ${transfer}
-            WHERE ${transfer.transactionHash} = ${votingPowerHistory.transactionHash}
-            AND ${transfer.logIndex} <= ${votingPowerHistory.logIndex}
-        )`,
-      )
-      .where(
-        and(
-          accountId ? eq(votingPowerHistory.accountId, accountId) : undefined,
-          minDelta
-            ? gte(votingPowerHistory.deltaMod, BigInt(minDelta))
-            : undefined,
-          maxDelta
-            ? lte(votingPowerHistory.deltaMod, BigInt(maxDelta))
-            : undefined,
-          fromDate
-            ? gte(votingPowerHistory.timestamp, BigInt(fromDate))
-            : undefined,
-          toDate
-            ? lte(votingPowerHistory.timestamp, BigInt(toDate))
-            : undefined,
-        ),
-      )
-      .orderBy(
-        orderDirection === "asc"
-          ? asc(
-              orderBy === "timestamp"
-                ? votingPowerHistory.timestamp
-                : votingPowerHistory.deltaMod,
-            )
-          : desc(
-              orderBy === "timestamp"
-                ? votingPowerHistory.timestamp
-                : votingPowerHistory.deltaMod,
-            ),
-      )
-      .limit(limit)
-      .offset(skip);
+    const result = await getHistoricalVotingPowersWithRelations(this.db, {
+      skip,
+      limit,
+      orderDirection,
+      orderBy,
+      accountId,
+      minDelta,
+      maxDelta,
+      fromDate,
+      toDate,
+      includeSameLogIndex: true,
+    });
 
     return result.map((row) => {
-      const transfers =
-        row.delegations &&
-        row.delegations?.logIndex > (row.transfers?.logIndex || 0)
-          ? null
-          : row.transfers;
+      const transfers = row.transfers;
 
       return {
-        ...row.voting_power_history,
-        delegations:
-          row.transfers &&
-          row.transfers?.logIndex > (row.delegations?.logIndex || 0)
-            ? null
-            : row.delegations,
+        ...row,
         // TORN's lock/unlock Transfer moves tokens OPPOSITE to the voting-power
         // change: a lock (VP gain) sends TORN wallet -> custody, an unlock (VP
         // loss) sends custody -> wallet. The dashboard derives the delegator as

--- a/apps/api/src/services/voting-power/aave.ts
+++ b/apps/api/src/services/voting-power/aave.ts
@@ -68,25 +68,27 @@ export class AAVEVotingPowerService {
     items: DBHistoricalVotingPowerWithRelations[];
     totalCount: number;
   }> {
-    const items = await this.repo.getHistoricalVotingPowers(
-      skip,
-      limit,
-      orderDirection,
-      orderBy,
-      accountId,
-      minDelta,
-      maxDelta,
-      fromDate,
-      toDate,
-    );
+    const [items, totalCount] = await Promise.all([
+      this.repo.getHistoricalVotingPowers(
+        skip,
+        limit,
+        orderDirection,
+        orderBy,
+        accountId,
+        minDelta,
+        maxDelta,
+        fromDate,
+        toDate,
+      ),
+      this.repo.getHistoricalVotingPowerCount(
+        accountId,
+        minDelta,
+        maxDelta,
+        fromDate,
+        toDate,
+      ),
+    ]);
 
-    const totalCount = await this.repo.getHistoricalVotingPowerCount(
-      accountId,
-      minDelta,
-      maxDelta,
-      fromDate,
-      toDate,
-    );
     return { items, totalCount };
   }
 

--- a/apps/api/src/services/voting-power/index.ts
+++ b/apps/api/src/services/voting-power/index.ts
@@ -89,8 +89,8 @@ export class VotingPowerService {
     items: DBHistoricalVotingPowerWithRelations[];
     totalCount: number;
   }> {
-    const items =
-      await this.historicalVotingRepository.getHistoricalVotingPowers(
+    const [items, totalCount] = await Promise.all([
+      this.historicalVotingRepository.getHistoricalVotingPowers(
         skip,
         limit,
         orderDirection,
@@ -100,16 +100,16 @@ export class VotingPowerService {
         maxDelta,
         fromDate,
         toDate,
-      );
-
-    const totalCount =
-      await this.historicalVotingRepository.getHistoricalVotingPowerCount(
+      ),
+      this.historicalVotingRepository.getHistoricalVotingPowerCount(
         accountId,
         minDelta,
         maxDelta,
         fromDate,
         toDate,
-      );
+      ),
+    ]);
+
     return { items, totalCount };
   }
 

--- a/apps/indexer/ponder.schema.ts
+++ b/apps/indexer/ponder.schema.ts
@@ -89,6 +89,8 @@ export const votingPowerHistory = onchainTable(
       table.accountId,
       table.timestamp,
     ),
+    votingPowerHistoryTimestampIdx: index().on(table.timestamp),
+    votingPowerHistoryDeltaModIdx: index().on(table.deltaMod),
   }),
 );
 


### PR DESCRIPTION
## Summary

Improves `GET /voting-powers/historical` by paginating `voting_power_history` before joining delegation/transfer context. This avoids joining the full history table before `LIMIT`, while preserving DAO-specific behavior for Nouns and TORN.

## What Changed

- Shared the optimized historical voting-power query path across general, AAVE, Nouns, and TORN repositories.
- Preserved Nouns future-transfer lookup and TORN same-log-index + transfer direction behavior.
- Runs historical items and count queries in parallel.
- Added `timestamp` and `delta_mod` indexes to the voting power history schema definitions.

## Validation

- Uni DB response matched production app output exactly for the requested drawer address.
- Uni global `EXPLAIN ANALYZE`: old query `96.556ms`, optimized query `49.348ms` before new indexes.
- `pnpm api typecheck`
- `pnpm api lint`
- `pnpm api test`
- `pnpm indexer typecheck`
- `pnpm indexer lint`