### PR TITLE
fix: comments

### DIFF
--- a/.changeset/proud-poems-sneeze.md
+++ b/.changeset/proud-poems-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Fix PR review findings: tag proposal-creation telemetry on the menu items instead of the trigger, keep the delegates amount filter in sync with the URL filter state, and derive the custom range end boundary from local midnight so DST days aren't off by an hour.

--- a/apps/dashboard/features/create-proposal/components/NewProposalMenu.tsx
+++ b/apps/dashboard/features/create-proposal/components/NewProposalMenu.tsx
@@ -8,24 +8,30 @@ import { Button } from "@/shared/components/design-system/buttons/button/Button"
 import { itemStatusStyles } from "@/shared/components/design-system/combobox/styles";
 import { cn } from "@/shared/utils/cn";
 
+type DataProps = Partial<Record<`data-${string}`, string | undefined>>;
+
 type NewProposalMenuProps = {
   onCreateNew: () => void;
   onImportJson: () => void;
-  triggerProps?: React.ComponentProps<typeof Button> &
-    Partial<Record<`data-${string}`, string | undefined>>;
+  // Analytics tags live on the items, not the trigger: tagging the trigger
+  // would fire the event on merely opening the menu.
+  createNewProps?: DataProps;
+  importJsonProps?: DataProps;
 };
 
 const MenuItem = ({
   label,
   onSelect,
+  ...rest
 }: {
   label: string;
   onSelect: () => void;
-}) => (
+} & DataProps) => (
   <button
     type="button"
     role="menuitem"
     onClick={onSelect}
+    {...rest}
     className={cn(
       "flex w-full items-center px-3 py-2 text-left",
       "text-primary text-sm font-normal leading-5",
@@ -40,7 +46,8 @@ const MenuItem = ({
 export const NewProposalMenu = ({
   onCreateNew,
   onImportJson,
-  triggerProps,
+  createNewProps,
+  importJsonProps,
 }: NewProposalMenuProps) => {
   const [open, setOpen] = useState(false);
 
@@ -57,11 +64,7 @@ export const NewProposalMenu = ({
           size="md"
           aria-haspopup="menu"
           aria-expanded={open}
-          {...triggerProps}
-          className={cn(
-            "flex-1 whitespace-nowrap lg:w-fit lg:flex-none",
-            triggerProps?.className,
-          )}
+          className="flex-1 whitespace-nowrap lg:w-fit lg:flex-none"
         >
           <Plus className="size-4" />
           New Proposal
@@ -81,8 +84,16 @@ export const NewProposalMenu = ({
           "animate-[popover-slide-in_0.15s_ease-out]",
         )}
       >
-        <MenuItem label="Create new" onSelect={choose(onCreateNew)} />
-        <MenuItem label="Import JSON" onSelect={choose(onImportJson)} />
+        <MenuItem
+          label="Create new"
+          onSelect={choose(onCreateNew)}
+          {...createNewProps}
+        />
+        <MenuItem
+          label="Import JSON"
+          onSelect={choose(onImportJson)}
+          {...importJsonProps}
+        />
       </PopoverPrimitive.Content>
     </PopoverPrimitive.Root>
   );

--- a/apps/dashboard/features/governance/components/governance-overview/GovernanceSection.tsx
+++ b/apps/dashboard/features/governance/components/governance-overview/GovernanceSection.tsx
@@ -401,10 +401,17 @@ export const GovernanceSection = () => {
         <NewProposalMenu
           onCreateNew={goToNewProposal}
           onImportJson={() => setImportOpen(true)}
-          triggerProps={{
+          createNewProps={{
             "data-umami-event": "proposal_create_click",
             "data-umami-event-dao": daoId,
             "data-ph-event": "proposal_create_click",
+            "data-ph-source": "governance_overview",
+            "data-ph-dao": daoId,
+          }}
+          importJsonProps={{
+            "data-umami-event": "proposal_import_json_click",
+            "data-umami-event-dao": daoId,
+            "data-ph-event": "proposal_import_json_click",
             "data-ph-source": "governance_overview",
             "data-ph-dao": daoId,
           }}

--- a/apps/dashboard/features/holders-and-delegates/HoldersAndDelegatesSection.tsx
+++ b/apps/dashboard/features/holders-and-delegates/HoldersAndDelegatesSection.tsx
@@ -38,7 +38,10 @@ const TABS = [
   { value: "tokenHolders", label: "Token Holders" },
 ];
 
-const DAY_IN_SECONDS = 24 * 60 * 60;
+// Last second of `date`'s local calendar day. Day-of-month arithmetic keeps it
+// correct across DST changes, where the local day is 23 or 25 hours long.
+const endOfLocalDay = (date: Date): Date =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1, 0, 0, -1);
 
 // Every value the period switcher can hold: the presets plus its two synthetic
 // options.
@@ -135,9 +138,9 @@ export const HoldersAndDelegatesSection = ({ daoId }: { daoId: DaoIdEnum }) => {
     if (days === CUSTOM_PERIOD && customRange.from && customRange.to) {
       return {
         fromDate: Math.floor(customRange.from.getTime() / 1000),
-        // include the whole end day
-        toDate:
-          Math.floor(customRange.to.getTime() / 1000) + DAY_IN_SECONDS - 1,
+        // Include the whole end day. Next local midnight minus a second, not
+        // +86400s: on DST change days the local day isn't 24h long.
+        toDate: Math.floor(endOfLocalDay(customRange.to).getTime() / 1000),
       };
     }
     const interval = (Object.values(TimeInterval) as string[]).includes(days)

--- a/apps/dashboard/features/holders-and-delegates/delegate/Delegates.tsx
+++ b/apps/dashboard/features/holders-and-delegates/delegate/Delegates.tsx
@@ -403,6 +403,8 @@ export const Delegates = ({
               setSortOrder("desc");
             }}
             isActive={!!(minValue || maxValue)}
+            minValue={minValue}
+            maxValue={maxValue}
           />
         </div>
       ),

--- a/apps/dashboard/shared/components/design-system/table/filters/amount-filter/AmountFilter.tsx
+++ b/apps/dashboard/shared/components/design-system/table/filters/amount-filter/AmountFilter.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect } from "react";
+
 import type { SortOption } from "@/shared/components/design-system/table/filters/amount-filter/components";
 import {
   FilterBox,
@@ -16,6 +18,14 @@ interface AmountFilterProps {
   isActive?: boolean;
   sortOptions?: SortOption[];
   filterId: string;
+  /**
+   * Applied range owned by the caller (URL/query state). The store is a module
+   * singleton, so without this the inputs drift from the rows that are actually
+   * filtered: stale values survive a tab switch, and a shared filtered URL opens
+   * with blank inputs.
+   */
+  minValue?: string | null;
+  maxValue?: string | null;
 }
 
 export const AmountFilter = ({
@@ -25,8 +35,18 @@ export const AmountFilter = ({
   isActive = false,
   sortOptions,
   filterId,
+  minValue,
+  maxValue,
 }: AmountFilterProps) => {
   const store = useAmountFilterStore();
+
+  const isControlled = minValue !== undefined || maxValue !== undefined;
+
+  useEffect(() => {
+    if (!isControlled) return;
+    store.setMinAmount(filterId, minValue ?? "");
+    store.setMaxAmount(filterId, maxValue ?? "");
+  }, [isControlled, store, filterId, minValue, maxValue]);
 
   const { minAmount, maxAmount, sortOrder } = store.getState(filterId);
 

--- a/apps/dashboard/shared/components/design-system/table/filters/amount-filter/AmountFilter.tsx
+++ b/apps/dashboard/shared/components/design-system/table/filters/amount-filter/AmountFilter.tsx
@@ -39,14 +39,19 @@ export const AmountFilter = ({
   maxValue,
 }: AmountFilterProps) => {
   const store = useAmountFilterStore();
+  // The setters are created once by `create`, so selecting them keeps the effect
+  // deps stable. Depending on the whole store object would re-run the effect on
+  // every write it performs — an update loop.
+  const setMinAmount = useAmountFilterStore((s) => s.setMinAmount);
+  const setMaxAmount = useAmountFilterStore((s) => s.setMaxAmount);
 
   const isControlled = minValue !== undefined || maxValue !== undefined;
 
   useEffect(() => {
     if (!isControlled) return;
-    store.setMinAmount(filterId, minValue ?? "");
-    store.setMaxAmount(filterId, maxValue ?? "");
-  }, [isControlled, store, filterId, minValue, maxValue]);
+    setMinAmount(filterId, minValue ?? "");
+    setMaxAmount(filterId, maxValue ?? "");
+  }, [isControlled, setMinAmount, setMaxAmount, filterId, minValue, maxValue]);
 
   const { minAmount, maxAmount, sortOrder } = store.getState(filterId);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UX/analytics and date-boundary fixes with no auth or data-model changes; AmountFilter remains backward compatible when min/max props are omitted.
> 
> **Overview**
> Addresses three PR review items across governance, delegates, and holders date filtering.
> 
> **Proposal telemetry:** `NewProposalMenu` no longer accepts `triggerProps` on the **New Proposal** button. Umami/PostHog `data-*` attributes move to **`createNewProps`** and **`importJsonProps`** on each menu item so events fire on **Create new** / **Import JSON** clicks, not when opening the popover. Governance overview wires separate events for create vs import.
> 
> **Delegates amount filter:** `AmountFilter` can take optional **`minValue`/`maxValue`** from URL state and syncs them into the module singleton store via `useEffect`, so inputs match applied filters after tab switches or when opening a shared filtered URL. Delegates passes query `minValue`/`maxValue` through.
> 
> **Custom date range end:** Holders/delegates custom ranges stop using `+86400 - 1` for the end day; **`endOfLocalDay`** uses next local midnight minus one second so DST days (23/25 hours) don’t skew `toDate` by an hour.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c864c11e5e93f9c5698a31af9c24077899151ce9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->