### PR TITLE
fix(dashboard): remove 10k character limit on proposal description

### DIFF
--- a/.changeset/proposal-body-no-limit.md
+++ b/.changeset/proposal-body-no-limit.md
@@ -2,4 +2,4 @@
 "@anticapture/dashboard": patch
 ---
 
-Remove the 10,000-character limit on the proposal description in the create-proposal form. The body field now accepts descriptions of any length, and the editor footer shows a plain character count instead of a limit counter.
+Raise the proposal description limit in the create-proposal form from 10,000 to 100,000 characters, matching the ceiling the drafts endpoint already enforces. Long governance proposals are no longer blocked from being published, and the editor footer counter warns as the new limit approaches instead of failing with a generic error.

--- a/.changeset/proposal-body-no-limit.md
+++ b/.changeset/proposal-body-no-limit.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Remove the 10,000-character limit on the proposal description in the create-proposal form. The body field now accepts descriptions of any length, and the editor footer shows a plain character count instead of a limit counter.

--- a/apps/dashboard/features/create-proposal/components/BodyField.tsx
+++ b/apps/dashboard/features/create-proposal/components/BodyField.tsx
@@ -44,6 +44,10 @@ const markdownHighlightStyle = HighlightStyle.define([
 const sourceViewExtensions = [syntaxHighlighting(markdownHighlightStyle)];
 
 import { TabGroup } from "@/shared/components/design-system/tabs/tab-group/TabGroup";
+import {
+  BODY_CHAR_LIMIT,
+  BODY_WARNING_THRESHOLD,
+} from "@/features/create-proposal/constants";
 import type { ProposalFormValues } from "@/features/create-proposal/schema";
 
 type Mode = "visual" | "markdown";
@@ -56,6 +60,13 @@ export const BodyField = ({ version = 0 }: BodyFieldProps) => {
   const { control, watch } = useFormContext<ProposalFormValues>();
   const body = watch("body") ?? "";
   const [mode, setMode] = useState<Mode>("visual");
+
+  const counterColor =
+    body.length > BODY_CHAR_LIMIT
+      ? "text-error"
+      : body.length >= BODY_WARNING_THRESHOLD
+        ? "text-warning"
+        : "text-secondary";
 
   return (
     <div className="flex w-full flex-col gap-1">
@@ -154,8 +165,8 @@ export const BodyField = ({ version = 0 }: BodyFieldProps) => {
           )}
         />
       </div>
-      <p className="text-secondary text-xs">
-        {body.length.toLocaleString()} characters
+      <p className={`${counterColor} text-xs`}>
+        {body.length.toLocaleString()} / {BODY_CHAR_LIMIT.toLocaleString()}
       </p>
     </div>
   );

--- a/apps/dashboard/features/create-proposal/components/BodyField.tsx
+++ b/apps/dashboard/features/create-proposal/components/BodyField.tsx
@@ -44,10 +44,6 @@ const markdownHighlightStyle = HighlightStyle.define([
 const sourceViewExtensions = [syntaxHighlighting(markdownHighlightStyle)];
 
 import { TabGroup } from "@/shared/components/design-system/tabs/tab-group/TabGroup";
-import {
-  BODY_CHAR_LIMIT,
-  BODY_WARNING_THRESHOLD,
-} from "@/features/create-proposal/constants";
 import type { ProposalFormValues } from "@/features/create-proposal/schema";
 
 type Mode = "visual" | "markdown";
@@ -60,13 +56,6 @@ export const BodyField = ({ version = 0 }: BodyFieldProps) => {
   const { control, watch } = useFormContext<ProposalFormValues>();
   const body = watch("body") ?? "";
   const [mode, setMode] = useState<Mode>("visual");
-
-  const counterColor =
-    body.length > BODY_CHAR_LIMIT
-      ? "text-error"
-      : body.length >= BODY_WARNING_THRESHOLD
-        ? "text-warning"
-        : "text-secondary";
 
   return (
     <div className="flex w-full flex-col gap-1">
@@ -165,8 +154,8 @@ export const BodyField = ({ version = 0 }: BodyFieldProps) => {
           )}
         />
       </div>
-      <p className={`${counterColor} text-xs`}>
-        {body.length} / {BODY_CHAR_LIMIT.toLocaleString()}
+      <p className="text-secondary text-xs">
+        {body.length.toLocaleString()} characters
       </p>
     </div>
   );

--- a/apps/dashboard/features/create-proposal/components/ProposalCreationForm.tsx
+++ b/apps/dashboard/features/create-proposal/components/ProposalCreationForm.tsx
@@ -263,12 +263,7 @@ export const ProposalCreationForm = ({
   const filledCount =
     (hasTitle ? 1 : 0) + (hasBody ? 1 : 0) + (hasActions ? 1 : 0);
   const canPublish =
-    hasTitle &&
-    hasBody &&
-    hasActions &&
-    !!address &&
-    form.formState.isValid &&
-    (values.body?.length ?? 0) <= 10_000;
+    hasTitle && hasBody && hasActions && !!address && form.formState.isValid;
 
   const stashPendingDraft = () => {
     try {

--- a/apps/dashboard/features/create-proposal/components/ProposalCreationForm.tsx
+++ b/apps/dashboard/features/create-proposal/components/ProposalCreationForm.tsx
@@ -26,7 +26,10 @@ import { useWalletPrompt } from "@/shared/services/auth/useWalletPrompt";
 import { getDraft } from "@/shared/services/user-api/draftsClient";
 import { showCustomToast } from "@/features/governance/utils/showCustomToast";
 import { copyDraftShareUrl } from "@/features/create-proposal/utils/draftShareUrl";
-import { BODY_PLACEHOLDER } from "@/features/create-proposal/constants";
+import {
+  BODY_CHAR_LIMIT,
+  BODY_PLACEHOLDER,
+} from "@/features/create-proposal/constants";
 import {
   ProposalFormSchema,
   type ProposalFormValues,
@@ -265,6 +268,12 @@ export const ProposalCreationForm = ({
   const canPublish =
     hasTitle && hasBody && hasActions && !!address && form.formState.isValid;
 
+  // The drafts endpoint rejects bodies past BODY_CHAR_LIMIT, and neither Save
+  // Draft nor Share runs schema validation before POSTing — without this the
+  // request fails with the generic "Could not save draft".
+  const isBodyOverLimit = (values.body?.length ?? 0) > BODY_CHAR_LIMIT;
+  const bodyOverLimitMessage = `Description is over the ${BODY_CHAR_LIMIT.toLocaleString()} character limit`;
+
   const stashPendingDraft = () => {
     try {
       sessionStorage.setItem(pendingDraftStashKey, JSON.stringify(values));
@@ -274,6 +283,10 @@ export const ProposalCreationForm = ({
   };
 
   const handleShare = async () => {
+    if (isBodyOverLimit) {
+      showCustomToast(bodyOverLimitMessage, "error");
+      return;
+    }
     // Persist before sharing when unsaved or dirty, so the link isn't stale.
     let id = currentDraftId;
     if (!id || form.formState.isDirty) {
@@ -360,6 +373,10 @@ export const ProposalCreationForm = ({
   ]);
 
   const handleSaveDraft = async (options?: { navigateToDrafts?: boolean }) => {
+    if (isBodyOverLimit) {
+      showCustomToast(bodyOverLimitMessage, "error");
+      return;
+    }
     // Saving is session-gated now, not wallet-gated: prompt sign-in when there
     // is no session (the user may be connected but not authenticated).
     if (drafts.needsAuth) {

--- a/apps/dashboard/features/create-proposal/constants.ts
+++ b/apps/dashboard/features/create-proposal/constants.ts
@@ -2,9 +2,6 @@ import { type Address, getAddress } from "viem";
 
 import { DaoIdEnum } from "@/shared/types/daos";
 
-export const BODY_CHAR_LIMIT = 10_000;
-export const BODY_WARNING_THRESHOLD = 9_500;
-
 export const canCreateProposalForDao = (daoId: DaoIdEnum | null | undefined) =>
   daoId === DaoIdEnum.ENS || daoId === DaoIdEnum.SHU;
 

--- a/apps/dashboard/features/create-proposal/constants.ts
+++ b/apps/dashboard/features/create-proposal/constants.ts
@@ -2,6 +2,15 @@ import { type Address, getAddress } from "viem";
 
 import { DaoIdEnum } from "@/shared/types/daos";
 
+/**
+ * Mirrors `BODY_MAX` in the user-api drafts mapper
+ * (`apps/user-api/src/mappers/drafts/index.ts`). Draft save and share both
+ * POST the body to that endpoint, which rejects anything longer — keep the two
+ * in sync so the form fails with a field error instead of a generic toast.
+ */
+export const BODY_CHAR_LIMIT = 100_000;
+export const BODY_WARNING_THRESHOLD = 95_000;
+
 export const canCreateProposalForDao = (daoId: DaoIdEnum | null | undefined) =>
   daoId === DaoIdEnum.ENS || daoId === DaoIdEnum.SHU;
 

--- a/apps/dashboard/features/create-proposal/schema.test.ts
+++ b/apps/dashboard/features/create-proposal/schema.test.ts
@@ -37,4 +37,18 @@ describe("ProposalFormSchema", () => {
         .success,
     ).toBe(true);
   });
+
+  test("accepts body at the 100,000 char draft-storage ceiling", () => {
+    expect(
+      ProposalFormSchema.safeParse({ ...valid, body: "a".repeat(100_000) })
+        .success,
+    ).toBe(true);
+  });
+
+  test("rejects body over the 100,000 char draft-storage ceiling", () => {
+    expect(
+      ProposalFormSchema.safeParse({ ...valid, body: "a".repeat(100_001) })
+        .success,
+    ).toBe(false);
+  });
 });

--- a/apps/dashboard/features/create-proposal/schema.test.ts
+++ b/apps/dashboard/features/create-proposal/schema.test.ts
@@ -31,10 +31,10 @@ describe("ProposalFormSchema", () => {
     ).toBe(false);
   });
 
-  test("rejects body over 10,000 chars", () => {
+  test("accepts body over 10,000 chars", () => {
     expect(
       ProposalFormSchema.safeParse({ ...valid, body: "a".repeat(10_001) })
         .success,
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/apps/dashboard/features/create-proposal/schema.ts
+++ b/apps/dashboard/features/create-proposal/schema.ts
@@ -70,7 +70,7 @@ export const ProposalFormSchema = z
           return false;
         }
       }, "Must be a valid URL"),
-    body: z.string().min(1, "Required").max(10_000, "10,000 character limit"),
+    body: z.string().min(1, "Required"),
     actions: z
       .array(ProposalActionSchema)
       .min(1, "At least one action is required"),

--- a/apps/dashboard/features/create-proposal/schema.ts
+++ b/apps/dashboard/features/create-proposal/schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { isAddress } from "viem";
 
+import { BODY_CHAR_LIMIT } from "@/features/create-proposal/constants";
 import { isEnsAddress } from "@/shared/utils/ens";
 
 const addressOrEnsSchema = z
@@ -70,7 +71,10 @@ export const ProposalFormSchema = z
           return false;
         }
       }, "Must be a valid URL"),
-    body: z.string().min(1, "Required"),
+    body: z
+      .string()
+      .min(1, "Required")
+      .max(BODY_CHAR_LIMIT, "100,000 character limit"),
     actions: z
       .array(ProposalActionSchema)
       .min(1, "At least one action is required"),


### PR DESCRIPTION
## Summary

Hotfix: the create-proposal form blocked proposal descriptions over 10,000 characters, preventing long governance proposals from being published. The limit is removed — the description now has no client-side length cap.

## Changes

- `schema.ts` — dropped `.max(10_000)` from the `body` field validation
- `ProposalCreationForm.tsx` — removed the `<= 10_000` condition from the `canPublish` gate
- `BodyField.tsx` — replaced the `x / 10,000` limit counter (with warning/error colors) with a plain character count
- `constants.ts` — removed the now-unused `BODY_CHAR_LIMIT` and `BODY_WARNING_THRESHOLD`
- `schema.test.ts` — flipped the limit test to assert bodies over 10k are accepted

## Note for reviewers

The user-api drafts endpoint still caps `body` at 100,000 characters (`BODY_MAX` in `apps/user-api/src/mappers/drafts/index.ts`) as a payload-size safeguard on the drafts store. That cap was left in place — it only affects saving drafts, not publishing, and removing a server-side abuse guard felt out of scope for this hotfix. Flag if it should go too.

## Verification

- `pnpm dashboard typecheck` ✅
- `pnpm dashboard lint` ✅
- `pnpm dashboard test` — 44 suites, 266 tests, all passing ✅