### PR TITLE
[DEV-1117] Shutter offchain indexer

### DIFF
--- a/.changeset/sharp-donuts-relax.md
+++ b/.changeset/sharp-donuts-relax.md
@@ -1,0 +1,6 @@
+---
+"@anticapture/api": patch
+"@anticapture/dashboard": patch
+---
+
+enable offchain (Snapshot) proposal data for ShutterDAO

--- a/apps/api/src/clients/shu/index.ts
+++ b/apps/api/src/clients/shu/index.ts
@@ -67,6 +67,10 @@ export class SHUClient<
     return BigInt(TIMELOCK_PERIOD_BLOCKS * BLOCK_TIME_SECONDS);
   }
 
+  supportOffchainData(): boolean {
+    return true;
+  }
+
   /**
    * Azorius proposal status computation.
    *

--- a/apps/dashboard/shared/dao-config/shu.ts
+++ b/apps/dashboard/shared/dao-config/shu.ts
@@ -361,4 +361,5 @@ export const SHU: DaoConfiguration = {
   dataTables: true,
   governancePage: true,
   activityFeed: true,
+  offchainProposals: true,
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small feature-flag changes on top of existing offchain infrastructure; no auth or on-chain governance logic changes.
> 
> **Overview**
> Turns on **Snapshot (offchain) proposal** support for ShutterDAO by aligning the API and dashboard with DAOs that already use this path.
> 
> `SHUClient` now overrides `supportOffchainData()` to return `true`, so when the API is configured for SHU it exposes the existing offchain proposal and vote endpoints instead of treating offchain as unsupported. The Shutter dashboard config sets **`offchainProposals: true`** so the governance UI can show indexed Snapshot data (the space is already referenced in `daoOverview.snapshot`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1051a2d698b74c95219df903862ed3afe658c514. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->