### PR TITLE
feat(dashboard): renew ENS security council term, add Compound proposal guardian

### DIFF
--- a/.changeset/renew-ens-security-council-add-comp-guardian.md
+++ b/.changeset/renew-ens-security-council-add-comp-guardian.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": minor
+---
+
+Update the ENS Security Council card to the council seated in July 2026 (5/8 multisig, expires July 16, 2028) and add Compound's Proposal Guardian with its expiration

--- a/apps/dashboard/features/dao-overview/components/ProgressBar.tsx
+++ b/apps/dashboard/features/dao-overview/components/ProgressBar.tsx
@@ -41,7 +41,9 @@ export const ProgressBar = ({
             <p className="text-error flex-nowrap text-xs font-medium leading-4">
               Danger Zone
             </p>
-            <TooltipInfo text="This means that the Security Council is approaching expiration and it might be good to start the process of renewal." />
+            <TooltipInfo
+              text={`This means that the ${daoOverview.securityCouncil?.label ?? "Security Council"} is approaching expiration and it might be good to start the process of renewal.`}
+            />
           </div>
         )}
 

--- a/apps/dashboard/features/dao-overview/components/SecurityCouncilCard.tsx
+++ b/apps/dashboard/features/dao-overview/components/SecurityCouncilCard.tsx
@@ -52,6 +52,11 @@ export const SecurityCouncilCard = ({
 
   if (!securityCouncil) return null;
 
+  const { label = "Security Council", multisig } = securityCouncil;
+  const multisigDescription =
+    multisig.description ??
+    `The ${label} is set up as a multisig with ${multisig.signers} signers, needing the signature of ${multisig.threshold} out of ${multisig.signers} to execute a cancel transaction for an approved proposal in the Timelock contract.`;
+
   return (
     <div className="flex flex-col gap-5">
       <div className="border-x-1 border-inverted mx-5">
@@ -59,22 +64,18 @@ export const SecurityCouncilCard = ({
           className={"lg:bg-surface-default flex w-full flex-col gap-4 lg:p-4"}
         >
           <div className="flex w-full flex-col text-[13px] lg:flex-row lg:items-center lg:gap-2">
-            <p className="text-primary flex items-center gap-2 font-mono font-medium tracking-wider lg:px-0">
-              SECURITY COUNCIL
+            <p className="text-primary flex items-center gap-2 font-mono font-medium uppercase tracking-wider lg:px-0">
+              {label}
             </p>
             <div className="hidden size-1 items-center rounded-full bg-[#3F3F46] lg:flex" />
             <div className="flex items-center gap-1.5">
-              <UnderlinedLink
-                href={securityCouncil.multisig.externalLink}
-                openInNewTab
-              >
+              <UnderlinedLink href={multisig.externalLink} openInNewTab>
                 <div className="flex items-center gap-2">
                   <div className="flex items-center gap-1">
                     <Key className="text-link size-3.5" /> Multisig:
                   </div>
                   <span>
-                    {securityCouncil.multisig.threshold}/
-                    {securityCouncil.multisig.signers}
+                    {multisig.threshold}/{multisig.signers}
                   </span>
                   <span className="hidden lg:inline">
                     required for transactions
@@ -83,7 +84,7 @@ export const SecurityCouncilCard = ({
                 </div>
               </UnderlinedLink>
               <div className="hidden lg:flex">
-                <TooltipInfo text="The security council is set up as a multisig with eight signers, needing the signature of 4 out of 8 to execute a cancel transaction for an approved proposal in the Timelock contract." />
+                <TooltipInfo text={multisigDescription} />
               </div>
             </div>
           </div>

--- a/apps/dashboard/shared/dao-config/comp.ts
+++ b/apps/dashboard/shared/dao-config/comp.ts
@@ -12,6 +12,7 @@ import {
   GovernanceImplementationEnum,
   RiskAreaEnum,
 } from "@/shared/types/enums";
+import { calculateMonthsBefore } from "@/shared/utils/calculateMonthsBefore";
 
 export const COMP: DaoConfiguration = {
   name: "Compound",
@@ -47,6 +48,30 @@ export const COMP: DaoConfiguration = {
       logic: "For",
       quorumCalculation: QUORUM_CALCULATION_TYPES.COMPOUND,
       proposalThreshold: "25K $COMP",
+    },
+    securityCouncil: {
+      isActive: true,
+      label: "Proposal Guardian",
+      // CompoundGovernor.proposalGuardian() -> Compound Community Multisig,
+      // expiry 1898467200 (2030-02-28 00:00:00 UTC), last extended 2026-02-19.
+      vetoCouncilAddress: "0xbbf3f1421D886E9b2c5D716B5192aC998af2012c",
+      multisig: {
+        threshold: 5,
+        signers: 9,
+        externalLink:
+          "https://app.safe.global/home?safe=eth:0xbbf3f1421D886E9b2c5D716B5192aC998af2012c",
+        description:
+          "The Proposal Guardian is the Compound Community Multisig, with nine signers needing five signatures to cancel a proposal on the Governor contract.",
+      },
+      expiration: {
+        startDate: "February 19, 2026",
+        date: "February 28, 2030",
+        timestamp: 1898467200,
+        alertExpiration: calculateMonthsBefore({
+          monthsBeforeTimestamp: 3,
+          timestamp: 1898467200,
+        }),
+      },
     },
   },
   attackProfitability: {
@@ -158,7 +183,7 @@ export const COMP: DaoConfiguration = {
         currentSetting:
           "Compound has the Proposal Guardian, a multisig responsible for canceling malicious proposals.",
         impact:
-          "The Security Council can protect the DAO from malicious proposals by canceling them after the 4/8 multisig approval.",
+          "The Security Council can protect the DAO from malicious proposals by canceling them after the 5/9 multisig approval.",
         recommendedSetting:
           RECOMMENDED_SETTINGS[GovernanceImplementationEnum.SECURITY_COUNCIL],
         nextStep:

--- a/apps/dashboard/shared/dao-config/comp.ts
+++ b/apps/dashboard/shared/dao-config/comp.ts
@@ -178,12 +178,12 @@ export const COMP: DaoConfiguration = {
             GovernanceImplementationEnum.SECURITY_COUNCIL
           ].description,
         requirements: [
-          "The Compound Security Council needs to raise the threshold to 75% for approvals on their multisig to be considered Low Risk.",
+          "The Compound Proposal Guardian needs to raise the threshold to 75% for approvals on their multisig to be considered Low Risk.",
         ],
         currentSetting:
           "Compound has the Proposal Guardian, a multisig responsible for canceling malicious proposals.",
         impact:
-          "The Security Council can protect the DAO from malicious proposals by canceling them after the 5/9 multisig approval.",
+          "The Proposal Guardian can protect the DAO from malicious proposals by canceling them after the 5/9 multisig approval.",
         recommendedSetting:
           RECOMMENDED_SETTINGS[GovernanceImplementationEnum.SECURITY_COUNCIL],
         nextStep:
@@ -241,7 +241,7 @@ export const COMP: DaoConfiguration = {
         currentSetting:
           "There is a veto strategy controlled by the Compound DAO.",
         impact:
-          "Compound can veto malicious proposals with the Security Council.",
+          "Compound can veto malicious proposals with the Proposal Guardian.",
         recommendedSetting:
           RECOMMENDED_SETTINGS[GovernanceImplementationEnum.VETO_STRATEGY],
         nextStep: "The parameter is in its lowest-risk condition.",

--- a/apps/dashboard/shared/dao-config/ens.ts
+++ b/apps/dashboard/shared/dao-config/ens.ts
@@ -192,7 +192,7 @@ export const ENS: DaoConfiguration = {
             GovernanceImplementationEnum.SECURITY_COUNCIL
           ].description,
         currentSetting:
-          "ENS has a Security Council, managed by a 4/8 multisig, whose authority to cancel proposals must be renewed every two years (and will expire in July 2026).",
+          "ENS has a Security Council, managed by a 5/8 multisig, whose authority to cancel proposals must be renewed every two years (and will expire in July 2028).",
         impact: "ENS can veto malicious proposals with the Security Council.",
         recommendedSetting:
           RECOMMENDED_SETTINGS[GovernanceImplementationEnum.SECURITY_COUNCIL],

--- a/apps/dashboard/shared/dao-config/ens.ts
+++ b/apps/dashboard/shared/dao-config/ens.ts
@@ -54,20 +54,22 @@ export const ENS: DaoConfiguration = {
     },
     securityCouncil: {
       isActive: true,
-      vetoCouncilAddress: "0x552DF471a4c7Fea11Ea8d7a7b0Acc6989b902a95",
+      // SecurityCouncil contract granted PROPOSER_ROLE on the ENS timelock on
+      // 2026-07-22; expiration() returns 1847389751 (2028-07-16 19:49:11 UTC).
+      vetoCouncilAddress: "0x2acBf518b3759f6e1fA163294eda55bF1d0ae051",
       multisig: {
-        threshold: 4,
+        threshold: 5,
         signers: 8,
         externalLink:
-          "https://app.safe.global/home?safe=eth:0xaA5cD05f6B62C3af58AE9c4F3F7A2aCC2Cdc2Cc7",
+          "https://app.safe.global/home?safe=eth:0x7101B78638e34444F0a5AdE9e1149fbEeC029931",
       },
       expiration: {
-        startDate: "July 1, 2024",
-        date: "July 26 2026",
-        timestamp: 1784919179,
+        startDate: "July 22, 2026",
+        date: "July 16, 2028",
+        timestamp: 1847389751,
         alertExpiration: calculateMonthsBefore({
           monthsBeforeTimestamp: 3,
-          timestamp: 1784919179,
+          timestamp: 1847389751,
         }),
       },
     },

--- a/apps/dashboard/shared/dao-config/types.ts
+++ b/apps/dashboard/shared/dao-config/types.ts
@@ -97,11 +97,15 @@ export interface DaoOverviewConfig {
   };
   securityCouncil?: {
     isActive: boolean;
+    /** Card heading (rendered uppercase). Defaults to "Security Council". */
+    label?: string;
     vetoCouncilAddress: string;
     multisig: {
       threshold: number;
       signers: number;
       externalLink: string;
+      /** Tooltip next to the multisig link. Falls back to a generated description. */
+      description?: string;
     };
     expiration: {
       date: string;

--- a/apps/dashboard/shared/dao-config/types.ts
+++ b/apps/dashboard/shared/dao-config/types.ts
@@ -104,7 +104,12 @@ export interface DaoOverviewConfig {
       threshold: number;
       signers: number;
       externalLink: string;
-      /** Tooltip next to the multisig link. Falls back to a generated description. */
+      /**
+       * Tooltip next to the multisig link. Falls back to a generated
+       * description that assumes cancellation happens on the Timelock, so set
+       * this explicitly whenever the cancellation path is somewhere else
+       * (Compound's guardian, for instance, cancels on the Governor).
+       */
       description?: string;
     };
     expiration: {


### PR DESCRIPTION
## What

The ENS Security Council card on `/ens` was showing an expired term (ended 2026-07-24). ENS has since seated a new council, so this points the card at it — and adds Compound's Proposal Guardian to the same card, which had no entry at all.

## Data (verified on-chain, mainnet)

### ENS

| | Old (in config) | New |
|---|---|---|
| `SecurityCouncil` contract | `0xb8fa0ce3…3ee0` (config had `0x552DF471…2a95`) | `0x2acBf518b3759f6e1fA163294eda55bF1d0ae051` |
| Safe multisig | `0xaA5cD05f…2Cc7` (4/8) | `0x7101B78638e34444F0a5AdE9e1149fbEeC029931` (5/8) |
| `expiration()` | `1784919179` → 2026-07-24 18:52:59 UTC | `1847389751` → 2028-07-16 19:49:11 UTC |
| Term start | July 1, 2024 (approx.) | 2026-07-22 05:44:59 UTC |

- `RoleGranted(PROPOSER_ROLE, 0x2acB…e051)` on the ENS timelock `0xFe89cc7a…44b7` at block **25586264** (ts `1784699099`), tx `0xb2f732c433471ce5274c77d1fe04bd060389319a3b32dfa26ee16164ef46812f` — used as the term start date.
- `0x2acB…e051`: `owner() = 0x7101B786…9931`, `timelock() = 0xFe89cc7a…44b7`, `expiration() = 1847389751`. Safe reports `getThreshold() = 5`, 8 owners.
- Matches the reported "two-year term until July 16, 2028, 5-of-8".

Note: the previous council contract still holds `PROPOSER_ROLE` (no `RoleRevoked` emitted) — nobody has called `renounceTimelockRoleByExpiration()` yet — but its `expiration()` has passed, so it can no longer cancel.

### Compound

`CompoundGovernor.proposalGuardian()` on `0x309a862b…c8C0` returns:

- account `0xbbf3f1421D886E9b2c5D716B5192aC998af2012c` (Compound Community Multisig, `getThreshold() = 5`, 9 owners)
- expiration `1898467200` → 2030-02-28 00:00:00 UTC

Extension history from `ProposalGuardianSet` events:

| Block | New expiry |
|---|---|
| 21688680 | 2025-02-17 |
| 22179688 | 2025-09-11 |
| 23418776 | 2026-09-12 |
| 24492577 (ts `1771524383`, 2026-02-19) | **2030-02-28** ← current |

Term start uses the block time of the most recent extension (2026-02-19).

## Changes

- `shared/dao-config/ens.ts` — new council address, 5/8 Safe, new start/expiration.
- `shared/dao-config/comp.ts` — new `securityCouncil` entry for the Proposal Guardian.
- `shared/dao-config/types.ts` — optional `label` (card heading) and `multisig.description` (tooltip).
- `SecurityCouncilCard.tsx` / `ProgressBar.tsx` — heading and multisig tooltip were hardcoded to ENS's wording and 4-of-8 numbers; both now read from config, so Compound renders "PROPOSAL GUARDIAN" with its own copy.

## Also fixed in passing

`comp.ts` `SECURITY_COUNCIL.impact` said "4/8 multisig approval". The Community Multisig is 5-of-9 on-chain, and leaving it would have contradicted the new card. Updated to 5/9. The adjacent `requirements` line ("raise the threshold to 75%") is unchanged — 5/9 is 55%, so the recommendation still stands.

## Verification

- Typecheck (`tsc --noEmit`) and ESLint/Prettier clean on all touched files. The repo-wide `pnpm dashboard typecheck` fails on pre-existing errors from `@anticapture/client` codegen (needs network to reach the Gateful spec) — unrelated to this diff and unchanged by it.
- Progress-bar math sanity-checked against today's date: ENS ~1.2% elapsed with the danger zone at 87.7%; Compound ~11% elapsed with the danger zone at 93.9%.
- Not rendered in a browser — no local `.env` for the dashboard. The card is pure config with no data fetching.