### PR TITLE
fix: wallet-only whitelabel login and branded magic-link email

### DIFF
--- a/.changeset/magic-link-email-branding.md
+++ b/.changeset/magic-link-email-branding.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/user-api": patch
+---
+
+Magic-link email restyled to match the Anticapture dashboard theme (dark surface, tangerine brand button, square corners) instead of the unbranded placeholder markup.

--- a/.changeset/whitelabel-wallet-only-login.md
+++ b/.changeset/whitelabel-wallet-only-login.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Whitelabel login modal is wallet-only again: the Email and Google sign-in options are hidden on whitelabel deployments regardless of which methods the server offers.

--- a/apps/dashboard/shared/components/auth/LoginModal.tsx
+++ b/apps/dashboard/shared/components/auth/LoginModal.tsx
@@ -22,7 +22,7 @@ import { useSiweLogin } from "@/shared/services/auth/useSiweLogin";
 
 export type LoginModalProps = {
   open: boolean;
-  onOpenChange: (open: boolean) => void;
+  onOpenChangeAction: (open: boolean) => void;
   /** Whitelabel deployments offer wallet sign-in only (no email/Google). */
   isWhitelabel?: boolean;
   /** The DAO branding a whitelabel render — drives the modal's icon. */
@@ -41,7 +41,7 @@ type View = "options" | "email" | "sent";
 
 export const LoginModal = ({
   open,
-  onOpenChange,
+  onOpenChangeAction,
   isWhitelabel = false,
   whitelabelDaoId = null,
   redirectTo,
@@ -56,13 +56,13 @@ export const LoginModal = ({
 
   // The server reports which methods its deployment actually serves (magic
   // link / Google are env-gated there); a method it can't handle is hidden
-  // rather than shown broken. Whitelabel is wallet-only by design.
-  // Fetched at mount (this component is always mounted, `open` just toggles
-  // it) so the answer is already cached when the modal first opens — the
-  // Email/Google buttons must not pop in after a round-trip.
+  // rather than shown broken. Fetched at mount (this component is always
+  // mounted, `open` just toggles it) so the answer is already cached when the
+  // modal first opens. Whitelabel is wallet-only by design, regardless of
+  // what the server offers.
   const methods = useAuthMethods();
-  const showEmail = methods.magicLink;
-  const showGoogle = methods.google;
+  const showEmail = methods.magicLink && !isWhitelabel;
+  const showGoogle = methods.google && !isWhitelabel;
   const showAlternatives = showEmail || showGoogle;
   const siweBusy = siwe.status !== "idle" && siwe.status !== "error";
 
@@ -95,7 +95,7 @@ export const LoginModal = ({
       siwe.reset();
       emailLogin.reset();
     }
-    onOpenChange(next);
+    onOpenChangeAction(next);
   };
 
   const callbackURL = () =>

--- a/apps/dashboard/shared/services/auth/LoginProvider.tsx
+++ b/apps/dashboard/shared/services/auth/LoginProvider.tsx
@@ -125,7 +125,7 @@ export function LoginProvider({
       {children}
       <LoginModal
         open={isOpen}
-        onOpenChange={handleOpenChange}
+        onOpenChangeAction={handleOpenChange}
         isWhitelabel={isWhitelabel}
         whitelabelDaoId={whitelabelDaoId}
         redirectTo={redirectTo}

--- a/apps/user-api/src/email/magic-link.ts
+++ b/apps/user-api/src/email/magic-link.ts
@@ -34,15 +34,19 @@ export const createMagicLinkSender = (
     const { error } = await resend.emails.send({
       from,
       to: email,
-      subject: "Sign in to Blockful",
+      subject: "Sign in to Anticapture",
+      // Inline-styled with the dashboard's dark-theme tokens (globals.css):
+      // background #09090b, surface #18181b, border #3f3f46, text #fafafa /
+      // #a1a1aa / #71717a, brand #ec762e — square corners like rounded-base.
       html: `
-        <div style="font-family: system-ui, sans-serif; max-width: 480px; margin: 0 auto;">
-          <h2 style="font-size: 18px;">Sign in to Blockful</h2>
-          <p style="color: #555;">Click the button below to sign in. This link expires shortly and can be used once.</p>
-          <p style="margin: 24px 0;">
-            <a href="${landingUrl}" style="background: #E66AE9; color: #fff; padding: 12px 20px; border-radius: 8px; text-decoration: none; display: inline-block;">Sign in</a>
-          </p>
-          <p style="color: #888; font-size: 13px;">If you didn't request this, you can safely ignore this email.</p>
+        <div style="background-color: #09090b; padding: 40px 16px; font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;">
+          <div style="max-width: 400px; margin: 0 auto; background-color: #18181b; border: 1px solid #3f3f46; padding: 32px 24px; text-align: center;">
+            <p style="margin: 0 0 24px; font-family: 'Roboto Mono', ui-monospace, monospace; font-size: 13px; line-height: 20px; letter-spacing: 0.08em; text-transform: uppercase; color: #ec762e;">Anticapture</p>
+            <h2 style="margin: 0 0 4px; font-size: 16px; line-height: 24px; font-weight: 600; color: #fafafa;">Sign in to Anticapture</h2>
+            <p style="margin: 0 0 24px; font-size: 14px; line-height: 20px; color: #a1a1aa;">Click the button below to sign in. This link expires shortly and can be used once.</p>
+            <a href="${landingUrl}" style="display: inline-block; background-color: #ec762e; color: #09090b; padding: 12px 24px; font-size: 14px; line-height: 20px; font-weight: 500; text-decoration: none;">Sign in</a>
+            <p style="margin: 24px 0 0; font-size: 12px; line-height: 16px; color: #71717a;">If you didn't request this, you can safely ignore this email.</p>
+          </div>
         </div>
       `,
     });


### PR DESCRIPTION
## Summary

Whitelabel deployments are wallet-only again — the login modal hides the Email and Google options when `isWhitelabel` is set — and the magic-link email sent by user-api now matches the Anticapture visual identity instead of the unbranded placeholder markup.

## Context

- 🌿 **Branch**: `fix/whitelabel-wallet-only-login`

## What changed

**UI (dashboard)**
- `LoginModal`: `showEmail` / `showGoogle` now gate on `!isWhitelabel`, so whitelabel renders offer wallet sign-in only regardless of which methods the server advertises.
- `LoginModal` prop renamed `onOpenChange` → `onOpenChangeAction` (caller in `LoginProvider` updated).

**Email (user-api)**
- Magic-link email restyled with the dashboard's dark-theme tokens from `globals.css`: background `#09090b`, card `#18181b` with `#3f3f46` border, text `#fafafa`/`#a1a1aa`/`#71717a`, tangerine brand button `#ec762e` with inverted dark text and square corners (`--radius-base: 0px`), plus an uppercase Roboto Mono "Anticapture" wordmark line. All styles inline for email-client compatibility; no logic change (previous button color `#E66AE9` was not a brand color).

## Self-review summary

- ✅ QA pass: 6 scenarios verified — sole `LoginModal` consumer updated; existing magic-link emails still verify on whitelabel hosts (`/auth/magic-link` interstitial unaffected); `useAuthMethods` fails closed; `landingUrl` interpolation is injection-safe (WHATWG `URL` serialization); email styles fully inline with font fallbacks.
- ✅ Engineer pass: typecheck + lint clean on `@anticapture/dashboard` and `@anticapture/user-api`; `magic-link.test.ts` 2/2 passing.
- ⚠️ Known limitations:
  - Whitelabel gating is UI-only: user-api's magic-link/Google endpoints remain callable from a whitelabel host. Hiding the entry points is the intended UX scope here; server-side enforcement can be a follow-up if desired.

## Changeset

- `@anticapture/dashboard`: patch — whitelabel login modal is wallet-only.
- `@anticapture/user-api`: patch — magic-link email matches the Anticapture theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)