### PR TITLE
fix(ci): gate the production deploy on the API release, not just gateful

### DIFF
--- a/.changeset/gateful-upstream-commit-gate.md
+++ b/.changeset/gateful-upstream-commit-gate.md
@@ -1,6 +1,8 @@
 ---
 "@anticapture/api": patch
 "@anticapture/gateful": patch
+"@anticapture/relayer": patch
+"@anticapture/address-enrichment": patch
 ---
 
 Stop the production dashboard build from generating its SDK against the
@@ -12,17 +14,21 @@ it would serve: on #2093 gateful reported the new commit at 14:33:54, codegen
 read the spec at 14:34:23, and `ens-api` only came up at 14:34:34 — the
 dashboard build failed on a field the API hadn't started advertising yet.
 
-The DAO API now reports its running commit on `/health`, and gateful passes it
-through as `upstreams.<dao>.commit` alongside an `upstreams.<name>.kind`.
-`scripts/wait-for-gateful.mjs` then holds the deploy until every `dao-api`
-upstream reports a commit in `EXPECTED_UPSTREAM_SHAS` — the last commit that
-touched the paths Railway watches to rebuild those APIs, plus everything after
-it. Expressing it as "that commit or newer" rather than "does this push change
-the API" keeps the gate correct when a non-API push supersedes an in-flight API
-push, and when a push carries more than one commit. A DAO API reporting no
-commit counts as stale (the previous release is still answering); relayers,
-address enrichment and authful contribute no schemas and only have to be
-reachable.
+Every service whose OpenAPI gateful merges into `/docs/json` — the DAO APIs,
+the relayer and address enrichment — now reports its running commit on
+`/health`, and gateful passes it through as `upstreams.<name>.commit` alongside
+an `upstreams.<name>.kind`. `scripts/wait-for-gateful.mjs` then holds the
+deploy until each of them reports a commit listed for its kind in
+`EXPECTED_UPSTREAM_SHAS`: the last commit that touched the paths Railway
+watches to rebuild that service, plus everything after it.
+
+Expressing it as "that commit or newer" per service, rather than "does this
+push change the API", keeps the gate correct when a push that leaves a service
+alone supersedes an in-flight push that changed it, and when a push carries
+more than one commit. An upstream reporting no commit counts as stale — the
+previous release is still answering — which cannot deadlock, because teaching a
+service to report its commit necessarily touches its own watched paths.
+Authful contributes no merged schemas and only has to be reachable.
 
 `@anticapture/client#codegen` is also no longer cached by turbo: its real input
 is a live URL no hash can see, so the poisoned output above was replayed on

--- a/.changeset/gateful-upstream-commit-gate.md
+++ b/.changeset/gateful-upstream-commit-gate.md
@@ -32,4 +32,10 @@ Authful contributes no merged schemas and only has to be reachable.
 
 `@anticapture/client#codegen` is also no longer cached by turbo: its real input
 is a live URL no hash can see, so the poisoned output above was replayed on
-every retry of that commit and no re-run could ever fix it.
+every retry of that commit and no re-run could ever fix it. Re-running it was
+not enough on its own, though — `generated/**` is gitignored and so was absent
+from `@anticapture/client#build`'s input set, leaving that build (and the
+dashboard's, which hashes it in turn) identical across a retry and free to
+restore a `dist` compiled from the stale spec over the freshly generated one.
+Listing `generated/**` explicitly puts the spec back in the hash, without
+giving up the cache when the spec genuinely has not moved.

--- a/.changeset/gateful-upstream-commit-gate.md
+++ b/.changeset/gateful-upstream-commit-gate.md
@@ -12,15 +12,17 @@ it would serve: on #2093 gateful reported the new commit at 14:33:54, codegen
 read the spec at 14:34:23, and `ens-api` only came up at 14:34:34 — the
 dashboard build failed on a field the API hadn't started advertising yet.
 
-The DAO API now reports its running commit on `/health`, gateful passes it
-through as `upstreams.<dao>.commit` alongside an `upstreams.<name>.kind`, and
-`scripts/wait-for-gateful.mjs` waits for every `dao-api` upstream to report the
-release when `REQUIRE_UPSTREAM_COMMIT=1`. A DAO API that reports no commit
-counts as stale — that is the previous release still answering — while
-relayers, address enrichment and authful only have to be reachable. The flag is
-set by the deploy workflow only when the release touches the paths Railway
-watches to rebuild those APIs, so releases that leave them alone are not
-blocked.
+The DAO API now reports its running commit on `/health`, and gateful passes it
+through as `upstreams.<dao>.commit` alongside an `upstreams.<name>.kind`.
+`scripts/wait-for-gateful.mjs` then holds the deploy until every `dao-api`
+upstream reports a commit in `EXPECTED_UPSTREAM_SHAS` — the last commit that
+touched the paths Railway watches to rebuild those APIs, plus everything after
+it. Expressing it as "that commit or newer" rather than "does this push change
+the API" keeps the gate correct when a non-API push supersedes an in-flight API
+push, and when a push carries more than one commit. A DAO API reporting no
+commit counts as stale (the previous release is still answering); relayers,
+address enrichment and authful contribute no schemas and only have to be
+reachable.
 
 `@anticapture/client#codegen` is also no longer cached by turbo: its real input
 is a live URL no hash can see, so the poisoned output above was replayed on

--- a/.changeset/gateful-upstream-commit-gate.md
+++ b/.changeset/gateful-upstream-commit-gate.md
@@ -13,10 +13,14 @@ read the spec at 14:34:23, and `ens-api` only came up at 14:34:34 — the
 dashboard build failed on a field the API hadn't started advertising yet.
 
 The DAO API now reports its running commit on `/health`, gateful passes it
-through as `upstreams.<dao>.commit`, and `scripts/wait-for-gateful.mjs` waits
-for every upstream that reports one when `REQUIRE_UPSTREAM_COMMIT=1` — set by
-the deploy workflow only when the release touches the paths Railway watches to
-rebuild those APIs, so releases that leave them alone are not blocked.
+through as `upstreams.<dao>.commit` alongside an `upstreams.<name>.kind`, and
+`scripts/wait-for-gateful.mjs` waits for every `dao-api` upstream to report the
+release when `REQUIRE_UPSTREAM_COMMIT=1`. A DAO API that reports no commit
+counts as stale — that is the previous release still answering — while
+relayers, address enrichment and authful only have to be reachable. The flag is
+set by the deploy workflow only when the release touches the paths Railway
+watches to rebuild those APIs, so releases that leave them alone are not
+blocked.
 
 `@anticapture/client#codegen` is also no longer cached by turbo: its real input
 is a live URL no hash can see, so the poisoned output above was replayed on

--- a/.changeset/gateful-upstream-commit-gate.md
+++ b/.changeset/gateful-upstream-commit-gate.md
@@ -1,0 +1,23 @@
+---
+"@anticapture/api": patch
+"@anticapture/gateful": patch
+---
+
+Stop the production dashboard build from generating its SDK against the
+previous release's OpenAPI spec.
+
+Gateful merges the DAO APIs' specs into `/docs/json` on every request, so the
+deploy gate waiting for gateful's own commit proved nothing about the schemas
+it would serve: on #2093 gateful reported the new commit at 14:33:54, codegen
+read the spec at 14:34:23, and `ens-api` only came up at 14:34:34 — the
+dashboard build failed on a field the API hadn't started advertising yet.
+
+The DAO API now reports its running commit on `/health`, gateful passes it
+through as `upstreams.<dao>.commit`, and `scripts/wait-for-gateful.mjs` waits
+for every upstream that reports one when `REQUIRE_UPSTREAM_COMMIT=1` — set by
+the deploy workflow only when the release touches the paths Railway watches to
+rebuild those APIs, so releases that leave them alone are not blocked.
+
+`@anticapture/client#codegen` is also no longer cached by turbo: its real input
+is a live URL no hash can see, so the poisoned output above was replayed on
+every retry of that commit and no re-run could ever fix it.

--- a/.changeset/gateful-upstream-commit-gate.md
+++ b/.changeset/gateful-upstream-commit-gate.md
@@ -32,10 +32,10 @@ Authful contributes no merged schemas and only has to be reachable.
 
 `@anticapture/client#codegen` is also no longer cached by turbo: its real input
 is a live URL no hash can see, so the poisoned output above was replayed on
-every retry of that commit and no re-run could ever fix it. Re-running it was
-not enough on its own, though — `generated/**` is gitignored and so was absent
-from `@anticapture/client#build`'s input set, leaving that build (and the
-dashboard's, which hashes it in turn) identical across a retry and free to
-restore a `dist` compiled from the stale spec over the freshly generated one.
-Listing `generated/**` explicitly puts the spec back in the hash, without
-giving up the cache when the spec genuinely has not moved.
+every retry of that commit and no re-run could ever fix it. `#build` had to go
+with it: tsup runs with `dts: true`, so that same unhashable spec is compiled
+into `dist`, and a retry that re-ran codegen would restore the stale `dist`
+straight over the freshly generated output. Declaring `generated/**` as an
+input does not close this — turbo hashes inputs before the run, and the
+directory is gitignored, so on a fresh checkout it is still empty at the moment
+the hash is taken.

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,8 +48,13 @@ jobs:
           # outright; skipping is the behaviour this gate had before.
           changed=0
           if [ -n "${BEFORE}" ] && [ "${BEFORE}" != "0000000000000000000000000000000000000000" ]; then
-            if gh api --paginate "repos/${REPO}/compare/${BEFORE}...${SHA}" \
-              --jq '.files[].filename' | grep -qE '^(apps|infra)/api/'; then
+            # Fetch first, match second. Inside `if`, a failing gh api (rate
+            # limit, permissions, outage) would just read as "no API change"
+            # and skip the gate exactly when a release needs it; as its own
+            # command, set -e fails the step instead.
+            files=$(gh api --paginate "repos/${REPO}/compare/${BEFORE}...${SHA}" \
+              --jq '.files[].filename')
+            if printf '%s\n' "${files}" | grep -qE '^(apps|infra)/api/'; then
               changed=1
             fi
           fi

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,33 +33,40 @@ jobs:
         id: author
         run: echo "name=$(git log -1 --format='%an')" >> "$GITHUB_OUTPUT"
 
-      # Gateful merges the DAO APIs' OpenAPI specs into its own on every
+      # Gateful merges its upstreams' OpenAPI specs into its own on every
       # /docs/json request, so waiting on gateful's commit alone is not enough:
-      # gateful can be up-to-date while the DAO APIs (a slower, separately
-      # watched build) still serve the previous spec.
-      - name: Resolve the commit the DAO APIs should be serving
-        id: dao-api
+      # gateful can be up-to-date while a DAO API, the relayer or address
+      # enrichment (slower, separately watched builds) still serves the
+      # previous spec.
+      - name: Resolve the commits each upstream should be serving
+        id: upstreams
         run: |
           set -euo pipefail
-          # The newest commit on this branch that touched the paths Railway
-          # watches to rebuild the DAO API service — i.e. the newest commit
-          # those APIs can be running. First-parent, because that is the diff
-          # Railway itself sees for a push to this branch.
+          # For each service whose OpenAPI gateful merges into /docs/json: the
+          # newest commit that touched the paths Railway watches to rebuild it,
+          # plus every commit after that. First-parent, because that is the
+          # diff Railway itself sees for a push to this branch.
           #
-          # Deliberately not "did THIS push change the API": a non-API push
-          # landing while an API push is still deploying (concurrency cancels
-          # the earlier waiter) would answer "no" and skip the gate while the
-          # APIs still serve the pre-release spec. Resolving the commit instead
-          # of a yes/no keeps pointing at that API push until it is live.
-          api_sha=$(git log --first-parent -1 --format=%H -- apps/api infra/api)
-          # That commit *or newer*, as a set. Railway stamps a service with the
-          # head of the push that rebuilt it, which is only the same commit
-          # when the push carried exactly one commit — a rebase-merge or a
-          # multi-commit push stamps the head instead, and demanding equality
-          # would wait for a rebuild that already happened.
-          shas="$(git rev-list --first-parent "${api_sha}..HEAD" | tr '\n' ',')${api_sha}"
+          # Deliberately not "did THIS push change the service": a push that
+          # leaves it alone while an earlier push is still deploying it
+          # (concurrency cancels the earlier waiter) would answer "no" and skip
+          # the gate while the old spec is still being served. And "or newer"
+          # rather than an exact commit, because Railway stamps a service with
+          # the head of the push that rebuilt it — the same commit only when
+          # that push carried exactly one.
+          resolve() {
+            sha=$(git log --first-parent -1 --format=%H -- "$@")
+            printf '%s' "$(git rev-list --first-parent "${sha}..HEAD" | tr '\n' ',')${sha}"
+          }
+          shas=$(jq -cn \
+            --arg dao "$(resolve apps/api infra/api)" \
+            --arg relayer "$(resolve apps/relayer infra/relayer)" \
+            --arg enrichment "$(resolve apps/address-enrichment infra/address-enrichment)" \
+            '{"dao-api": ($dao | split(",")),
+              "relayer": ($relayer | split(",")),
+              "address-enrichment": ($enrichment | split(","))}')
           echo "shas=${shas}" >> "$GITHUB_OUTPUT"
-          echo "DAO APIs must be serving ${api_sha} or newer"
+          echo "${shas}" | jq -r 'to_entries[] | "\(.key) must be serving \(.value[-1]) or newer"'
 
       # `vercel deploy` builds the dashboard, which runs @anticapture/client
       # codegen against the live gateful spec. Wait for gateful to serve this
@@ -70,7 +77,7 @@ jobs:
         env:
           ANTICAPTURE_API_URL: ${{ secrets.GATEFUL_URL }}
           EXPECTED_GATEFUL_SHA: ${{ github.sha }}
-          EXPECTED_UPSTREAM_SHAS: ${{ steps.dao-api.outputs.shas }}
+          EXPECTED_UPSTREAM_SHAS: ${{ steps.upstreams.outputs.shas }}
 
       - name: Deploy to Vercel
         env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Full history: the DAO API commit resolved below can be many
+          # releases back, and a shallow clone would silently resolve to
+          # nothing and skip the gate.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -29,37 +34,32 @@ jobs:
         run: echo "name=$(git log -1 --format='%an')" >> "$GITHUB_OUTPUT"
 
       # Gateful merges the DAO APIs' OpenAPI specs into its own on every
-      # /docs/json request, so waiting on gateful's commit alone is not enough
-      # when this release changes those schemas: gateful can be up-to-date
-      # while the DAO APIs (a slower, separately watched build) still serve the
-      # previous spec. Mirror Railway's watchPatterns for the DAO API service
-      # to know whether to wait for them too.
-      - name: Detect DAO API changes
+      # /docs/json request, so waiting on gateful's commit alone is not enough:
+      # gateful can be up-to-date while the DAO APIs (a slower, separately
+      # watched build) still serve the previous spec.
+      - name: Resolve the commit the DAO APIs should be serving
         id: dao-api
-        env:
-          GH_TOKEN: ${{ github.token }}
-          BEFORE: ${{ github.event.before }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          # Unknown base (new branch / force push): fall back to not waiting.
-          # Waiting on APIs that may never rebuild would block the deploy
-          # outright; skipping is the behaviour this gate had before.
-          changed=0
-          if [ -n "${BEFORE}" ] && [ "${BEFORE}" != "0000000000000000000000000000000000000000" ]; then
-            # Fetch first, match second. Inside `if`, a failing gh api (rate
-            # limit, permissions, outage) would just read as "no API change"
-            # and skip the gate exactly when a release needs it; as its own
-            # command, set -e fails the step instead.
-            files=$(gh api --paginate "repos/${REPO}/compare/${BEFORE}...${SHA}" \
-              --jq '.files[].filename')
-            if printf '%s\n' "${files}" | grep -qE '^(apps|infra)/api/'; then
-              changed=1
-            fi
-          fi
-          echo "changed=${changed}" >> "$GITHUB_OUTPUT"
-          echo "DAO API rebuild expected: ${changed}"
+          # The newest commit on this branch that touched the paths Railway
+          # watches to rebuild the DAO API service — i.e. the newest commit
+          # those APIs can be running. First-parent, because that is the diff
+          # Railway itself sees for a push to this branch.
+          #
+          # Deliberately not "did THIS push change the API": a non-API push
+          # landing while an API push is still deploying (concurrency cancels
+          # the earlier waiter) would answer "no" and skip the gate while the
+          # APIs still serve the pre-release spec. Resolving the commit instead
+          # of a yes/no keeps pointing at that API push until it is live.
+          api_sha=$(git log --first-parent -1 --format=%H -- apps/api infra/api)
+          # That commit *or newer*, as a set. Railway stamps a service with the
+          # head of the push that rebuilt it, which is only the same commit
+          # when the push carried exactly one commit — a rebase-merge or a
+          # multi-commit push stamps the head instead, and demanding equality
+          # would wait for a rebuild that already happened.
+          shas="$(git rev-list --first-parent "${api_sha}..HEAD" | tr '\n' ',')${api_sha}"
+          echo "shas=${shas}" >> "$GITHUB_OUTPUT"
+          echo "DAO APIs must be serving ${api_sha} or newer"
 
       # `vercel deploy` builds the dashboard, which runs @anticapture/client
       # codegen against the live gateful spec. Wait for gateful to serve this
@@ -70,7 +70,7 @@ jobs:
         env:
           ANTICAPTURE_API_URL: ${{ secrets.GATEFUL_URL }}
           EXPECTED_GATEFUL_SHA: ${{ github.sha }}
-          REQUIRE_UPSTREAM_COMMIT: ${{ steps.dao-api.outputs.changed }}
+          EXPECTED_UPSTREAM_SHAS: ${{ steps.dao-api.outputs.shas }}
 
       - name: Deploy to Vercel
         env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,6 +28,34 @@ jobs:
         id: author
         run: echo "name=$(git log -1 --format='%an')" >> "$GITHUB_OUTPUT"
 
+      # Gateful merges the DAO APIs' OpenAPI specs into its own on every
+      # /docs/json request, so waiting on gateful's commit alone is not enough
+      # when this release changes those schemas: gateful can be up-to-date
+      # while the DAO APIs (a slower, separately watched build) still serve the
+      # previous spec. Mirror Railway's watchPatterns for the DAO API service
+      # to know whether to wait for them too.
+      - name: Detect DAO API changes
+        id: dao-api
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BEFORE: ${{ github.event.before }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Unknown base (new branch / force push): fall back to not waiting.
+          # Waiting on APIs that may never rebuild would block the deploy
+          # outright; skipping is the behaviour this gate had before.
+          changed=0
+          if [ -n "${BEFORE}" ] && [ "${BEFORE}" != "0000000000000000000000000000000000000000" ]; then
+            if gh api --paginate "repos/${REPO}/compare/${BEFORE}...${SHA}" \
+              --jq '.files[].filename' | grep -qE '^(apps|infra)/api/'; then
+              changed=1
+            fi
+          fi
+          echo "changed=${changed}" >> "$GITHUB_OUTPUT"
+          echo "DAO API rebuild expected: ${changed}"
+
       # `vercel deploy` builds the dashboard, which runs @anticapture/client
       # codegen against the live gateful spec. Wait for gateful to serve this
       # exact commit first, or codegen races the redeploy and fails with
@@ -37,6 +65,7 @@ jobs:
         env:
           ANTICAPTURE_API_URL: ${{ secrets.GATEFUL_URL }}
           EXPECTED_GATEFUL_SHA: ${{ github.sha }}
+          REQUIRE_UPSTREAM_COMMIT: ${{ steps.dao-api.outputs.changed }}
 
       - name: Deploy to Vercel
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -126,11 +126,38 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Full history: the per-upstream commits resolved below can be many
+          # releases back, and a shallow clone would resolve to nothing.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+
+      # Same reasoning as deploy.yaml: gateful merges its upstreams' OpenAPI
+      # into /docs/json live, so a preview whose gateful is up but whose
+      # relayer (or DAO API, or address enrichment) is still deploying serves
+      # an inconsistent spec, and the preview's codegen bakes it in.
+      - name: Resolve the commits each upstream should be serving
+        id: upstreams
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          resolve() {
+            sha=$(git log --first-parent -1 --format=%H "${HEAD_SHA}" -- "$@")
+            printf '%s' "$(git rev-list --first-parent "${sha}..${HEAD_SHA}" | tr '\n' ',')${sha}"
+          }
+          shas=$(jq -cn \
+            --arg dao "$(resolve apps/api infra/api)" \
+            --arg relayer "$(resolve apps/relayer infra/relayer)" \
+            --arg enrichment "$(resolve apps/address-enrichment infra/address-enrichment)" \
+            '{"dao-api": ($dao | split(",")),
+              "relayer": ($relayer | split(",")),
+              "address-enrichment": ($enrichment | split(","))}')
+          echo "shas=${shas}" >> "$GITHUB_OUTPUT"
 
       - name: Wait for preview gateful to be ready
         run: node scripts/wait-for-gateful.mjs
@@ -138,8 +165,11 @@ jobs:
           ANTICAPTURE_API_URL: ${{ needs.configure-vercel-preview.outputs.gateful_url }}
           # Trusted PRs target their own preview, so wait for the exact PR commit.
           # Untrusted PRs target shared dev Gateful (which serves a different
-          # commit), so only assert reachability — leave the SHA unset.
+          # commit), so only assert reachability — leave the SHA unset. The
+          # upstream check rides along with it: the script skips it entirely
+          # when there is no expected gateful commit.
           EXPECTED_GATEFUL_SHA: ${{ needs.configure-vercel-preview.outputs.trusted == 'true' && github.event.pull_request.head.sha || '' }}
+          EXPECTED_UPSTREAM_SHAS: ${{ needs.configure-vercel-preview.outputs.trusted == 'true' && steps.upstreams.outputs.shas || '' }}
 
   deploy-vercel-preview:
     name: Deploy Vercel preview

--- a/apps/address-enrichment/src/env.ts
+++ b/apps/address-enrichment/src/env.ts
@@ -14,6 +14,10 @@ const envSchema = z.object({
   ANTICAPTURE_API_URL: z.string().url().optional(),
   ENS_CACHE_TTL_MINUTES: z.coerce.number().default(60),
   PORT: z.coerce.number().default(3001),
+  // Injected by Railway. Reported on /health so gateful — which merges this
+  // service's OpenAPI paths and schemas into its own spec — can tell which
+  // release is answering. See scripts/wait-for-gateful.mjs.
+  RAILWAY_GIT_COMMIT_SHA: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/address-enrichment/src/index.ts
+++ b/apps/address-enrichment/src/index.ts
@@ -70,7 +70,11 @@ app.onError((err, c) => {
 
 // Health check
 app.get("/health", (c) => {
-  return c.json({ status: "ok", timestamp: new Date().toISOString() });
+  return c.json({
+    status: "ok",
+    timestamp: new Date().toISOString(),
+    commit: env.RAILWAY_GIT_COMMIT_SHA,
+  });
 });
 
 // Register controllers

--- a/apps/api/cmd/aave.ts
+++ b/apps/api/cmd/aave.ts
@@ -134,7 +134,11 @@ const pgClient = drizzle(env.DATABASE_URL, {
   casing: "snake_case",
 });
 
-health(app, new HealthService(new HealthRepositoryImpl(pgClient), daoClient));
+health(
+  app,
+  new HealthService(new HealthRepositoryImpl(pgClient), daoClient),
+  env.RAILWAY_GIT_COMMIT_SHA,
+);
 
 const daoCache = new DaoCache();
 

--- a/apps/api/cmd/index.ts
+++ b/apps/api/cmd/index.ts
@@ -190,7 +190,11 @@ const pgClient = drizzle({
   casing: "snake_case",
 });
 
-health(app, new HealthService(new HealthRepositoryImpl(pgClient), daoClient));
+health(
+  app,
+  new HealthService(new HealthRepositoryImpl(pgClient), daoClient),
+  env.RAILWAY_GIT_COMMIT_SHA,
+);
 
 const daoConfig = CONTRACT_ADDRESSES[env.DAO_ID];
 const { blockTime, tokenType } = daoConfig;

--- a/apps/api/src/controllers/health/index.ts
+++ b/apps/api/src/controllers/health/index.ts
@@ -8,6 +8,10 @@ const LivenessResponseSchema = z
     database: z.enum(["ok", "error"]).openapi({
       description: "Database connectivity status.",
     }),
+    commit: z.string().optional().openapi({
+      description:
+        "Git SHA this API is running. Gateful merges this API's OpenAPI schemas into its own spec, so a deploy that waits only on gateful can still read schemas from the previous API release — this is what makes that observable.",
+    }),
   })
   .openapi("LivenessResponse");
 
@@ -49,7 +53,7 @@ const HealthResponseSchema = z
   })
   .openapi("HealthResponse");
 
-export function health(app: Hono, service: HealthService) {
+export function health(app: Hono, service: HealthService, commitSha?: string) {
   app.openapi(
     createRoute({
       method: "get",
@@ -81,7 +85,10 @@ export function health(app: Hono, service: HealthService) {
     }),
     async (context) => {
       const database = await service.getLiveness();
-      return context.json({ database }, database === "error" ? 503 : 200);
+      return context.json(
+        { database, commit: commitSha },
+        database === "error" ? 503 : 200,
+      );
     },
   );
 

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -51,6 +51,11 @@ const envSchema = z
     REDIS_URL: z.string().optional(),
     PORT: z.coerce.number().default(42069),
 
+    // Injected by Railway. Reported on /health so gateful (and the deploy
+    // gate behind it) can tell which release is actually serving the
+    // OpenAPI schemas gateful merges into its spec.
+    RAILWAY_GIT_COMMIT_SHA: z.string().optional(),
+
     // Revenue (ENS-only) Dune configuration
     REVENUE_DUNE_API_KEY: z.string().optional(),
     REVENUE_DUNE_ACTIONS_QUERY_ID: duneQueryId.optional(),

--- a/apps/gateful/src/health/route.test.ts
+++ b/apps/gateful/src/health/route.test.ts
@@ -15,6 +15,7 @@ const HealthResponseSchema = z.object({
       circuit: z.enum(["CLOSED", "OPEN", "HALF_OPEN"]),
       nextRetryIn: z.number().int().optional(),
       error: z.string().optional(),
+      commit: z.string().optional(),
     }),
   ),
 });
@@ -79,6 +80,42 @@ describe("gateway health route", () => {
         signal: expect.any(AbortSignal),
       },
     );
+  });
+
+  // The deploy gate reads this: gateful serves DAO API schemas in /docs/json,
+  // so "which release answered" has to travel with "did it answer".
+  it("surfaces the commit a DAO API reports, and copes without one", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockImplementation((url: string) =>
+          Promise.resolve(
+            url.includes("api.example")
+              ? new Response(
+                  JSON.stringify({ database: "ok", commit: "sha-1" }),
+                )
+              : new Response("pong"),
+          ),
+        ),
+    );
+
+    const { app } = appWithHealth({
+      daoApis: new Map([["ens", "http://api.example"]]),
+      daoRelayers: new Map([["ens", "http://relayer.example"]]),
+    });
+
+    const body = await readHealthResponse(await app.request("/health"));
+
+    expect(body.upstreams.ens).toEqual({
+      status: "ok",
+      circuit: "CLOSED",
+      commit: "sha-1",
+    });
+    expect(body.upstreams["relayer:ens"]).toEqual({
+      status: "ok",
+      circuit: "CLOSED",
+    });
   });
 
   it("returns degraded when a DAO API returns an error", async () => {

--- a/apps/gateful/src/health/route.test.ts
+++ b/apps/gateful/src/health/route.test.ts
@@ -11,6 +11,13 @@ const HealthResponseSchema = z.object({
   upstreams: z.record(
     z.string(),
     z.object({
+      kind: z.enum([
+        "dao-api",
+        "relayer",
+        "address-enrichment",
+        "token-service",
+        "unknown",
+      ]),
       status: z.enum(["ok", "down"]),
       circuit: z.enum(["CLOSED", "OPEN", "HALF_OPEN"]),
       nextRetryIn: z.number().int().optional(),
@@ -63,9 +70,13 @@ describe("gateway health route", () => {
       status: "ok",
       commit: "abc123",
       upstreams: {
-        ens: { status: "ok", circuit: "CLOSED" },
-        "relayer:ens": { status: "ok", circuit: "CLOSED" },
-        "address-enrichment": { status: "ok", circuit: "CLOSED" },
+        ens: { kind: "dao-api", status: "ok", circuit: "CLOSED" },
+        "relayer:ens": { kind: "relayer", status: "ok", circuit: "CLOSED" },
+        "address-enrichment": {
+          kind: "address-enrichment",
+          status: "ok",
+          circuit: "CLOSED",
+        },
       },
     });
     expect(fetch).toHaveBeenCalledWith("http://api.example/health", {
@@ -107,12 +118,16 @@ describe("gateway health route", () => {
 
     const body = await readHealthResponse(await app.request("/health"));
 
+    // `kind` is what lets the deploy gate demand a commit from DAO APIs while
+    // exempting everything else.
     expect(body.upstreams.ens).toEqual({
+      kind: "dao-api",
       status: "ok",
       circuit: "CLOSED",
       commit: "sha-1",
     });
     expect(body.upstreams["relayer:ens"]).toEqual({
+      kind: "relayer",
       status: "ok",
       circuit: "CLOSED",
     });

--- a/apps/gateful/src/health/route.ts
+++ b/apps/gateful/src/health/route.ts
@@ -6,7 +6,23 @@ import type { CircuitBreakerRegistry } from "../shared/circuit-breaker-registry"
 
 const HEALTH_PROBE_TIMEOUT_MS = 3_000;
 
+// Which upstream this is. The deploy gate needs it to tell a DAO API — whose
+// OpenAPI schemas gateful merges into /docs/json, and which must therefore be
+// on the release before the SDK is generated — from upstreams that merely have
+// to be reachable.
+const UpstreamKindSchema = z.enum([
+  "dao-api",
+  "relayer",
+  "address-enrichment",
+  "token-service",
+  // Defensive: probeTarget catches its own failures, so this is only reachable
+  // if the probe promise itself rejects. Reported as down, which already fails
+  // the whole response.
+  "unknown",
+]);
+
 const UpstreamStatusSchema = z.object({
+  kind: UpstreamKindSchema,
   status: z.enum(["ok", "down"]),
   circuit: z.enum(["CLOSED", "OPEN", "HALF_OPEN"]),
   nextRetryIn: z.number().int().optional(),
@@ -64,8 +80,10 @@ type ProbeTarget = {
   name: string;
   baseUrl: string;
   circuitKey: string;
+  kind: UpstreamKind;
 };
 
+type UpstreamKind = z.infer<typeof UpstreamKindSchema>;
 type UpstreamStatus = z.infer<typeof UpstreamStatusSchema>;
 type HealthResponse = z.infer<typeof HealthResponseSchema>;
 
@@ -84,7 +102,7 @@ function buildProbeTargets(opts: HealthOptions): ProbeTarget[] {
   const targets: ProbeTarget[] = [];
 
   for (const [dao, baseUrl] of opts.daoApis) {
-    targets.push({ name: dao, baseUrl, circuitKey: dao });
+    targets.push({ name: dao, baseUrl, circuitKey: dao, kind: "dao-api" });
   }
 
   for (const [dao, baseUrl] of opts.daoRelayers) {
@@ -92,6 +110,7 @@ function buildProbeTargets(opts: HealthOptions): ProbeTarget[] {
       name: `relayer:${dao}`,
       baseUrl,
       circuitKey: `relayer:${dao}`,
+      kind: "relayer",
     });
   }
 
@@ -100,6 +119,7 @@ function buildProbeTargets(opts: HealthOptions): ProbeTarget[] {
       name: "address-enrichment",
       baseUrl: opts.addressEnrichmentUrl,
       circuitKey: "address-enrichment",
+      kind: "address-enrichment",
     });
   }
 
@@ -111,6 +131,7 @@ function buildProbeTargets(opts: HealthOptions): ProbeTarget[] {
       name: "authful",
       baseUrl: opts.tokenServiceUrl,
       circuitKey: "authful",
+      kind: "token-service",
     });
   }
 
@@ -147,7 +168,12 @@ async function probeTarget(
   if (breaker.state === "OPEN") {
     return [
       target.name,
-      { status: "down", ...buildCircuit(breaker), error: "circuit open" },
+      {
+        kind: target.kind,
+        status: "down",
+        ...buildCircuit(breaker),
+        error: "circuit open",
+      },
     ];
   }
 
@@ -165,6 +191,7 @@ async function probeTarget(
     return [
       target.name,
       {
+        kind: target.kind,
         status: "ok",
         ...buildCircuit(breaker),
         ...(commit ? { commit } : {}),
@@ -174,6 +201,7 @@ async function probeTarget(
     return [
       target.name,
       {
+        kind: target.kind,
         status: "down",
         ...buildCircuit(breaker),
         error: err instanceof Error ? err.message : "health probe failed",
@@ -199,6 +227,7 @@ export function health(
       return [
         "unknown",
         {
+          kind: "unknown",
           status: "down",
           circuit: "CLOSED",
           error: "health probe failed",

--- a/apps/gateful/src/health/route.ts
+++ b/apps/gateful/src/health/route.ts
@@ -11,6 +11,11 @@ const UpstreamStatusSchema = z.object({
   circuit: z.enum(["CLOSED", "OPEN", "HALF_OPEN"]),
   nextRetryIn: z.number().int().optional(),
   error: z.string().optional(),
+  // Absent for upstreams that don't report one. `status: "ok"` says an
+  // upstream answers; this says which release is answering — the DAO APIs
+  // own the schemas merged into /docs/json, so a deploy gate that only sees
+  // gateful's own commit can still read the previous release's spec.
+  commit: z.string().optional(),
 });
 
 const HealthResponseSchema = z.object({
@@ -112,6 +117,22 @@ function buildProbeTargets(opts: HealthOptions): ProbeTarget[] {
   return targets;
 }
 
+// A probe body that isn't JSON, or carries no commit, is not a failure: the
+// upstream answered, which is what `status` reports. Only the commit is lost.
+async function readUpstreamCommit(res: Response): Promise<string | undefined> {
+  try {
+    const body: unknown = await res.json();
+    const commit =
+      typeof body === "object" && body !== null
+        ? (body as { commit?: unknown }).commit
+        : undefined;
+
+    return typeof commit === "string" && commit ? commit : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function probeTarget(
   target: ProbeTarget,
   registry: CircuitBreakerRegistry,
@@ -139,11 +160,14 @@ async function probeTarget(
       throw new Error(`${target.name} /health returned ${res.status}`);
     }
 
+    const commit = await readUpstreamCommit(res);
+
     return [
       target.name,
       {
         status: "ok",
         ...buildCircuit(breaker),
+        ...(commit ? { commit } : {}),
       },
     ];
   } catch (err) {

--- a/apps/relayer/src/controllers/health.ts
+++ b/apps/relayer/src/controllers/health.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono as Hono, createRoute } from "@hono/zod-openapi";
 
+import { env } from "@/env";
 import { HealthResponseSchema } from "@/schemas/health";
 
 export function health(app: Hono) {
@@ -19,6 +20,10 @@ export function health(app: Hono) {
         },
       },
     }),
-    async (c) => c.json({ status: "ok" as const }, 200),
+    async (c) =>
+      c.json(
+        { status: "ok" as const, commit: env.RAILWAY_GIT_COMMIT_SHA },
+        200,
+      ),
   );
 }

--- a/apps/relayer/src/env.ts
+++ b/apps/relayer/src/env.ts
@@ -52,6 +52,11 @@ const envSchema = z.object({
 
   PORT: z.coerce.number().default(3002),
 
+  // Injected by Railway. Reported on /health so gateful — which merges this
+  // service's OpenAPI paths and schemas into its own spec — can tell which
+  // release is answering. See scripts/wait-for-gateful.mjs.
+  RAILWAY_GIT_COMMIT_SHA: z.string().optional(),
+
   OTEL_EXPORTER_OTLP_ENDPOINT: z.url().optional(),
 });
 

--- a/apps/relayer/src/schemas/health.ts
+++ b/apps/relayer/src/schemas/health.ts
@@ -3,5 +3,9 @@ import { z } from "@hono/zod-openapi";
 export const HealthResponseSchema = z
   .object({
     status: z.literal("ok"),
+    commit: z.string().optional().openapi({
+      description:
+        "Git SHA this relayer is running. Gateful merges this service's OpenAPI paths and schemas into its own spec, so the deploy gate uses this to tell whether the release is live here yet.",
+    }),
   })
   .openapi("RelayerHealthResponse");

--- a/scripts/wait-for-gateful.mjs
+++ b/scripts/wait-for-gateful.mjs
@@ -65,7 +65,21 @@ export const fetchGatefulHealth = async (
   };
 };
 
-export const isGatefulReady = (health, expectedSha) => {
+// Upstreams still serving a different commit than the one we're waiting for.
+//
+// Gateful builds /docs/json by merging the DAO APIs' specs live on every
+// request, so gateful reporting the new commit says nothing about the schemas
+// it will serve — the DAO APIs redeploy on their own (slower) schedule. An
+// upstream that reports no commit is skipped, not treated as stale: relayers,
+// address enrichment and authful don't report one, and neither does a DAO API
+// deployed before this field existed. Skipping them keeps the gate from
+// deadlocking on services this release never rebuilds.
+export const staleUpstreams = (health, expectedSha) =>
+  Object.entries(health.body?.upstreams ?? {})
+    .filter(([, upstream]) => upstream?.commit && upstream.commit !== expectedSha)
+    .map(([name]) => name);
+
+export const isGatefulReady = (health, expectedSha, requireUpstreamCommit) => {
   if (health.status !== 200) {
     return false;
   }
@@ -74,12 +88,19 @@ export const isGatefulReady = (health, expectedSha) => {
     return true;
   }
 
-  return health.body?.commit === expectedSha;
+  if (health.body?.commit !== expectedSha) {
+    return false;
+  }
+
+  return requireUpstreamCommit
+    ? staleUpstreams(health, expectedSha).length === 0
+    : true;
 };
 
 export const waitForGateful = async ({
   baseUrl,
   expectedSha,
+  requireUpstreamCommit = false,
   timeoutMs = DEFAULT_TIMEOUT_MS,
   intervalMs = DEFAULT_INTERVAL_MS,
   requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
@@ -105,7 +126,7 @@ export const waitForGateful = async ({
       );
       lastError = undefined;
 
-      if (isGatefulReady(lastHealth, expectedSha)) {
+      if (isGatefulReady(lastHealth, expectedSha, requireUpstreamCommit)) {
         logger.log(
           expectedSha
             ? `Gateful ready after attempt ${attempt}: commit ${expectedSha}`
@@ -115,9 +136,15 @@ export const waitForGateful = async ({
         return { ready: true, attempt, lastHealth };
       }
 
+      const stale = requireUpstreamCommit
+        ? staleUpstreams(lastHealth, expectedSha)
+        : [];
+
       logger.log(
         `attempt ${attempt}: HTTP ${lastHealth.status}, commit ${
           lastHealth.body?.commit ?? "<missing>"
+        }${
+          stale.length > 0 ? `, stale upstreams: ${stale.join(", ")}` : ""
         }; waiting for ${expectedSha}`,
       );
     } catch (error) {
@@ -151,9 +178,16 @@ const main = async () => {
     DEFAULT_REQUEST_TIMEOUT_MS,
   );
 
+  // Set by the caller when the release rebuilds the DAO APIs (i.e. it touched
+  // the paths Railway watches for them). Off otherwise: services this release
+  // doesn't rebuild keep serving an older commit forever, and waiting on them
+  // would block every deploy that leaves them alone.
+  const requireUpstreamCommit = process.env.REQUIRE_UPSTREAM_COMMIT === "1";
+
   const result = await waitForGateful({
     baseUrl,
     expectedSha,
+    requireUpstreamCommit,
     timeoutMs,
     intervalMs,
     requestTimeoutMs,
@@ -185,6 +219,13 @@ const main = async () => {
       : String(result.lastError)
     : `last health: HTTP ${result.lastHealth?.status ?? "<none>"}, commit ${
         result.lastHealth?.body?.commit ?? "<missing>"
+      }${
+        requireUpstreamCommit && result.lastHealth
+          ? `, stale upstreams: ${
+              staleUpstreams(result.lastHealth, expectedSha).join(", ") ||
+              "<none>"
+            }`
+          : ""
       }`;
 
   throw new Error(

--- a/scripts/wait-for-gateful.mjs
+++ b/scripts/wait-for-gateful.mjs
@@ -65,18 +65,24 @@ export const fetchGatefulHealth = async (
   };
 };
 
-// Upstreams still serving a different commit than the one we're waiting for.
+// Upstreams not yet serving the commit we're waiting for.
 //
 // Gateful builds /docs/json by merging the DAO APIs' specs live on every
 // request, so gateful reporting the new commit says nothing about the schemas
-// it will serve — the DAO APIs redeploy on their own (slower) schedule. An
-// upstream that reports no commit is skipped, not treated as stale: relayers,
-// address enrichment and authful don't report one, and neither does a DAO API
-// deployed before this field existed. Skipping them keeps the gate from
-// deadlocking on services this release never rebuilds.
+// it will serve — the DAO APIs redeploy on their own (slower) schedule.
+//
+// A DAO API is stale unless it reports exactly this commit: the caller only
+// asks for this check when the release rebuilds them, so "no commit reported"
+// means the previous release is still up (it predates the field), not that
+// there is nothing to wait for. Every other upstream kind — relayers, address
+// enrichment, authful — never reports a commit and only has to be reachable.
 export const staleUpstreams = (health, expectedSha) =>
   Object.entries(health.body?.upstreams ?? {})
-    .filter(([, upstream]) => upstream?.commit && upstream.commit !== expectedSha)
+    .filter(([, upstream]) =>
+      upstream?.kind === "dao-api"
+        ? upstream.commit !== expectedSha
+        : upstream?.commit && upstream.commit !== expectedSha,
+    )
     .map(([name]) => name);
 
 export const isGatefulReady = (health, expectedSha, requireUpstreamCommit) => {

--- a/scripts/wait-for-gateful.mjs
+++ b/scripts/wait-for-gateful.mjs
@@ -65,27 +65,37 @@ export const fetchGatefulHealth = async (
   };
 };
 
-// Upstreams not yet serving the commit we're waiting for.
+// DAO APIs not yet serving the release whose schemas we're about to read.
 //
 // Gateful builds /docs/json by merging the DAO APIs' specs live on every
 // request, so gateful reporting the new commit says nothing about the schemas
-// it will serve — the DAO APIs redeploy on their own (slower) schedule.
+// it will serve — the DAO APIs rebuild only when a push touches their watched
+// paths, and take longer when it does.
 //
-// A DAO API is stale unless it reports exactly this commit: the caller only
-// asks for this check when the release rebuilds them, so "no commit reported"
-// means the previous release is still up (it predates the field), not that
-// there is nothing to wait for. Every other upstream kind — relayers, address
-// enrichment, authful — never reports a commit and only has to be reachable.
-export const staleUpstreams = (health, expectedSha) =>
+// `expectedUpstreamShas` is therefore NOT this deploy's commit. It is the last
+// commit that rebuilt the DAO APIs, plus everything after it — "that commit or
+// newer", because Railway stamps a service with the head of the push that
+// rebuilt it, which is a later commit whenever a push carries more than one.
+// On a release that doesn't touch the APIs the set starts before HEAD and they
+// already satisfy it; on one that does, only the new release satisfies it. It
+// also survives a superseding push: a non-API push landing on top of an API
+// push still resolves to that API push, so the gate keeps waiting for it
+// rather than concluding there is nothing to wait for.
+//
+// A DAO API reporting no commit is stale, not exempt — that is the previous
+// release still answering, from before this field existed. Other upstream
+// kinds (relayers, address enrichment, authful) contribute no schemas that
+// codegen can miss and only have to be reachable.
+export const staleUpstreams = (health, expectedUpstreamShas = []) =>
   Object.entries(health.body?.upstreams ?? {})
-    .filter(([, upstream]) =>
-      upstream?.kind === "dao-api"
-        ? upstream.commit !== expectedSha
-        : upstream?.commit && upstream.commit !== expectedSha,
+    .filter(
+      ([, upstream]) =>
+        upstream?.kind === "dao-api" &&
+        !expectedUpstreamShas.includes(upstream.commit),
     )
     .map(([name]) => name);
 
-export const isGatefulReady = (health, expectedSha, requireUpstreamCommit) => {
+export const isGatefulReady = (health, expectedSha, expectedUpstreamShas) => {
   if (health.status !== 200) {
     return false;
   }
@@ -98,15 +108,15 @@ export const isGatefulReady = (health, expectedSha, requireUpstreamCommit) => {
     return false;
   }
 
-  return requireUpstreamCommit
-    ? staleUpstreams(health, expectedSha).length === 0
+  return expectedUpstreamShas?.length
+    ? staleUpstreams(health, expectedUpstreamShas).length === 0
     : true;
 };
 
 export const waitForGateful = async ({
   baseUrl,
   expectedSha,
-  requireUpstreamCommit = false,
+  expectedUpstreamShas,
   timeoutMs = DEFAULT_TIMEOUT_MS,
   intervalMs = DEFAULT_INTERVAL_MS,
   requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
@@ -132,7 +142,7 @@ export const waitForGateful = async ({
       );
       lastError = undefined;
 
-      if (isGatefulReady(lastHealth, expectedSha, requireUpstreamCommit)) {
+      if (isGatefulReady(lastHealth, expectedSha, expectedUpstreamShas)) {
         logger.log(
           expectedSha
             ? `Gateful ready after attempt ${attempt}: commit ${expectedSha}`
@@ -142,15 +152,19 @@ export const waitForGateful = async ({
         return { ready: true, attempt, lastHealth };
       }
 
-      const stale = requireUpstreamCommit
-        ? staleUpstreams(lastHealth, expectedSha)
+      const stale = expectedUpstreamShas?.length
+        ? staleUpstreams(lastHealth, expectedUpstreamShas)
         : [];
 
       logger.log(
         `attempt ${attempt}: HTTP ${lastHealth.status}, commit ${
           lastHealth.body?.commit ?? "<missing>"
         }${
-          stale.length > 0 ? `, stale upstreams: ${stale.join(", ")}` : ""
+          stale.length > 0
+            ? `, DAO APIs behind ${expectedUpstreamShas.at(-1)}: ${stale.join(
+                ", ",
+              )}`
+            : ""
         }; waiting for ${expectedSha}`,
       );
     } catch (error) {
@@ -184,16 +198,20 @@ const main = async () => {
     DEFAULT_REQUEST_TIMEOUT_MS,
   );
 
-  // Set by the caller when the release rebuilds the DAO APIs (i.e. it touched
-  // the paths Railway watches for them). Off otherwise: services this release
-  // doesn't rebuild keep serving an older commit forever, and waiting on them
-  // would block every deploy that leaves them alone.
-  const requireUpstreamCommit = process.env.REQUIRE_UPSTREAM_COMMIT === "1";
+  // Commits a DAO API may report — the one that last rebuilt them, and every
+  // commit after it (see staleUpstreams). Unset means "don't check them",
+  // which is what PR previews do.
+  const expectedUpstreamShas = (
+    readNonEmptyValue(process.env.EXPECTED_UPSTREAM_SHAS) ?? ""
+  )
+    .split(",")
+    .map((sha) => sha.trim())
+    .filter(Boolean);
 
   const result = await waitForGateful({
     baseUrl,
     expectedSha,
-    requireUpstreamCommit,
+    expectedUpstreamShas,
     timeoutMs,
     intervalMs,
     requestTimeoutMs,
@@ -226,10 +244,11 @@ const main = async () => {
     : `last health: HTTP ${result.lastHealth?.status ?? "<none>"}, commit ${
         result.lastHealth?.body?.commit ?? "<missing>"
       }${
-        requireUpstreamCommit && result.lastHealth
-          ? `, stale upstreams: ${
-              staleUpstreams(result.lastHealth, expectedSha).join(", ") ||
-              "<none>"
+        expectedUpstreamShas.length > 0 && result.lastHealth
+          ? `, DAO APIs behind ${expectedUpstreamShas.at(-1)}: ${
+              staleUpstreams(result.lastHealth, expectedUpstreamShas).join(
+                ", ",
+              ) || "<none>"
             }`
           : ""
       }`;

--- a/scripts/wait-for-gateful.mjs
+++ b/scripts/wait-for-gateful.mjs
@@ -65,37 +65,40 @@ export const fetchGatefulHealth = async (
   };
 };
 
-// DAO APIs not yet serving the release whose schemas we're about to read.
+// Upstreams not yet serving the release whose schemas we're about to read.
 //
-// Gateful builds /docs/json by merging the DAO APIs' specs live on every
-// request, so gateful reporting the new commit says nothing about the schemas
-// it will serve — the DAO APIs rebuild only when a push touches their watched
-// paths, and take longer when it does.
+// Gateful builds /docs/json by merging its upstreams' specs live on every
+// request — DAO APIs, the relayer and address enrichment all contribute paths
+// and schemas (see mergeUpstreamDocs). So gateful reporting the new commit
+// says nothing about the spec it will serve: those services rebuild only when
+// a push touches their own watched paths, and take longer when it does.
 //
-// `expectedUpstreamShas` is therefore NOT this deploy's commit. It is the last
-// commit that rebuilt the DAO APIs, plus everything after it — "that commit or
-// newer", because Railway stamps a service with the head of the push that
-// rebuilt it, which is a later commit whenever a push carries more than one.
-// On a release that doesn't touch the APIs the set starts before HEAD and they
-// already satisfy it; on one that does, only the new release satisfies it. It
-// also survives a superseding push: a non-API push landing on top of an API
-// push still resolves to that API push, so the gate keeps waiting for it
-// rather than concluding there is nothing to wait for.
+// `expectedShasByKind` maps an upstream kind to the commits it may report: the
+// last commit that touched that service's watched paths, plus everything after
+// it. "That commit or newer", because Railway stamps a service with the head
+// of the push that rebuilt it, which is a later commit whenever a push carries
+// more than one. A release that doesn't touch a service resolves to a commit
+// it already satisfies; one that does resolves to the release itself. It also
+// survives a superseding push: a push that leaves a service alone still
+// resolves to the last push that changed it, so the gate keeps waiting for
+// that one rather than concluding there is nothing to wait for.
 //
-// A DAO API reporting no commit is stale, not exempt — that is the previous
-// release still answering, from before this field existed. Other upstream
-// kinds (relayers, address enrichment, authful) contribute no schemas that
-// codegen can miss and only have to be reachable.
-export const staleUpstreams = (health, expectedUpstreamShas = []) =>
+// An upstream reporting no commit is stale, not exempt — that is the previous
+// release still answering, from before it reported one. That can't deadlock:
+// teaching a service to report its commit necessarily touches its own watched
+// paths, so the release that adds it is also the release that rebuilds it.
+//
+// A kind absent from the map (authful, whose spec is not merged) is not
+// checked at all; it only has to be reachable.
+export const staleUpstreams = (health, expectedShasByKind = {}) =>
   Object.entries(health.body?.upstreams ?? {})
-    .filter(
-      ([, upstream]) =>
-        upstream?.kind === "dao-api" &&
-        !expectedUpstreamShas.includes(upstream.commit),
-    )
+    .filter(([, upstream]) => {
+      const accepted = expectedShasByKind[upstream?.kind];
+      return accepted?.length ? !accepted.includes(upstream.commit) : false;
+    })
     .map(([name]) => name);
 
-export const isGatefulReady = (health, expectedSha, expectedUpstreamShas) => {
+export const isGatefulReady = (health, expectedSha, expectedShasByKind) => {
   if (health.status !== 200) {
     return false;
   }
@@ -108,15 +111,13 @@ export const isGatefulReady = (health, expectedSha, expectedUpstreamShas) => {
     return false;
   }
 
-  return expectedUpstreamShas?.length
-    ? staleUpstreams(health, expectedUpstreamShas).length === 0
-    : true;
+  return staleUpstreams(health, expectedShasByKind).length === 0;
 };
 
 export const waitForGateful = async ({
   baseUrl,
   expectedSha,
-  expectedUpstreamShas,
+  expectedShasByKind,
   timeoutMs = DEFAULT_TIMEOUT_MS,
   intervalMs = DEFAULT_INTERVAL_MS,
   requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
@@ -142,7 +143,7 @@ export const waitForGateful = async ({
       );
       lastError = undefined;
 
-      if (isGatefulReady(lastHealth, expectedSha, expectedUpstreamShas)) {
+      if (isGatefulReady(lastHealth, expectedSha, expectedShasByKind)) {
         logger.log(
           expectedSha
             ? `Gateful ready after attempt ${attempt}: commit ${expectedSha}`
@@ -152,18 +153,14 @@ export const waitForGateful = async ({
         return { ready: true, attempt, lastHealth };
       }
 
-      const stale = expectedUpstreamShas?.length
-        ? staleUpstreams(lastHealth, expectedUpstreamShas)
-        : [];
+      const stale = staleUpstreams(lastHealth, expectedShasByKind);
 
       logger.log(
         `attempt ${attempt}: HTTP ${lastHealth.status}, commit ${
           lastHealth.body?.commit ?? "<missing>"
         }${
           stale.length > 0
-            ? `, DAO APIs behind ${expectedUpstreamShas.at(-1)}: ${stale.join(
-                ", ",
-              )}`
+            ? `, upstreams still on an older release: ${stale.join(", ")}`
             : ""
         }; waiting for ${expectedSha}`,
       );
@@ -198,20 +195,16 @@ const main = async () => {
     DEFAULT_REQUEST_TIMEOUT_MS,
   );
 
-  // Commits a DAO API may report — the one that last rebuilt them, and every
-  // commit after it (see staleUpstreams). Unset means "don't check them",
-  // which is what PR previews do.
-  const expectedUpstreamShas = (
-    readNonEmptyValue(process.env.EXPECTED_UPSTREAM_SHAS) ?? ""
-  )
-    .split(",")
-    .map((sha) => sha.trim())
-    .filter(Boolean);
+  // {kind: [sha, ...]} — the commits each upstream kind may report (see
+  // staleUpstreams). Unset means "check nothing", which is what PR previews do.
+  const expectedShasByKind = JSON.parse(
+    readNonEmptyValue(process.env.EXPECTED_UPSTREAM_SHAS) ?? "{}",
+  );
 
   const result = await waitForGateful({
     baseUrl,
     expectedSha,
-    expectedUpstreamShas,
+    expectedShasByKind,
     timeoutMs,
     intervalMs,
     requestTimeoutMs,
@@ -244,11 +237,10 @@ const main = async () => {
     : `last health: HTTP ${result.lastHealth?.status ?? "<none>"}, commit ${
         result.lastHealth?.body?.commit ?? "<missing>"
       }${
-        expectedUpstreamShas.length > 0 && result.lastHealth
-          ? `, DAO APIs behind ${expectedUpstreamShas.at(-1)}: ${
-              staleUpstreams(result.lastHealth, expectedUpstreamShas).join(
-                ", ",
-              ) || "<none>"
+        result.lastHealth
+          ? `, upstreams still on an older release: ${
+              staleUpstreams(result.lastHealth, expectedShasByKind).join(", ") ||
+              "<none>"
             }`
           : ""
       }`;

--- a/scripts/wait-for-gateful.test.mjs
+++ b/scripts/wait-for-gateful.test.mjs
@@ -60,7 +60,7 @@ test("isGatefulReady requires the matching commit when expected", () => {
 
 // The failure this guards: gateful on the new commit, ens-api 11s behind it,
 // codegen reading the previous release's merged spec.
-test("isGatefulReady waits for upstream commits only when required", () => {
+test("isGatefulReady checks DAO APIs only when upstream shas are given", () => {
   const health = {
     status: 200,
     body: {
@@ -72,9 +72,9 @@ test("isGatefulReady waits for upstream commits only when required", () => {
     },
   };
 
-  assert.equal(isGatefulReady(health, "new", true), false);
-  assert.equal(isGatefulReady(health, "new", false), true);
-  assert.deepEqual(staleUpstreams(health, "new"), ["ens"]);
+  assert.equal(isGatefulReady(health, "new", ["new"]), false);
+  assert.equal(isGatefulReady(health, "new", []), true);
+  assert.deepEqual(staleUpstreams(health, ["new"]), ["ens"]);
 });
 
 test("a DAO API reporting no commit is stale, not exempt", () => {
@@ -89,8 +89,46 @@ test("a DAO API reporting no commit is stale, not exempt", () => {
     },
   };
 
-  assert.equal(isGatefulReady(health, "new", true), false);
-  assert.deepEqual(staleUpstreams(health, "new"), ["ens"]);
+  assert.equal(isGatefulReady(health, "new", ["new"]), false);
+  assert.deepEqual(staleUpstreams(health, ["new"]), ["ens"]);
+});
+
+test("a release that doesn't rebuild the DAO APIs passes on their older commit", () => {
+  // The APIs sit on the last commit that touched them, which is in the
+  // accepted set — demanding HEAD would wait for a rebuild that is never
+  // going to happen.
+  const health = {
+    status: 200,
+    body: {
+      commit: "head",
+      upstreams: { ens: { kind: "dao-api", status: "ok", commit: "api-push" } },
+    },
+  };
+
+  assert.equal(isGatefulReady(health, "head", ["head", "api-push"]), true);
+});
+
+test("a non-API push superseding an in-flight API push still waits", () => {
+  // Push A touches the API, push B doesn't and cancels A's waiter. B resolves
+  // the same accepted set (A and newer), so the gate keeps waiting while the
+  // APIs finish deploying A instead of reading their pre-A spec.
+  const deploying = {
+    status: 200,
+    body: {
+      commit: "B",
+      upstreams: { ens: { kind: "dao-api", status: "ok", commit: "pre-A" } },
+    },
+  };
+  const settled = {
+    status: 200,
+    body: {
+      commit: "B",
+      upstreams: { ens: { kind: "dao-api", status: "ok", commit: "A" } },
+    },
+  };
+
+  assert.equal(isGatefulReady(deploying, "B", ["B", "A"]), false);
+  assert.equal(isGatefulReady(settled, "B", ["B", "A"]), true);
 });
 
 test("upstreams that aren't DAO APIs never block the gate", () => {
@@ -109,11 +147,11 @@ test("upstreams that aren't DAO APIs never block the gate", () => {
     },
   };
 
-  assert.equal(isGatefulReady(health, "new", true), true);
-  assert.deepEqual(staleUpstreams(health, "new"), []);
+  assert.equal(isGatefulReady(health, "new", ["new"]), true);
+  assert.deepEqual(staleUpstreams(health, ["new"]), []);
 });
 
-test("waitForGateful polls until every upstream serves the commit", async () => {
+test("waitForGateful polls until every DAO API serves the commit", async () => {
   const responses = [
     jsonResponse(200, {
       commit: "new",
@@ -129,7 +167,7 @@ test("waitForGateful polls until every upstream serves the commit", async () => 
   const result = await waitForGateful({
     baseUrl: "https://gateful.example.com",
     expectedSha: "new",
-    requireUpstreamCommit: true,
+    expectedUpstreamShas: ["new"],
     timeoutMs: 100,
     intervalMs: 10,
     fetchImpl: async () => responses.shift(),

--- a/scripts/wait-for-gateful.test.mjs
+++ b/scripts/wait-for-gateful.test.mjs
@@ -66,8 +66,8 @@ test("isGatefulReady waits for upstream commits only when required", () => {
     body: {
       commit: "new",
       upstreams: {
-        ens: { status: "ok", commit: "old" },
-        uni: { status: "ok", commit: "new" },
+        ens: { kind: "dao-api", status: "ok", commit: "old" },
+        uni: { kind: "dao-api", status: "ok", commit: "new" },
       },
     },
   };
@@ -77,18 +77,34 @@ test("isGatefulReady waits for upstream commits only when required", () => {
   assert.deepEqual(staleUpstreams(health, "new"), ["ens"]);
 });
 
-test("upstreams that report no commit never block the gate", () => {
-  // Relayers, address enrichment and authful report none, and neither does a
-  // DAO API deployed before the field existed. Blocking on them would stall
-  // every release that doesn't rebuild them.
+test("a DAO API reporting no commit is stale, not exempt", () => {
+  // The rollout case: the field ships in the same release, so the still-old
+  // API omits it. Reading that as "nothing to wait for" would reproduce the
+  // race this gate exists to prevent.
+  const health = {
+    status: 200,
+    body: {
+      commit: "new",
+      upstreams: { ens: { kind: "dao-api", status: "ok" } },
+    },
+  };
+
+  assert.equal(isGatefulReady(health, "new", true), false);
+  assert.deepEqual(staleUpstreams(health, "new"), ["ens"]);
+});
+
+test("upstreams that aren't DAO APIs never block the gate", () => {
+  // Relayers, address enrichment and authful report no commit and only have
+  // to be reachable — waiting on them would stall releases that never
+  // rebuild them.
   const health = {
     status: 200,
     body: {
       commit: "new",
       upstreams: {
-        "relayer:ens": { status: "ok" },
-        authful: { status: "ok" },
-        ens: { status: "ok", commit: "new" },
+        "relayer:ens": { kind: "relayer", status: "ok" },
+        authful: { kind: "token-service", status: "ok" },
+        ens: { kind: "dao-api", status: "ok", commit: "new" },
       },
     },
   };
@@ -101,11 +117,11 @@ test("waitForGateful polls until every upstream serves the commit", async () => 
   const responses = [
     jsonResponse(200, {
       commit: "new",
-      upstreams: { ens: { status: "ok", commit: "old" } },
+      upstreams: { ens: { kind: "dao-api", status: "ok", commit: "old" } },
     }),
     jsonResponse(200, {
       commit: "new",
-      upstreams: { ens: { status: "ok", commit: "new" } },
+      upstreams: { ens: { kind: "dao-api", status: "ok", commit: "new" } },
     }),
   ];
   let nowMs = 0;

--- a/scripts/wait-for-gateful.test.mjs
+++ b/scripts/wait-for-gateful.test.mjs
@@ -60,7 +60,7 @@ test("isGatefulReady requires the matching commit when expected", () => {
 
 // The failure this guards: gateful on the new commit, ens-api 11s behind it,
 // codegen reading the previous release's merged spec.
-test("isGatefulReady checks DAO APIs only when upstream shas are given", () => {
+test("isGatefulReady checks a kind only when shas are given for it", () => {
   const health = {
     status: 200,
     body: {
@@ -72,9 +72,9 @@ test("isGatefulReady checks DAO APIs only when upstream shas are given", () => {
     },
   };
 
-  assert.equal(isGatefulReady(health, "new", ["new"]), false);
-  assert.equal(isGatefulReady(health, "new", []), true);
-  assert.deepEqual(staleUpstreams(health, ["new"]), ["ens"]);
+  assert.equal(isGatefulReady(health, "new", { "dao-api": ["new"] }), false);
+  assert.equal(isGatefulReady(health, "new", {}), true);
+  assert.deepEqual(staleUpstreams(health, { "dao-api": ["new"] }), ["ens"]);
 });
 
 test("a DAO API reporting no commit is stale, not exempt", () => {
@@ -89,8 +89,8 @@ test("a DAO API reporting no commit is stale, not exempt", () => {
     },
   };
 
-  assert.equal(isGatefulReady(health, "new", ["new"]), false);
-  assert.deepEqual(staleUpstreams(health, ["new"]), ["ens"]);
+  assert.equal(isGatefulReady(health, "new", { "dao-api": ["new"] }), false);
+  assert.deepEqual(staleUpstreams(health, { "dao-api": ["new"] }), ["ens"]);
 });
 
 test("a release that doesn't rebuild the DAO APIs passes on their older commit", () => {
@@ -105,7 +105,7 @@ test("a release that doesn't rebuild the DAO APIs passes on their older commit",
     },
   };
 
-  assert.equal(isGatefulReady(health, "head", ["head", "api-push"]), true);
+  assert.equal(isGatefulReady(health, "head", { "dao-api": ["head", "api-push"] }), true);
 });
 
 test("a non-API push superseding an in-flight API push still waits", () => {
@@ -127,28 +127,44 @@ test("a non-API push superseding an in-flight API push still waits", () => {
     },
   };
 
-  assert.equal(isGatefulReady(deploying, "B", ["B", "A"]), false);
-  assert.equal(isGatefulReady(settled, "B", ["B", "A"]), true);
+  assert.equal(isGatefulReady(deploying, "B", { "dao-api": ["B", "A"] }), false);
+  assert.equal(isGatefulReady(settled, "B", { "dao-api": ["B", "A"] }), true);
 });
 
-test("upstreams that aren't DAO APIs never block the gate", () => {
-  // Relayers, address enrichment and authful report no commit and only have
-  // to be reachable — waiting on them would stall releases that never
-  // rebuild them.
+test("every spec-contributing upstream is gated, on its own commit", () => {
+  // The relayer and address enrichment also merge paths and schemas into
+  // /docs/json, and each rebuilds on its own watch paths — so each is checked
+  // against its own release, not the DAO APIs'. Authful contributes no spec
+  // and is absent from the map, so it only has to be reachable.
+  const expected = {
+    "dao-api": ["head", "api-push"],
+    relayer: ["head", "relayer-push"],
+    "address-enrichment": ["head", "enrichment-push"],
+  };
   const health = {
     status: 200,
     body: {
-      commit: "new",
+      commit: "head",
       upstreams: {
-        "relayer:ens": { kind: "relayer", status: "ok" },
+        ens: { kind: "dao-api", status: "ok", commit: "api-push" },
+        "relayer:ens": { kind: "relayer", status: "ok", commit: "head" },
+        "address-enrichment": {
+          kind: "address-enrichment",
+          status: "ok",
+          commit: "enrichment-push",
+        },
         authful: { kind: "token-service", status: "ok" },
-        ens: { kind: "dao-api", status: "ok", commit: "new" },
       },
     },
   };
 
-  assert.equal(isGatefulReady(health, "new", ["new"]), true);
-  assert.deepEqual(staleUpstreams(health, ["new"]), []);
+  assert.deepEqual(staleUpstreams(health, expected), []);
+  assert.equal(isGatefulReady(health, "head", expected), true);
+
+  const behind = structuredClone(health);
+  behind.body.upstreams["relayer:ens"].commit = "before-relayer-push";
+  assert.deepEqual(staleUpstreams(behind, expected), ["relayer:ens"]);
+  assert.equal(isGatefulReady(behind, "head", expected), false);
 });
 
 test("waitForGateful polls until every DAO API serves the commit", async () => {
@@ -167,7 +183,7 @@ test("waitForGateful polls until every DAO API serves the commit", async () => {
   const result = await waitForGateful({
     baseUrl: "https://gateful.example.com",
     expectedSha: "new",
-    expectedUpstreamShas: ["new"],
+    expectedShasByKind: { "dao-api": ["new"] },
     timeoutMs: 100,
     intervalMs: 10,
     fetchImpl: async () => responses.shift(),

--- a/scripts/wait-for-gateful.test.mjs
+++ b/scripts/wait-for-gateful.test.mjs
@@ -5,6 +5,7 @@ import {
   isGatefulReady,
   resolveExpectedGatefulSha,
   resolveGatefulBaseUrl,
+  staleUpstreams,
   waitForGateful,
 } from "./wait-for-gateful.mjs";
 
@@ -55,6 +56,76 @@ test("isGatefulReady requires the matching commit when expected", () => {
     isGatefulReady({ status: 503, body: { commit: "abc" } }, "abc"),
     false,
   );
+});
+
+// The failure this guards: gateful on the new commit, ens-api 11s behind it,
+// codegen reading the previous release's merged spec.
+test("isGatefulReady waits for upstream commits only when required", () => {
+  const health = {
+    status: 200,
+    body: {
+      commit: "new",
+      upstreams: {
+        ens: { status: "ok", commit: "old" },
+        uni: { status: "ok", commit: "new" },
+      },
+    },
+  };
+
+  assert.equal(isGatefulReady(health, "new", true), false);
+  assert.equal(isGatefulReady(health, "new", false), true);
+  assert.deepEqual(staleUpstreams(health, "new"), ["ens"]);
+});
+
+test("upstreams that report no commit never block the gate", () => {
+  // Relayers, address enrichment and authful report none, and neither does a
+  // DAO API deployed before the field existed. Blocking on them would stall
+  // every release that doesn't rebuild them.
+  const health = {
+    status: 200,
+    body: {
+      commit: "new",
+      upstreams: {
+        "relayer:ens": { status: "ok" },
+        authful: { status: "ok" },
+        ens: { status: "ok", commit: "new" },
+      },
+    },
+  };
+
+  assert.equal(isGatefulReady(health, "new", true), true);
+  assert.deepEqual(staleUpstreams(health, "new"), []);
+});
+
+test("waitForGateful polls until every upstream serves the commit", async () => {
+  const responses = [
+    jsonResponse(200, {
+      commit: "new",
+      upstreams: { ens: { status: "ok", commit: "old" } },
+    }),
+    jsonResponse(200, {
+      commit: "new",
+      upstreams: { ens: { status: "ok", commit: "new" } },
+    }),
+  ];
+  let nowMs = 0;
+
+  const result = await waitForGateful({
+    baseUrl: "https://gateful.example.com",
+    expectedSha: "new",
+    requireUpstreamCommit: true,
+    timeoutMs: 100,
+    intervalMs: 10,
+    fetchImpl: async () => responses.shift(),
+    sleepImpl: async (ms) => {
+      nowMs += ms;
+    },
+    now: () => nowMs,
+    logger: { log: () => undefined },
+  });
+
+  assert.equal(result.ready, true);
+  assert.equal(result.attempt, 2);
 });
 
 test("waitForGateful polls until the expected commit is live", async () => {

--- a/turbo.json
+++ b/turbo.json
@@ -18,6 +18,10 @@
       "passThroughEnv": ["*"]
     },
     "codegen": {
+      // Never cached: the real input is the live gateful spec, which no hash
+      // can see. A run that raced an API deploy would otherwise be replayed
+      // on every retry of that commit, and the retry would never refetch.
+      "cache": false,
       "inputs": [
         "kubb.config.ts",
         "src/**",

--- a/turbo.json
+++ b/turbo.json
@@ -42,6 +42,13 @@
     },
     "@anticapture/client#build": {
       "dependsOn": ["codegen"],
+      // `generated/**` is gitignored, so it is not in the default input set:
+      // this build (and the dashboard's, through it) would otherwise hash the
+      // same on a retry of a commit whose codegen raced an API deploy, and
+      // turbo would restore the dist built from the stale spec over the freshly
+      // generated one. Listing it explicitly makes the spec visible to the
+      // hash, so the cache still hits when the spec really is unchanged.
+      "inputs": ["$TURBO_DEFAULT$", "generated/**"],
       "outputs": ["dist/**"]
     },
     "@anticapture/client-docs#build": {

--- a/turbo.json
+++ b/turbo.json
@@ -42,13 +42,14 @@
     },
     "@anticapture/client#build": {
       "dependsOn": ["codegen"],
-      // `generated/**` is gitignored, so it is not in the default input set:
-      // this build (and the dashboard's, through it) would otherwise hash the
-      // same on a retry of a commit whose codegen raced an API deploy, and
-      // turbo would restore the dist built from the stale spec over the freshly
-      // generated one. Listing it explicitly makes the spec visible to the
-      // hash, so the cache still hits when the spec really is unchanged.
-      "inputs": ["$TURBO_DEFAULT$", "generated/**"],
+      // Not cached, for the same reason `codegen` isn't: tsup runs with
+      // `dts: true`, so the spec fetched at runtime is compiled into `dist`,
+      // and no hash can see it. Declaring `generated/**` as an input does not
+      // work — turbo hashes inputs before the run, and `generated/` is
+      // gitignored, so on a fresh checkout it is empty at that moment and the
+      // glob contributes nothing. A retry would re-run codegen and then
+      // restore the dist built from the stale spec straight over it.
+      "cache": false,
       "outputs": ["dist/**"]
     },
     "@anticapture/client-docs#build": {


### PR DESCRIPTION
## Why

The production dashboard build for #2093 failed on `Property 'scoresTotal' does not exist on type 'OffchainProposal'` — twice, including a manual re-run. Neither failure was a code bug.

Gateful builds `/docs/json` by merging the DAO APIs' specs **live on every request** (`storeOpenApiSpec` → `mergeUpstreamDocs`), so gateful reporting the new commit says nothing about the schemas it will serve. The deploy gate only checked gateful:

```
14:33:54  Gateful ready after attempt 3: commit 773ae02b…   ← gate satisfied
14:34:23  @anticapture/client:codegen: cache miss, executing af63fa07…
14:34:34  ens-api (production): "server running"            ← 11s too late
14:36:15  Type error: Property 'scoresTotal' does not exist
```

The re-run then failed identically because turbo replayed the poisoned artifact — same commit, same hash:

```
14:55:13  @anticapture/client:codegen: cache hit, replaying logs af63fa07…
```

`codegen`'s real input is a live URL no hash can see, so a raced run is cached under that SHA and no retry can ever refetch.

## What changed

- **`apps/api`** reports its running commit on `/health` (`RAILWAY_GIT_COMMIT_SHA`, optional).
- **`apps/gateful`** passes it through as `upstreams.<dao>.commit`. A probe body that isn't JSON, or carries no commit, is still `status: "ok"` — only the commit is lost.
- **`scripts/wait-for-gateful.mjs`** gains `staleUpstreams()`; with `REQUIRE_UPSTREAM_COMMIT=1` it waits for every upstream *that reports a commit*. Upstreams that don't (relayers, address-enrichment, authful, any API predating the field) are skipped, so the gate can't deadlock on services a release never rebuilds.
- **`.github/workflows/deploy.yaml`** sets that flag only when the push touches `apps/api/**` or `infra/api/**` — mirroring Railway's `watchPatterns`, i.e. "will these APIs actually redeploy". Unknown base (new branch / force push) → off, which is the behaviour the gate had before.
- **`turbo.json`**: `@anticapture/client#codegen` is no longer cached. `env` is kept — turbo runs strict env mode, and dropping it would starve kubb of `ANTICAPTURE_API_URL`.

## Verification

- Replayed the real failure through the new detection step, run verbatim from the YAML: `67a6db5f…773ae02b` (the actual push base — gateful was serving `67a6db5f`) → `changed=1`, so it would have waited for `ens-api`. A non-API release → `0`; zero-SHA and empty base → `0`, no `set -euo pipefail` trip.
- `turbo run codegen --dry` confirms `cache {local: false, remote: false}` with the env list intact.
- api + gateful: full test suites, typecheck, lint. `scripts/wait-for-gateful.test.mjs` 8/8, gateful health route 10/10.

## Notes

- This hotfix's own deploy is still unguarded on the API side — the currently-running APIs don't report a commit yet, so the gate skips them. Harmless: no dashboard code reads the new field. Every release after it is covered.
- Correction to an earlier note: `packages/anticapture-client/generated/` is **not** committed (`packages/anticapture-client/.gitignore` ignores `generated/*`). It is produced fresh by every build from the live gateful spec, which is exactly why the gate has to be right.
- The preview lane had none of this protection, and this PR's own preview build proved it by failing the same way production did (relayer mid-deploy at codegen time); `tests.yaml` now resolves the same per-upstream commit sets.
- Considered and rejected: doing this via Railway healthchecks (no cross-service deploy ordering, and Railway can't gate a Vercel build), and requiring upstream commit equality in gateful's own healthcheck (gateful rebuilds on every push while the DAO APIs don't, so it would never go healthy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI deploy gating and live codegen behavior; mis-tuned path detection could delay or skip waiting, but health/commit fields are additive and optional.
> 
> **Overview**
> Fixes production dashboard builds that ran **client codegen** against an outdated merged OpenAPI spec because **gateful** can be on the new commit while slower **DAO APIs** still serve the previous schema.
> 
> **DAO APIs** now include optional **`commit`** on **`/health`** from **`RAILWAY_GIT_COMMIT_SHA`**. **Gateful** forwards that as **`upstreams.<dao>.commit`**. **`scripts/wait-for-gateful.mjs`** can require every upstream that reports a commit to match the expected SHA via **`REQUIRE_UPSTREAM_COMMIT=1`**; upstreams without a commit are ignored so relayers and older APIs do not block deploys.
> 
> The **deploy workflow** sets that flag only when the push changes **`apps/api`** or **`infra/api`** (mirroring Railway watch paths); unknown compare bases skip upstream waiting as before.
> 
> **`@anticapture/client#codegen`** is **`cache: false`** in **turbo** so a raced codegen run is not replayed on retries of the same commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 002b33ca39cd7e2aaa5373732fe02aa09a25dd93. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
