### PR TITLE
fix(dashboard): voting on uniswap governor with wrong output

### DIFF
--- a/.changeset/tidy-moons-vote.md
+++ b/.changeset/tidy-moons-vote.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Fix "Failed to vote" on GovernorBravo DAOs (UNI, COMP, GTC, Nouns): castVote simulation used an OZ Governor ABI declaring a uint256 return, but Bravo's castVote returns no data, making viem throw before the wallet opened. Votes now simulate with a void-return ABI.

--- a/.github/workflows/release-readiness.yaml
+++ b/.github/workflows/release-readiness.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   unconsumed-changesets:
     name: Check unconsumed changesets
+    # Only the dev -> main promotion must be changeset-free; hotfix PRs carry
+    # their own changeset, consumed later when main is back-merged into dev.
+    if: github.head_ref == 'dev'
     runs-on: ubuntu-latest
 
     steps:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-* @pikonha @alextnetto @LeonardoVieira1630 @PedroBinotto @brunod-e @isadorable-png
+* @pikonha @alextnetto @LeonardoVieira1630 @PedroBinotto @brunod-e 
+apps/dashboard @isadorable-png

--- a/apps/dashboard/features/governance/utils/voteOnProposal.test.ts
+++ b/apps/dashboard/features/governance/utils/voteOnProposal.test.ts
@@ -73,6 +73,44 @@ describe("voteOnProposal", () => {
     expect(setTransactionhash).toHaveBeenNthCalledWith(2, "");
   });
 
+  it("casts governor votes with a void-return ABI (GovernorBravo compat)", async () => {
+    const account = { address: accountAddress } as unknown as Account;
+    const request = { to: governor };
+    const simulateContract = jest.fn().mockResolvedValue({ request });
+    const writeContract = jest.fn().mockResolvedValue(transactionHash);
+    const waitForTransactionReceipt = jest
+      .fn()
+      .mockResolvedValue({ transactionHash });
+    const walletClient = {
+      extend: jest.fn(() => ({
+        simulateContract,
+        writeContract,
+        waitForTransactionReceipt,
+      })),
+    } as unknown as WalletClient;
+
+    const receipt = await voteOnProposal(
+      "for",
+      "98",
+      account,
+      {} as Chain,
+      DaoIdEnum.UNISWAP,
+      walletClient,
+      jest.fn(),
+    );
+
+    expect(receipt).toEqual({ transactionHash });
+    const call = simulateContract.mock.calls[0][0];
+    expect(call.functionName).toBe("castVote");
+    expect(call.args).toEqual([98n, 1]);
+    // GovernorBravo's castVote returns no data; declaring outputs makes viem
+    // throw decoding the empty simulate result, so the ABI must stay void.
+    const castVoteAbi = call.abi.find(
+      (entry: { name?: string }) => entry.name === "castVote",
+    );
+    expect(castVoteAbi.outputs).toEqual([]);
+  });
+
   it("rejects Tornado Cash abstain votes before sending a transaction", async () => {
     const account = { address: accountAddress } as unknown as Account;
     const simulateContract = jest.fn();

--- a/apps/dashboard/features/governance/utils/voteOnProposal.ts
+++ b/apps/dashboard/features/governance/utils/voteOnProposal.ts
@@ -11,7 +11,6 @@ import type {
 import { relayVote } from "@anticapture/client";
 import type { RelayVotePathParamsDaoEnumKey } from "@anticapture/client";
 
-import EnsGovernorAbi from "@/abis/ens-governor.json";
 import { showCustomToast } from "@/features/governance/utils/showCustomToast";
 import daoConfigByDaoId from "@/shared/dao-config";
 import { DaoIdEnum } from "@/shared/types/daos";
@@ -27,6 +26,33 @@ const LinearVotingStrategyAbi = [
       { internalType: "uint8", name: "_voteType", type: "uint8" },
     ],
     name: "vote",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;
+
+// Shared by OZ Governor (returns uint256) and GovernorBravo (returns void).
+// `outputs` must stay empty: Bravo's castVote returns no data, and declaring a
+// uint256 output makes viem's simulateContract throw decoding the empty result.
+const GovernorCastVoteAbi = [
+  {
+    inputs: [
+      { internalType: "uint256", name: "proposalId", type: "uint256" },
+      { internalType: "uint8", name: "support", type: "uint8" },
+    ],
+    name: "castVote",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "proposalId", type: "uint256" },
+      { internalType: "uint8", name: "support", type: "uint8" },
+      { internalType: "string", name: "reason", type: "string" },
+    ],
+    name: "castVoteWithReason",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",
@@ -138,20 +164,20 @@ const ozGovernorVoteHandler =
 
     if (!params.comment) {
       const { request } = await client.simulateContract({
-        abi: EnsGovernorAbi,
+        abi: GovernorCastVoteAbi,
         address,
         functionName: "castVote",
-        args: [params.proposalId, params.voteNumber],
+        args: [BigInt(params.proposalId), params.voteNumber],
         account: params.account,
       });
       return client.writeContract(request);
     }
 
     const { request } = await client.simulateContract({
-      abi: EnsGovernorAbi,
+      abi: GovernorCastVoteAbi,
       address,
       functionName: "castVoteWithReason",
-      args: [params.proposalId, params.voteNumber, params.comment],
+      args: [BigInt(params.proposalId), params.voteNumber, params.comment],
       account: params.account,
     });
     return client.writeContract(request);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches on-chain governance vote submission for multiple DAOs, but the change is limited to simulation ABI/decoding and is covered by a new test.
> 
> **Overview**
> Fixes **"Failed to vote"** on GovernorBravo-style governors (e.g. UNI, COMP, GTC, Nouns) where `simulateContract` ran before the wallet could open.
> 
> `ozGovernorVoteHandler` no longer uses the ENS/OZ governor JSON ABI for `castVote` / `castVoteWithReason`. It now uses a minimal **`GovernorCastVoteAbi`** with **empty `outputs`**, because Bravo governors return no returndata and viem was erroring when the ABI expected a `uint256`. Proposal IDs are passed as **`BigInt(params.proposalId)`** in those calls.
> 
> A unit test asserts Uniswap governor votes simulate with void-return `castVote` ABI and the expected args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97b2dc77b66fa332f4da37608d04c443a2b0aec9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->