### PR TITLE
chore: add pg pool config to avoid infinity loop

### DIFF
--- a/.changeset/tough-rules-do.md
+++ b/.changeset/tough-rules-do.md
@@ -1,0 +1,8 @@
+---
+"@anticapture/address-enrichment": patch
+"@anticapture/offchain-indexer": patch
+"@anticapture/authful": patch
+"@anticapture/api": patch
+---
+
+add pg pool config to avoid hanging db connections

--- a/apps/address-enrichment/src/db/helpers.ts
+++ b/apps/address-enrichment/src/db/helpers.ts
@@ -16,8 +16,11 @@ export function initDb(connectionString: string) {
     return db;
   }
 
+  // Fail fast when Postgres is unreachable instead of hanging pg-pool connects
+  // forever. No statement_timeout: this pool also runs migrations.
   pool = new Pool({
     connectionString,
+    connectionTimeoutMillis: 10_000,
   });
 
   db = drizzle(pool, { schema });

--- a/apps/api/cmd/index.ts
+++ b/apps/api/cmd/index.ts
@@ -181,12 +181,23 @@ if (!daoClient) {
   throw new Error(`Client not found for DAO ${env.DAO_ID}`);
 }
 
-const pgClient = drizzle(env.DATABASE_URL, {
+// Fail fast when Postgres is unreachable/starved instead of hanging pg-pool
+// connects for minutes.
+const pgClient = drizzle({
+  connection: {
+    connectionString: env.DATABASE_URL,
+    connectionTimeoutMillis: 10_000,
+    statement_timeout: 30_000,
+  },
   schema: { ...schema, ...offchainSchema },
   casing: "snake_case",
 });
 
-const pgGeneralClient = drizzle(env.DATABASE_URL, {
+const pgGeneralClient = drizzle({
+  connection: {
+    connectionString: env.DATABASE_URL,
+    connectionTimeoutMillis: 10_000,
+  },
   schema: generalSchema,
   casing: "snake_case",
 });

--- a/apps/authful/src/index.ts
+++ b/apps/authful/src/index.ts
@@ -9,7 +9,14 @@ import { logger } from "@/logger";
 import { TokensRepository } from "@/repositories/tokens";
 import { TokensService } from "@/services/tokens";
 
-const db = drizzle(env.DATABASE_URL, { schema });
+const db = drizzle({
+  connection: {
+    connectionString: env.DATABASE_URL,
+    connectionTimeoutMillis: 10_000,
+    statement_timeout: 30_000,
+  },
+  schema,
+});
 const service = new TokensService(new TokensRepository(db));
 
 // Fixed identity for the CI/preview seed token. Only the plaintext value varies

--- a/apps/offchain-indexer/src/index.ts
+++ b/apps/offchain-indexer/src/index.ts
@@ -12,7 +12,15 @@ import * as schema from "@/repository/schema";
 async function main() {
   logger.info({ dao: env.PROVIDER_DAO_ID }, "starting offchain indexer");
 
-  const db = drizzle(env.DATABASE_URL, { schema });
+  // Fail fast when Postgres is unreachable instead of hanging pg-pool connects
+  // forever.
+  const db = drizzle({
+    connection: {
+      connectionString: env.DATABASE_URL,
+      connectionTimeoutMillis: 10_000,
+    },
+    schema,
+  });
 
   await migrate(db, {
     migrationsFolder: "./drizzle",


### PR DESCRIPTION
## Why

During the 2026-07-13 prod incident, `authful-db`'s volume I/O degraded to a crawl (Postgres checkpoints of a few KB taking 5–10 minutes). Authful's `pg-pool.connect` calls hung for up to **21+ minutes** (visible in Tempo traces) instead of failing, because node-postgres defaults to `connectionTimeoutMillis: 0` — wait forever. The service stayed "up" while every DB-touching request silently hung, with no errors in the logs.

## What

Add explicit timeouts to every node-postgres pool in the monorepo:

| Package | `connectionTimeoutMillis` | `statement_timeout` |
|---|---|---|
| `apps/authful` | 10s | 30s |
| `apps/api` (`pgClient`, request-serving) | 10s | 30s |
| `apps/api` (`pgGeneralClient`, runs migrations) | 10s | — |
| `apps/offchain-indexer` | 10s | — |
| `apps/address-enrichment` | 10s | — |

- **`connectionTimeoutMillis: 10s`** — cap on acquiring a connection (TCP + TLS + auth, or waiting for a free pool slot). A sick DB now produces immediate, loggable errors instead of indefinite hangs.
- **`statement_timeout: 30s`** — server-side kill for any single query, only on request-serving pools. Prevents a starved/locked DB from holding pool slots hostage and cascading into pool exhaustion.

Pools that run migrations or long batch writes (`pgGeneralClient`, offchain-indexer, address-enrichment) intentionally omit `statement_timeout` so legitimate long operations aren't killed.

## Impact

No behavior change under a healthy DB. Under a degraded DB, requests fail fast with clear errors (and 5xx) instead of hanging for minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
