### PR TITLE
fix(infra): scope the DAO API DB image and cover its entrypoint in CI

### DIFF
--- a/.changeset/olive-pandas-guard.md
+++ b/.changeset/olive-pandas-guard.md
@@ -1,0 +1,6 @@
+---
+---
+
+Scope the DAO API database image to its own watch patterns and cover its
+entrypoint derivation with a CI self-test. Infra and CI only — no workspace
+package changes.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -424,6 +424,24 @@ jobs:
           flags: api
           fail_ci_if_error: false
 
+  dao-api-db-entrypoint:
+    name: DAO API DB entrypoint self-test
+    if: ${{ !(startsWith(github.head_ref, 'changeset-release/') && github.actor == 'github-actions[bot]' && github.event.pull_request.user.login == 'github-actions[bot]' && github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # The entrypoint derives max_connections and effective_cache_size from the
+      # container's own cgroup limit, so a wrong derivation silently mis-provisions
+      # every DAO database at once — and the tiers it keys off are not visible from
+      # the repo. The script ships assertions for the four fleet tiers, both clamp
+      # boundaries and both fallback paths; this runs them on every PR instead of
+      # relying on someone remembering to.
+      - name: Run entrypoint self-test
+        run: bash infra/dao-api-db/entrypoint.dao-api-db.sh --self-test
+
   # dashboard-e2e:
   #   name: Dashboard E2E
   #   needs: wait-for-gateful

--- a/infra/dao-api-db/dao-api-db.railway.toml
+++ b/infra/dao-api-db/dao-api-db.railway.toml
@@ -1,6 +1,11 @@
 [build]
 builder = "DOCKERFILE"
 dockerfilePath = "infra/dao-api-db/Dockerfile.dao-api-db"
+# Railway watches the whole repo when this is unset, so without it every merge to
+# dev rebuilds and restarts all 17 Postgres services at once. Nothing outside the
+# image's own directory can change what this service runs, and the image is shared
+# by the whole fleet, so the pattern is the same for every DB service.
+watchPatterns = ["infra/dao-api-db/**"]
 
 [deploy]
 # No healthcheckPath: Postgres speaks the wire protocol, not HTTP, so Railway's


### PR DESCRIPTION
Targets `chore/dao-api-db-image`, not `dev` — this is the two mechanical items from my review on #2099, so they can land without you re-deriving them. The two findings that need your judgement (the `postgres-exporter` dependency and the `max_connections` floor vs the API's three pools) are deliberately not touched here.

## 1. `watchPatterns` on the DB image

Railway watches the whole repo when `watchPatterns` is unset. Once the 17 Postgres services are pointed at `dao-api-db.railway.toml`, every merge to `dev` would rebuild and restart the entire database fleet on commits that cannot affect them. Scoped to `infra/dao-api-db/**`, which is the only directory that changes what these services run.

**Correcting myself from the review:** I also flagged the missing `[environments.pr.deploy]` NOOP block there, on the grounds that every other repo-backed service carries one. That was wrong and I did not implement it. The DAO APIs are *not* NOOP'd in PR environments, so they need a live database to serve against — NOOPing the DB would break every preview rather than save anything. `postgres-exporter` can carry the NOOP because it is only a scraper. The absence is correct; only `watchPatterns` was missing.

## 2. The self-test runs in CI

`entrypoint.dao-api-db.sh` ships assertions for the four fleet tiers, both clamp boundaries and both fallback paths, and #2099 cites them as verification — but nothing executes them. A wrong derivation mis-provisions every DAO database simultaneously, and the tiers it keys off live in the Railway UI, so the repo has no other way to notice the table drifting from the fleet.

New `dao-api-db-entrypoint` job in `tests.yaml`: checkout, then `bash infra/dao-api-db/entrypoint.dao-api-db.sh --self-test`. No pnpm install, no paths filter — running it unconditionally is cheaper than deciding whether it needed to run.

## Verified

- `bash infra/dao-api-db/entrypoint.dao-api-db.sh --self-test` → `self-test OK`, exit 0, from the repo root exactly as the job invokes it
- `tests.yaml` parses; the job resolves to `runs-on: ubuntu-latest` with the two expected steps
- `dao-api-db.railway.toml` still parses with `build.watchPatterns` as a list
- Empty changeset, matching `yellow-windows-swim.md` on the base branch — infra and CI only, no workspace package changes
