### PR TITLE
fix(ci): enable npm trusted publishing in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,9 +36,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
+
+      # npm trusted publishing (OIDC) needs npm >= 11.5.1 and Node >= 22.14;
+      # Node 22 still bundles npm 10, which silently falls back to token auth.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -58,6 +63,8 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # npm >= 11.5.1 prefers OIDC (trusted publisher configured on
+          # npmjs.com); NPM_TOKEN remains only as fallback auth.
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Problem

`Release Packages` has failed at the publish step since Jun 23. Runs up to Jul 13 died earlier in client codegen (fixed by 4e5275d0d); the Jul 17 runs reach `changeset publish` and fail with:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@anticapture%2fclient
```

npm masks auth failures on scoped packages as E404. The workflow authenticated with `NPM_TOKEN`, which is expired/revoked (last working publish: Jun 4). A trusted publisher (OIDC) is now configured on npmjs.com for the packages, but the job still used token auth: **trusted publishing requires npm >= 11.5.1 and Node >= 22.14**, and the workflow ran Node 20 / npm 10, which silently falls back to the token.

## Fix

- Bump `setup-node` to Node 22
- Add `npm install -g npm@11` before publish so `changeset publish` (which shells out to `npm publish`) uses OIDC
- Keep `NPM_TOKEN` env only as fallback auth (npm >= 11.5.1 prefers OIDC when available)

No changeset: CI-only change, no package affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release workflow changes with no application code; main risk is publish still failing if OIDC/npm trusted publisher setup is misconfigured.
> 
> **Overview**
> Fixes failing **Release Packages** publishes by aligning the job with npm **trusted publishing (OIDC)** instead of relying on an expired `NPM_TOKEN`.
> 
> The workflow bumps **Node.js from 20 to 22** and adds a step to **install npm 11 globally** before `changeset publish`, because npm ≥11.5.1 on Node ≥22.14 is required for OIDC; Node 22’s bundled npm 10 would otherwise keep using token auth and surface scoped-package failures as **404**. Comments clarify that **`NPM_TOKEN` / `NODE_AUTH_TOKEN` stay as fallback** while OIDC is preferred when the trusted publisher is configured on npmjs.com.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d2fd190343d41977ddb9f9e896f1b86831b5bbf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->