### PR TITLE
fix(dashboard): sync amount filters with URL

### DIFF
--- a/.changeset/lazy-filters-sync.md
+++ b/.changeset/lazy-filters-sync.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Sync the Token Holders and AAVE delegation amount filters with the URL so shared links show the active range.

--- a/apps/dashboard/app/aave/stakeholders/DelegationTable.tsx
+++ b/apps/dashboard/app/aave/stakeholders/DelegationTable.tsx
@@ -355,6 +355,8 @@ export function DelegationTable({ days }: { days: TimeInterval }) {
               setSortOrder("desc");
             }}
             isActive={!!(minValue || maxValue)}
+            minValue={minValue}
+            maxValue={maxValue}
           />
         </div>
       ),

--- a/apps/dashboard/features/holders-and-delegates/token-holder/TokenHolders.tsx
+++ b/apps/dashboard/features/holders-and-delegates/token-holder/TokenHolders.tsx
@@ -323,6 +323,8 @@ export const TokenHolders = ({
               setOrderDirection("desc");
             }}
             isActive={!!(minValue || maxValue)}
+            minValue={minValue}
+            maxValue={maxValue}
           />
         </div>
       ),


### PR DESCRIPTION
Passes the URL-owned `minValue`/`maxValue` into `AmountFilter` on Token Holders and the AAVE delegation table, matching what `Delegates.tsx` already does. Without it, opening a shared link with an amount range filtered the rows but left the filter inputs blank/stale, so pressing Apply replaced the active range with unrelated values.

Addresses the codex-connector P2 comment on #2104.

Skipped: the `neverVoted` proposal-count comment — that's an API contract change, not deploy-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI wiring change with no auth, API, or data-model impact; aligns two tables with an existing delegates pattern.
> 
> **Overview**
> **Token Holders** and the **AAVE delegation table** now pass URL-backed `minValue` and `maxValue` into `AmountFilter`, matching the pattern already used in `Delegates.tsx`.
> 
> Those tables already read `minValue`/`maxValue` from query state and send them to the API, but the filter UI kept its own singleton store values. Opening a link with an amount range filtered the rows while the min/max inputs stayed empty or stale; **Apply** could then overwrite the URL with unrelated numbers. Wiring the props lets `AmountFilter` sync the inputs with the applied range.
> 
> A patch changeset notes the dashboard fix for shared links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12e803ef4d83ac877be1c0cd15a7443d17725ab6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->