### PR TITLE
ci: redeploy docs on Railway after gateful deploys

### DIFF
--- a/.changeset/docs-redeploy-after-gateful.md
+++ b/.changeset/docs-redeploy-after-gateful.md
@@ -1,0 +1,6 @@
+---
+---
+
+CI/infra only — no package code changes. Adds a `redeploy-docs` job to the
+deploy workflow so the Railway docs service rebuilds (and re-fetches the live
+Gateful OpenAPI spec) after every Gateful deploy on dev and production.

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -79,3 +79,89 @@ jobs:
             --meta githubRepo="${GIT_REPO}" \
             --meta githubRepoId="${GIT_REPO_ID}" \
             --meta githubDeployment=1
+
+  # The docs site bakes the LIVE gateful OpenAPI spec into its static build
+  # (packages/anticapture-client/docs/scripts/prepare-spec.mjs), but Railway
+  # only auto-deploys the docs service when docs files change (watchPatterns
+  # in infra/docs/railway.json). Without this job, a gateful deploy leaves the
+  # published API reference stale until the next docs commit.
+  redeploy-docs:
+    name: Redeploy docs (${{ github.ref_name == 'main' && 'production' || 'dev' }})
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name == 'main' && 'production' || 'dev' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # Rebuild only AFTER gateful serves this exact commit: the docs build
+      # fetches the spec from the live gateful, so triggering it against the
+      # previous deployment would bake in the OLD spec (same race the deploy
+      # job above guards against for dashboard codegen).
+      - name: Wait for gateful to be ready
+        run: node scripts/wait-for-gateful.mjs
+        env:
+          ANTICAPTURE_API_URL: ${{ secrets.GATEFUL_URL }}
+          EXPECTED_GATEFUL_SHA: ${{ github.sha }}
+
+      # RAILWAY_TOKEN is a Railway *project token* scoped to this GitHub
+      # environment's Railway environment; RAILWAY_DOCS_SERVICE_ID is the docs
+      # service id. Both live in the dev/production GitHub environments (see
+      # packages/anticapture-client/docs/README.md).
+      - name: Trigger docs rebuild on Railway
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_DOCS_SERVICE_ID: ${{ secrets.RAILWAY_DOCS_SERVICE_ID }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${RAILWAY_TOKEN:-}" ] || [ -z "${RAILWAY_DOCS_SERVICE_ID:-}" ]; then
+            echo "::warning::Skipping docs redeploy; RAILWAY_TOKEN / RAILWAY_DOCS_SERVICE_ID secrets are not configured."
+            exit 0
+          fi
+
+          api="https://backboard.railway.com/graphql/v2"
+
+          graphql() {
+            local body response
+            body="$1"
+            response=$(curl --fail-with-body --silent --show-error \
+              --request POST "${api}" \
+              --header "Project-Access-Token: ${RAILWAY_TOKEN}" \
+              --header "Content-Type: application/json" \
+              --data "${body}")
+            # GraphQL errors come back as HTTP 200 with an `errors` array, so
+            # --fail-with-body alone doesn't catch them.
+            if jq --exit-status '.errors' >/dev/null 2>&1 <<<"${response}"; then
+              echo "::error::Railway API error: ${response}" >&2
+              return 1
+            fi
+            echo "${response}"
+          }
+
+          # Project tokens are scoped to a single project+environment; resolve
+          # the environment from the token itself instead of a third secret so
+          # the pair can never point at the wrong environment.
+          environment_id=$(graphql '{"query":"query { projectToken { environmentId } }"}' \
+            | jq --exit-status --raw-output '.data.projectToken.environmentId')
+
+          # serviceInstanceDeployV2 builds from the connected repo at the given
+          # commit. serviceInstanceRedeploy would NOT work here: it reuses the
+          # previous build, whose static output embeds the old spec.
+          payload=$(jq --null-input \
+            --arg query 'mutation Deploy($serviceId: String!, $environmentId: String!, $commitSha: String) { serviceInstanceDeployV2(serviceId: $serviceId, environmentId: $environmentId, commitSha: $commitSha) }' \
+            --arg serviceId "${RAILWAY_DOCS_SERVICE_ID}" \
+            --arg environmentId "${environment_id}" \
+            --arg commitSha "${GIT_SHA}" \
+            '{ query: $query, variables: { serviceId: $serviceId, environmentId: $environmentId, commitSha: $commitSha } }')
+
+          deployment_id=$(graphql "${payload}" \
+            | jq --exit-status --raw-output '.data.serviceInstanceDeployV2')
+
+          echo "Triggered docs deployment ${deployment_id} for commit ${GIT_SHA}."

--- a/infra/docs/Dockerfile
+++ b/infra/docs/Dockerfile
@@ -21,7 +21,14 @@ COPY --from=builder /app/out/full/ .
 # See packages/anticapture-client/docs/scripts/gateful-openapi-spec.mjs.
 ARG RAILWAY_ENVIRONMENT_NAME
 ARG ANTICAPTURE_API_URL
-RUN pnpm --filter @anticapture/client-docs build
+# The build bakes the spec fetched from the live Gateful into the static
+# output. Deploys triggered after a gateful deploy (deploy.yaml redeploy-docs)
+# usually arrive with an unchanged docs tree, so reference the commit SHA in
+# the RUN to defeat Railway's layer cache — a cached layer would keep serving
+# the previous spec.
+ARG RAILWAY_GIT_COMMIT_SHA
+RUN echo "docs build for commit ${RAILWAY_GIT_COMMIT_SHA:-unknown}" \
+  && pnpm --filter @anticapture/client-docs build
 
 FROM base AS runner
 ENV NODE_ENV=production

--- a/packages/anticapture-client/docs/README.md
+++ b/packages/anticapture-client/docs/README.md
@@ -1,0 +1,58 @@
+# @anticapture/client-docs
+
+Docusaurus site for the Anticapture API documentation, served at
+[anticapture.xyz/docs](https://anticapture.xyz/docs).
+
+## How the API reference is built
+
+The OpenAPI reference is **not** generated from committed spec files. At build
+time, `scripts/prepare-spec.mjs` fetches the OpenAPI spec from the **live
+Gateful deployment** (resolved by `scripts/gateful-openapi-spec.mjs` from
+`ANTICAPTURE_API_URL` / `RAILWAY_ENVIRONMENT_NAME`), filters it, and writes it
+to `openapi/` for the Docusaurus OpenAPI plugin. Docs and client codegen
+therefore always generate from the same source.
+
+The consequence: the published docs reflect whatever spec Gateful served _at
+the moment the docs were last built_ — deploying Gateful alone does not
+refresh them.
+
+## When the docs deploy
+
+The site runs as a Railway service built from `infra/docs/Dockerfile`. Two
+triggers produce a deployment:
+
+1. **Docs changes** — Railway auto-deploys on pushes to `dev`/`main` that
+   touch `packages/anticapture-client/docs/**` or `infra/docs/**`
+   (`watchPatterns` in `infra/docs/railway.json`).
+2. **Gateful deploys** — the `redeploy-docs` job in
+   `.github/workflows/deploy.yaml` runs on every push to `dev`/`main`. It
+   waits for Gateful to serve that exact commit (`scripts/wait-for-gateful.mjs`
+   — rebuilding earlier would bake in the old spec), then calls Railway's
+   `serviceInstanceDeployV2` mutation so the docs rebuild against the freshly
+   deployed spec. `infra/docs/Dockerfile` references `RAILWAY_GIT_COMMIT_SHA`
+   in the build step so these rebuilds bypass Railway's layer cache even when
+   no docs file changed.
+
+### Required GitHub secrets
+
+Set per GitHub environment (`dev` and `production`):
+
+| Secret                    | Value                                                                  |
+| ------------------------- | ---------------------------------------------------------------------- |
+| `RAILWAY_TOKEN`           | Railway **project token** scoped to the matching Railway environment   |
+| `RAILWAY_DOCS_SERVICE_ID` | Service id of the docs service (Railway dashboard → docs service → id) |
+
+If either secret is missing, the job logs a warning and skips instead of
+failing the deploy.
+
+## Local development
+
+```bash
+pnpm client-docs start   # dev server (fetches the spec on start)
+pnpm client-docs build   # production build into build/
+```
+
+`ANTICAPTURE_API_URL` selects which Gateful the spec is fetched from and is
+required (on Railway PR previews the URL is derived from
+`RAILWAY_ENVIRONMENT_NAME` instead); the resolution rules live in
+`scripts/gateful-openapi-spec.mjs`.


### PR DESCRIPTION
## Problem

The docs site (`anticapture.xyz/docs`, Railway service built from `infra/docs/Dockerfile`) bakes the **live Gateful OpenAPI spec** into its static build (`packages/anticapture-client/docs/scripts/prepare-spec.mjs`). Railway only auto-deploys the docs service when docs files change (`watchPatterns` in `infra/docs/railway.json`), so a Gateful deploy leaves the published API reference stale until the next docs commit.

Follow-up to #2074 (ClickUp DEV-1121).

## Solution

**New `redeploy-docs` job in `deploy.yaml`** (runs on every push to `dev`/`main`, alongside the existing Vercel job):

1. Waits for gateful to serve the exact pushed commit (`scripts/wait-for-gateful.mjs`) — rebuilding docs against the previous gateful would bake in the *old* spec, the same race the Vercel job already guards against for dashboard codegen.
2. Triggers a docs rebuild via Railway's `serviceInstanceDeployV2` GraphQL mutation, pinned to the pushed commit. `serviceInstanceRedeploy` would *not* work here — it reuses the previous build, whose static output embeds the old spec.

**Cache-bust in `infra/docs/Dockerfile`**: these triggered rebuilds usually arrive with an unchanged docs tree, so without referencing `RAILWAY_GIT_COMMIT_SHA` in the build `RUN`, Railway's layer cache would reuse the cached build layer and the whole trigger would be a no-op.

**New `packages/anticapture-client/docs/README.md`** documenting the build/deploy pipeline and required secrets.

## Setup required (per GitHub environment, `dev` and `production`)

| Secret | Value |
| --- | --- |
| `RAILWAY_TOKEN` | Railway **project token** scoped to the matching Railway environment (the job resolves the environment id from the token itself) |
| `RAILWAY_DOCS_SERVICE_ID` | Service id of the Railway docs service |

Until these are set, the job logs a warning and skips — deploys are unaffected.

## Notes

- Auth uses the `Project-Access-Token` header (project tokens don't use `Authorization: Bearer`); endpoint and mutation signature verified against Railway's live schema (`serviceInstanceDeployV2(serviceId!, environmentId!, commitSha)` → deployment id).
- Empty changeset included (CI/infra only, no package code changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)