### PR TITLE
fix: lil nouns prometheus colector

### DIFF
--- a/infra/monitoring/entrypoint.prometheus.sh
+++ b/infra/monitoring/entrypoint.prometheus.sh
@@ -5,7 +5,7 @@ envsubst < /etc/prometheus/prometheus.yml.tmpl > /etc/prometheus/prometheus.yml
 # its <DAO>_INDEXER_ENDPOINT / <DAO>_API_ENDPOINT vars).
 DAOS="${DAOS:-ens aave shutter scroll nouns gitcoin compound uniswap obol}"
 for dao in $DAOS; do
-  DAO=$(echo "$dao" | tr '[:lower:]' '[:upper:]')
+  DAO=$(echo "$dao" | tr '[:lower:]-' '[:upper:]_')
   eval indexer=\"\$${DAO}_INDEXER_ENDPOINT\"
   eval api=\"\$${DAO}_API_ENDPOINT\"
   cat >> /etc/prometheus/prometheus.yml <<EOF


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line shell change in monitoring bootstrap only; no auth or application logic affected.
> 
> **Overview**
> Fixes Prometheus scrape config generation for DAOs whose slug includes a hyphen (e.g. **lil-nouns**).
> 
> In `entrypoint.prometheus.sh`, the loop that builds `${DAO}_INDEXER_ENDPOINT` / `${DAO}_API_ENDPOINT` now translates **hyphens to underscores** when uppercasing the slug, so names like `lil-nouns` resolve to `LIL_NOUNS_*` instead of invalid `LIL-NOUNS_*` variable names. **Job names** still use the original lowercase slug (`anticapture-lil-nouns-indexer`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 810977ea0b4659f0f2e8ad926b81bf07b63ece38. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->