### PR TITLE
fix(dashboard): make the RPC proxy URL absolute for WalletConnect

### DIFF
--- a/.changeset/walletconnect-absolute-rpc-url.md
+++ b/.changeset/walletconnect-absolute-rpc-url.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Fix WalletConnect pairing by giving the provider an absolute RPC proxy URL.

--- a/apps/dashboard/shared/services/wallet/wallet.ts
+++ b/apps/dashboard/shared/services/wallet/wallet.ts
@@ -10,7 +10,14 @@ import { createWalletClient } from "viem";
 import { createConfig, http } from "wagmi";
 import { mainnet, optimism, scroll } from "wagmi/chains";
 
-const rpcTransport = (chainId: number) => http(`/api/rpc/${chainId}`);
+// The RPC proxy path must be absolute in the browser: wagmi hands these
+// transport URLs to the WalletConnect provider's rpcMap, whose HTTP
+// connection rejects relative URLs (breaking every WalletConnect pairing
+// right after session approval). During SSR the transports are never
+// called, so the relative path is fine there.
+const origin = typeof window === "undefined" ? "" : window.location.origin;
+
+const rpcTransport = (chainId: number) => http(`${origin}/api/rpc/${chainId}`);
 
 export const walletClient = createWalletClient({
   chain: mainnet,


### PR DESCRIPTION
## Summary

WalletConnect pairings on the deployed dashboard break right after session approval with:

- `Error: Provided URL is not compatible with HTTP connection: /api/rpc/1`
- `TypeError: Cannot read properties of undefined (reading 'getDefaultChain')`
- `TypeError: Cannot read properties of undefined (reading 'request')`

Wagmi hands the transport URLs to the WalletConnect provider's `rpcMap`, and its HTTP connection rejects relative URLs, so the provider's RPC map never initializes and every subsequent session event dereferences `undefined`.

This prefixes the `/api/rpc/<chainId>` proxy path with `window.location.origin` in the browser. During SSR the transports are never called, so the relative path stays as-is there.

## Test plan

- `pnpm dashboard typecheck` and `pnpm dashboard lint` pass (0 errors)
- Connect a wallet via WalletConnect on a preview deploy and confirm the session survives approval with no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)