### PR TITLE
Dev

### DIFF
--- a/.changeset/tidy-timelock-delay-cache.md
+++ b/.changeset/tidy-timelock-delay-cache.md
@@ -1,5 +1,0 @@
----
-"@anticapture/api": patch
----
-
-Dedupe concurrent timelock delay RPC reads in GovernorBase, fall back to the indexed proposal status when RPC reads fail (e.g. rate limits) instead of returning 500, and include the error cause in the unhandled-error log message.

--- a/.changeset/tidy-timelock-delay-cache.md
+++ b/.changeset/tidy-timelock-delay-cache.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/api": patch
+---
+
+Dedupe concurrent timelock delay RPC reads in GovernorBase, fall back to the indexed proposal status when RPC reads fail (e.g. rate limits) instead of returning 500, and include the error cause in the unhandled-error log message.

--- a/apps/api/CHANGELOG.md
+++ b/apps/api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @anticapture/api
 
+## 1.5.5
+
+### Patch Changes
+
+- [#2064](https://github.com/blockful/anticapture/pull/2064) [`a28e99f`](https://github.com/blockful/anticapture/commit/a28e99f5f7974437a6ba038106cb380984080f5f) Thanks [@pikonha](https://github.com/pikonha)! - Dedupe concurrent timelock delay RPC reads in GovernorBase, fall back to the indexed proposal status when RPC reads fail (e.g. rate limits) instead of returning 500, and include the error cause in the unhandled-error log message.
+
 ## 1.5.4
 
 ### Patch Changes

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anticapture/api",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "private": true,
   "main": "dist/index.js",
   "type": "module",

--- a/apps/api/src/clients/aave/index.ts
+++ b/apps/api/src/clients/aave/index.ts
@@ -41,7 +41,7 @@ export class AAVEClient<
     return 0n;
   }
 
-  async getTimelockDelay(): Promise<bigint> {
+  protected async fetchTimelockDelay(): Promise<bigint> {
     return 0n;
   }
 

--- a/apps/api/src/clients/comp/index.ts
+++ b/apps/api/src/clients/comp/index.ts
@@ -40,34 +40,31 @@ export class COMPClient<
     });
   }
 
-  async getTimelockDelay(): Promise<bigint> {
-    if (!this.cache.timelockDelay) {
-      const timelockAddress = await this.readContract({
-        abi: this.abi,
-        address: this.address,
-        functionName: "timelock",
-      });
-      this.cache.timelockDelay = await this.readContract({
-        abi: [
-          {
-            inputs: [],
-            name: "delay",
-            outputs: [
-              {
-                internalType: "uint256",
-                name: "",
-                type: "uint256",
-              },
-            ],
-            stateMutability: "view",
-            type: "function",
-          },
-        ],
-        address: timelockAddress,
-        functionName: "delay",
-      });
-    }
-    return this.cache.timelockDelay;
+  protected async fetchTimelockDelay(): Promise<bigint> {
+    const timelockAddress = await this.readContract({
+      abi: this.abi,
+      address: this.address,
+      functionName: "timelock",
+    });
+    return this.readContract({
+      abi: [
+        {
+          inputs: [],
+          name: "delay",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+      ],
+      address: timelockAddress,
+      functionName: "delay",
+    });
   }
 
   async getGracePeriod(): Promise<bigint> {

--- a/apps/api/src/clients/ens/index.ts
+++ b/apps/api/src/clients/ens/index.ts
@@ -40,30 +40,27 @@ export class ENSClient<
     });
   }
 
-  async getTimelockDelay(): Promise<bigint> {
-    if (!this.cache.timelockDelay) {
-      const timelockAddress = await this.readContract({
-        abi: this.abi,
-        address: this.address,
-        functionName: "timelock",
-      });
-      this.cache.timelockDelay = await this.readContract({
-        abi: [
-          {
-            constant: true,
-            inputs: [],
-            outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-            payable: false,
-            stateMutability: "view",
-            type: "function",
-            name: "getMinDelay",
-          },
-        ],
-        address: timelockAddress,
-        functionName: "getMinDelay",
-      });
-    }
-    return this.cache.timelockDelay;
+  protected async fetchTimelockDelay(): Promise<bigint> {
+    const timelockAddress = await this.readContract({
+      abi: this.abi,
+      address: this.address,
+      functionName: "timelock",
+    });
+    return this.readContract({
+      abi: [
+        {
+          constant: true,
+          inputs: [],
+          outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+          payable: false,
+          stateMutability: "view",
+          type: "function",
+          name: "getMinDelay",
+        },
+      ],
+      address: timelockAddress,
+      functionName: "getMinDelay",
+    });
   }
 
   alreadySupportCalldataReview(): boolean {

--- a/apps/api/src/clients/fluid/index.ts
+++ b/apps/api/src/clients/fluid/index.ts
@@ -31,34 +31,31 @@ export class FLUIDClient<
     return parseEther("4000000");
   }
 
-  async getTimelockDelay(): Promise<bigint> {
-    if (!this.cache.timelockDelay) {
-      const timelockAddress = await this.readContract({
-        abi: this.abi,
-        address: this.address,
-        functionName: "timelock",
-      });
-      this.cache.timelockDelay = await this.readContract({
-        abi: [
-          {
-            inputs: [],
-            name: "delay",
-            outputs: [
-              {
-                internalType: "uint256",
-                name: "",
-                type: "uint256",
-              },
-            ],
-            stateMutability: "view",
-            type: "function",
-          },
-        ],
-        address: timelockAddress,
-        functionName: "delay",
-      });
-    }
-    return this.cache.timelockDelay;
+  protected async fetchTimelockDelay(): Promise<bigint> {
+    const timelockAddress = await this.readContract({
+      abi: this.abi,
+      address: this.address,
+      functionName: "timelock",
+    });
+    return this.readContract({
+      abi: [
+        {
+          inputs: [],
+          name: "delay",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+      ],
+      address: timelockAddress,
+      functionName: "delay",
+    });
   }
 
   async getGracePeriod(): Promise<bigint> {

--- a/apps/api/src/clients/governor.base.ts
+++ b/apps/api/src/clients/governor.base.ts
@@ -47,6 +47,7 @@ export abstract class GovernorBase<
     number: number;
     timestamp: number | null;
   }> | null = null;
+  private timelockDelayFetch: Promise<bigint> | null = null;
   private readonly quorumCache = new Map<
     string,
     { value: bigint; expiresAt: number }
@@ -160,7 +161,30 @@ export abstract class GovernorBase<
 
   abstract getQuorum(proposalId: string | null): Promise<bigint>;
 
-  abstract getTimelockDelay(): Promise<bigint>;
+  /** Uncached timelock delay read (RPC or constant), implemented per DAO. */
+  protected abstract fetchTimelockDelay(): Promise<bigint>;
+
+  async getTimelockDelay(): Promise<bigint> {
+    if (this.cache.timelockDelay !== undefined) {
+      return this.cache.timelockDelay;
+    }
+
+    // Share one in-flight fetch across concurrent callers: getProposalStatus
+    // runs per proposal, so a cache miss would otherwise fire a burst of
+    // eth_calls and trip upstream RPC rate limits.
+    if (!this.timelockDelayFetch) {
+      this.timelockDelayFetch = this.fetchTimelockDelay()
+        .then((delay) => {
+          this.cache.timelockDelay = delay;
+          return delay;
+        })
+        .finally(() => {
+          this.timelockDelayFetch = null;
+        });
+    }
+
+    return this.timelockDelayFetch;
+  }
 
   async getGracePeriod(): Promise<bigint | null> {
     return null;
@@ -180,8 +204,20 @@ export abstract class GovernorBase<
     currentBlock: number,
     currentTimestamp: number,
   ): Promise<string> {
-    const timelockDelay = await this.getTimelockDelay();
-    const gracePeriod = await this.getGracePeriod();
+    let timelockDelay: bigint;
+    let gracePeriod: bigint | null;
+    try {
+      timelockDelay = await this.getTimelockDelay();
+      gracePeriod = await this.getGracePeriod();
+    } catch (error) {
+      // Degrade gracefully on RPC failures (e.g. rate limits): serve the
+      // indexed status instead of failing the whole request.
+      logger.warn(
+        { error, proposalId: proposal.id },
+        "RPC read failed while computing proposal status; falling back to indexed status",
+      );
+      return proposal.status;
+    }
 
     if (
       proposal.status === ProposalStatus.QUEUED &&
@@ -232,7 +268,16 @@ export abstract class GovernorBase<
         abstainVotes: proposal.abstainVotes,
       });
 
-      const quorum = await this.getQuorum(proposal.id);
+      let quorum: bigint;
+      try {
+        quorum = await this.getQuorum(proposal.id);
+      } catch (error) {
+        logger.warn(
+          { error, proposalId: proposal.id },
+          "RPC read failed while computing proposal status; falling back to indexed status",
+        );
+        return proposal.status;
+      }
       const hasQuorum = proposalQuorum >= quorum;
       if (!hasQuorum) return ProposalStatus.NO_QUORUM;
 

--- a/apps/api/src/clients/governor.base.unit.test.ts
+++ b/apps/api/src/clients/governor.base.unit.test.ts
@@ -16,8 +16,11 @@ class TestGovernor extends GovernorBase {
     return this.getCachedQuorum(async () => 1n);
   }
 
-  getTimelockDelay(): Promise<bigint> {
-    return Promise.resolve(0n);
+  timelockDelayFetches = 0;
+
+  protected async fetchTimelockDelay(): Promise<bigint> {
+    this.timelockDelayFetches++;
+    return 0n;
   }
 }
 
@@ -51,5 +54,22 @@ describe("GovernorBase", () => {
       timestamp: 100,
       latestBlockCalls: 1,
     });
+  });
+
+  it("should dedupe concurrent timelock delay fetches", async () => {
+    const client = createPublicClient({
+      chain: mainnet,
+      transport: custom({ request: async () => null }),
+    });
+    const governor = new TestGovernor(client);
+
+    const delays = await Promise.all([
+      governor.getTimelockDelay(),
+      governor.getTimelockDelay(),
+      governor.getTimelockDelay(),
+    ]);
+
+    expect(delays).toEqual([0n, 0n, 0n]);
+    expect(governor.timelockDelayFetches).toBe(1);
   });
 });

--- a/apps/api/src/clients/gtc/index.ts
+++ b/apps/api/src/clients/gtc/index.ts
@@ -40,34 +40,31 @@ export class GTCClient<
     });
   }
 
-  async getTimelockDelay(): Promise<bigint> {
-    if (!this.cache.timelockDelay) {
-      const timelockAddress = await this.readContract({
-        abi: this.abi,
-        address: this.address,
-        functionName: "timelock",
-      });
-      this.cache.timelockDelay = await this.readContract({
-        abi: [
-          {
-            inputs: [],
-            name: "delay",
-            outputs: [
-              {
-                internalType: "uint256",
-                name: "",
-                type: "uint256",
-              },
-            ],
-            stateMutability: "view",
-            type: "function",
-          },
-        ],
-        address: timelockAddress,
-        functionName: "delay",
-      });
-    }
-    return this.cache.timelockDelay;
+  protected async fetchTimelockDelay(): Promise<bigint> {
+    const timelockAddress = await this.readContract({
+      abi: this.abi,
+      address: this.address,
+      functionName: "timelock",
+    });
+    return this.readContract({
+      abi: [
+        {
+          inputs: [],
+          name: "delay",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+      ],
+      address: timelockAddress,
+      functionName: "delay",
+    });
   }
 
   async getGracePeriod(): Promise<bigint> {

--- a/apps/api/src/clients/nouns/index.ts
+++ b/apps/api/src/clients/nouns/index.ts
@@ -48,34 +48,31 @@ export class Client<
     });
   }
 
-  async getTimelockDelay(): Promise<bigint> {
-    if (!this.cache.timelockDelay) {
-      const timelockAddress = await this.readContract({
-        abi: this.abi,
-        address: this.address,
-        functionName: "timelock",
-      });
-      this.cache.timelockDelay = await this.readContract({
-        abi: [
-          {
-            inputs: [],
-            name: "delay",
-            outputs: [
-              {
-                internalType: "uint256",
-                name: "",
-                type: "uint256",
-              },
-            ],
-            stateMutability: "view",
-            type: "function",
-          },
-        ],
-        address: timelockAddress,
-        functionName: "delay",
-      });
-    }
-    return this.cache.timelockDelay;
+  protected async fetchTimelockDelay(): Promise<bigint> {
+    const timelockAddress = await this.readContract({
+      abi: this.abi,
+      address: this.address,
+      functionName: "timelock",
+    });
+    return this.readContract({
+      abi: [
+        {
+          inputs: [],
+          name: "delay",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+      ],
+      address: timelockAddress,
+      functionName: "delay",
+    });
   }
 
   async getGracePeriod(): Promise<bigint> {

--- a/apps/api/src/clients/obol/index.ts
+++ b/apps/api/src/clients/obol/index.ts
@@ -40,30 +40,27 @@ export class ObolClient<
     });
   }
 
-  async getTimelockDelay(): Promise<bigint> {
-    if (!this.cache.timelockDelay) {
-      const timelockAddress = await this.readContract({
-        abi: this.abi,
-        address: this.address,
-        functionName: "timelock",
-      });
-      this.cache.timelockDelay = await this.readContract({
-        abi: [
-          {
-            constant: true,
-            inputs: [],
-            outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-            payable: false,
-            stateMutability: "view",
-            type: "function",
-            name: "getMinDelay",
-          },
-        ],
-        address: timelockAddress,
-        functionName: "getMinDelay",
-      });
-    }
-    return this.cache.timelockDelay;
+  protected async fetchTimelockDelay(): Promise<bigint> {
+    const timelockAddress = await this.readContract({
+      abi: this.abi,
+      address: this.address,
+      functionName: "timelock",
+    });
+    return this.readContract({
+      abi: [
+        {
+          constant: true,
+          inputs: [],
+          outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+          payable: false,
+          stateMutability: "view",
+          type: "function",
+          name: "getMinDelay",
+        },
+      ],
+      address: timelockAddress,
+      functionName: "getMinDelay",
+    });
   }
 
   calculateQuorum(votes: {

--- a/apps/api/src/clients/op/index.ts
+++ b/apps/api/src/clients/op/index.ts
@@ -39,7 +39,7 @@ export class OPClient<
     }, `quorum:proposal:${proposalId}`);
   }
 
-  async getTimelockDelay(): Promise<bigint> {
+  protected async fetchTimelockDelay(): Promise<bigint> {
     return 0n;
   }
 

--- a/apps/api/src/clients/scr/index.ts
+++ b/apps/api/src/clients/scr/index.ts
@@ -33,34 +33,31 @@ export class SCRClient<
     });
   }
 
-  async getTimelockDelay(): Promise<bigint> {
-    if (!this.cache.timelockDelay) {
-      const timelockAddress = await this.readContract({
-        abi: this.abi,
-        address: this.address,
-        functionName: "timelock",
-      });
-      this.cache.timelockDelay = await this.readContract({
-        abi: [
-          {
-            inputs: [],
-            name: "getMinDelay",
-            outputs: [
-              {
-                internalType: "uint256",
-                name: "duration",
-                type: "uint256",
-              },
-            ],
-            stateMutability: "view",
-            type: "function",
-          },
-        ],
-        address: timelockAddress,
-        functionName: "getMinDelay",
-      });
-    }
-    return this.cache.timelockDelay;
+  protected async fetchTimelockDelay(): Promise<bigint> {
+    const timelockAddress = await this.readContract({
+      abi: this.abi,
+      address: this.address,
+      functionName: "timelock",
+    });
+    return this.readContract({
+      abi: [
+        {
+          inputs: [],
+          name: "getMinDelay",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "duration",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+      ],
+      address: timelockAddress,
+      functionName: "getMinDelay",
+    });
   }
 
   calculateQuorum(votes: {

--- a/apps/api/src/clients/shu/index.ts
+++ b/apps/api/src/clients/shu/index.ts
@@ -61,7 +61,7 @@ export class SHUClient<
     return BigInt(VOTING_PERIOD_BLOCKS);
   }
 
-  async getTimelockDelay(): Promise<bigint> {
+  protected async fetchTimelockDelay(): Promise<bigint> {
     // Returned in seconds (cross-DAO convention — see GovernorBase.getProposalStatus),
     // converted from Azorius.timelockPeriod() which is denominated in blocks.
     return BigInt(TIMELOCK_PERIOD_BLOCKS * BLOCK_TIME_SECONDS);

--- a/apps/api/src/clients/torn/index.ts
+++ b/apps/api/src/clients/torn/index.ts
@@ -78,15 +78,12 @@ export class TORNClient<
     return this.cache.proposalThreshold!;
   }
 
-  async getTimelockDelay(): Promise<bigint> {
-    if (!this.cache.timelockDelay) {
-      this.cache.timelockDelay = (await this.readContract({
-        abi: this.abi,
-        address: this.address,
-        functionName: "EXECUTION_DELAY",
-      })) as bigint;
-    }
-    return this.cache.timelockDelay!;
+  protected async fetchTimelockDelay(): Promise<bigint> {
+    return (await this.readContract({
+      abi: this.abi,
+      address: this.address,
+      functionName: "EXECUTION_DELAY",
+    })) as bigint;
   }
 
   private async getExecutionExpiration(): Promise<bigint> {

--- a/apps/api/src/clients/uni/index.ts
+++ b/apps/api/src/clients/uni/index.ts
@@ -38,30 +38,27 @@ export class UNIClient<
     });
   }
 
-  async getTimelockDelay(): Promise<bigint> {
-    if (!this.cache.timelockDelay) {
-      const timelockAddress = await this.readContract({
-        abi: this.abi,
-        address: this.address,
-        functionName: "timelock",
-      });
-      this.cache.timelockDelay = await this.readContract({
-        abi: [
-          {
-            constant: true,
-            inputs: [],
-            outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
-            payable: false,
-            stateMutability: "view",
-            type: "function",
-            name: "delay",
-          },
-        ],
-        address: timelockAddress,
-        functionName: "delay",
-      });
-    }
-    return this.cache.timelockDelay;
+  protected async fetchTimelockDelay(): Promise<bigint> {
+    const timelockAddress = await this.readContract({
+      abi: this.abi,
+      address: this.address,
+      functionName: "timelock",
+    });
+    return this.readContract({
+      abi: [
+        {
+          constant: true,
+          inputs: [],
+          outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+          payable: false,
+          stateMutability: "view",
+          type: "function",
+          name: "delay",
+        },
+      ],
+      address: timelockAddress,
+      functionName: "delay",
+    });
   }
 
   async getGracePeriod(): Promise<bigint> {

--- a/apps/api/src/clients/zk/index.ts
+++ b/apps/api/src/clients/zk/index.ts
@@ -38,34 +38,31 @@ export class ZKClient<
     });
   }
 
-  async getTimelockDelay(): Promise<bigint> {
-    if (!this.cache.timelockDelay) {
-      const timelockAddress = await this.readContract({
-        abi: this.abi,
-        address: this.address,
-        functionName: "timelock",
-      });
-      this.cache.timelockDelay = await this.readContract({
-        abi: [
-          {
-            inputs: [],
-            name: "getMinDelay",
-            outputs: [
-              {
-                internalType: "uint256",
-                name: "",
-                type: "uint256",
-              },
-            ],
-            stateMutability: "view",
-            type: "function",
-          },
-        ],
-        address: timelockAddress,
-        functionName: "getMinDelay",
-      });
-    }
-    return this.cache.timelockDelay;
+  protected async fetchTimelockDelay(): Promise<bigint> {
+    const timelockAddress = await this.readContract({
+      abi: this.abi,
+      address: this.address,
+      functionName: "timelock",
+    });
+    return this.readContract({
+      abi: [
+        {
+          inputs: [],
+          name: "getMinDelay",
+          outputs: [
+            {
+              internalType: "uint256",
+              name: "",
+              type: "uint256",
+            },
+          ],
+          stateMutability: "view",
+          type: "function",
+        },
+      ],
+      address: timelockAddress,
+      functionName: "getMinDelay",
+    });
   }
 
   calculateQuorum(votes: {

--- a/apps/api/src/middlewares/errorHandler.ts
+++ b/apps/api/src/middlewares/errorHandler.ts
@@ -21,9 +21,12 @@ export const errorHandler: ErrorHandler = (err, c) => {
     );
   }
 
+  // viem errors carry a one-line shortMessage; err.message is multi-line.
+  const cause =
+    (err as Error & { shortMessage?: string }).shortMessage ?? err.message;
   logger.error(
     { err, url: c.req.path, method: c.req.method },
-    "unhandled error",
+    `unhandled error: ${cause}`,
   );
 
   return c.json(

--- a/infra/erpc/erpc.dev.yaml
+++ b/infra/erpc/erpc.dev.yaml
@@ -248,6 +248,7 @@ rateLimiters:
           maxCount: 20
           period: 1s
           perIP: true
+          waitTime: 5s
     - id: dashboard-limit
       rules:
         - method: "*"

--- a/infra/erpc/erpc.prod.yaml
+++ b/infra/erpc/erpc.prod.yaml
@@ -248,6 +248,7 @@ rateLimiters:
           maxCount: 20
           period: 1s
           perIP: true
+          waitTime: 5s
     - id: dashboard-limit
       rules:
         - method: "*"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Proposal status may be slightly stale when RPC fails (indexed fallback), which affects governance UX but avoids outages; timelock caching behavior changed from per-client to shared base logic.
> 
> **Overview**
> Reduces RPC pressure and hard failures when serving live proposal status across many DAO governor clients.
> 
> **GovernorBase** now owns timelock delay caching: DAOs implement **`fetchTimelockDelay()`** (uncached reads) while **`getTimelockDelay()`** caches the result and **dedupes concurrent in-flight fetches**—important when **`getProposalStatus`** runs per proposal on list endpoints. **`getProposalStatus`** **catches RPC errors** (e.g. rate limits) on timelock/grace and quorum reads and **returns the indexed DB status** with a warn log instead of failing the whole request with 500.
> 
> The global error handler **includes viem’s `shortMessage`** in unhandled-error log lines. **eRPC `api-limit`** budgets in dev/prod gain **`waitTime: 5s`** so throttled clients wait briefly instead of failing immediately. API **1.5.5** with a unit test for concurrent timelock dedupe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1575b90764145d8328cb48e04aac95b6e583dbef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->