### PR TITLE
fix(dashboard): keep the address column readable on whitelabel stakeholders

### DIFF
--- a/.changeset/wl-stakeholders-address-column.md
+++ b/.changeset/wl-stakeholders-address-column.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Fix the whitelabel stakeholders table cutting off the address column.

--- a/apps/dashboard/features/holders-and-delegates/delegate/Delegates.tsx
+++ b/apps/dashboard/features/holders-and-delegates/delegate/Delegates.tsx
@@ -340,9 +340,6 @@ export const Delegates = ({
           />
         </div>
       ),
-      // No width on purpose: in the fixed table layout the address column is
-      // the only unsized one, so it absorbs all leftover space instead of
-      // splitting it with the whitelabel Delegate column.
     },
     {
       accessorKey: "votingPower",
@@ -474,8 +471,6 @@ export const Delegates = ({
         </Button>
       ),
       meta: {
-        // Narrower on whitelabel so the address column keeps roughly the same
-        // width it has without the extra Delegate button column.
         columnClassName: isWhitelabel ? "w-[13%]" : "w-[16%]",
       },
     },
@@ -657,9 +652,6 @@ export const Delegates = ({
             },
             header: () => null,
             meta: {
-              // Wide enough for the Delegate button (78px) plus px-2; with
-              // less, the button overflows the table and forces a
-              // horizontal scroll.
               columnClassName: "w-24 px-2",
             },
           } satisfies ColumnDef<DelegateTableData>,

--- a/apps/dashboard/features/holders-and-delegates/delegate/Delegates.tsx
+++ b/apps/dashboard/features/holders-and-delegates/delegate/Delegates.tsx
@@ -340,9 +340,9 @@ export const Delegates = ({
           />
         </div>
       ),
-      meta: {
-        columnClassName: "w-40",
-      },
+      // No width on purpose: in the fixed table layout the address column is
+      // the only unsized one, so it absorbs all leftover space instead of
+      // splitting it with the whitelabel Delegate column.
     },
     {
       accessorKey: "votingPower",
@@ -474,7 +474,9 @@ export const Delegates = ({
         </Button>
       ),
       meta: {
-        columnClassName: "w-[16%]",
+        // Narrower on whitelabel so the address column keeps roughly the same
+        // width it has without the extra Delegate button column.
+        columnClassName: isWhitelabel ? "w-[13%]" : "w-[16%]",
       },
     },
     {
@@ -531,7 +533,7 @@ export const Delegates = ({
         </h4>
       ),
       meta: {
-        columnClassName: "w-[11%]",
+        columnClassName: isWhitelabel ? "w-[10%]" : "w-[11%]",
       },
     },
     {
@@ -582,7 +584,7 @@ export const Delegates = ({
         </div>
       ),
       meta: {
-        columnClassName: "w-[16%]",
+        columnClassName: isWhitelabel ? "w-[13%]" : "w-[16%]",
       },
     },
     {
@@ -625,7 +627,7 @@ export const Delegates = ({
         </Button>
       ),
       meta: {
-        columnClassName: "w-[12%]",
+        columnClassName: isWhitelabel ? "w-[11%]" : "w-[12%]",
       },
     },
     ...(isWhitelabel
@@ -655,7 +657,10 @@ export const Delegates = ({
             },
             header: () => null,
             meta: {
-              columnClassName: "w-18",
+              // Wide enough for the Delegate button (78px) plus px-2; with
+              // less, the button overflows the table and forces a
+              // horizontal scroll.
+              columnClassName: "w-24 px-2",
             },
           } satisfies ColumnDef<DelegateTableData>,
         ]


### PR DESCRIPTION
## Summary

On whitelabel Stakeholders pages the Delegates table clipped the Address column (truncated ENS names and 0x addresses), while the main Anticapture dashboard rendered it correctly. Fixed by making the Address column the table's single elastic column and sizing the whitelabel-only Delegate button column to what the button actually needs.

## Context

- 📋 **Ticket**: none (reported directly with screenshots comparing app.anticapture.com and a whitelabel deployment)
- 🌿 **Branch**: `fix/whitelabel-stakeholders-address-column`

## Root cause

The table uses `table-fixed` at lg+. In that layout, leftover space is split proportionally among pixel-width columns. On the main dashboard the Address column (`w-40`) was the only pixel column, so it absorbed all leftover space. On whitelabel, the extra Delegate button column (`w-18`) joined that split and starved the Address column; the address cell also permanently reserves ~120px for the hover Copy/Details cluster, so names got clipped. On top of that, the Delegate button (78px) never fit its 72px column and overflowed the table edge.

## What changed

- UI (`apps/dashboard/features/holders-and-delegates/delegate/Delegates.tsx`, whitelabel Delegates table only):
  - Address column: dropped `w-40` so it is the only unsized column and absorbs all leftover space instead of splitting it with the Delegate button column. Identical result on the non-whitelabel table, where it already took all leftover space.
  - Whitelabel-only width trims to make room for the button column: Change 16% to 13%, Activity 11% to 10%, Avg Vote Timing 16% to 13%, Delegators 12% to 11%. Non-whitelabel keeps the previous values.
  - Delegate button column: `w-18` to `w-24 px-2`, so the 78px button fits inside the column instead of overflowing the table and forcing a horizontal scroll.
- Changeset: `@anticapture/dashboard` patch.

## Verification (local dev server, real gateway data)

| Page | Viewport | Before | After |
| --- | --- | --- | --- |
| /whitelabel/shu/stakeholders | 1280px | Address col 207px, every name clipped | Address col 285px, zero clipped, no h-scroll |
| /whitelabel/ens/stakeholders | 1354px | h-scroll, names clipped | no h-scroll, all names fit incl. scratch.ricmoo.eth |
| /whitelabel/ens/stakeholders | 1600px | names clipped | Address col 394px, zero clipped |
| /shu/stakeholders (main) | 1280px | baseline | unchanged (15/16/11/16/12%, elastic Address) |

`pnpm dashboard typecheck` and `pnpm dashboard lint` pass.

## Self-review summary

- ✅ QA pass: Tailwind arbitrary classes statically scannable, mobile (`table-auto`) unaffected, CSV export unaffected, non-whitelabel widths byte-identical, both whitelabel DAOs (ENS, SHU) verified
- ✅ Engineer pass: `px-2` override confirmed via tailwind-merge ordering on both th and td; no over-constraint in the fixed layout
- ⚠️ Known limitations (deferred to a follow-up):
  - Connected-wallet button states are wider than the column ("Delegated" 106px, "Delegate + Free" 125px vs 80px content box) and can still spill past the table edge. This predates this PR and was worse before it (the old column gave the button 40px). Fitting them statically would starve the Address column again, so it needs a compact button variant or a slimmer hover cluster instead.

## Changeset

- `@anticapture/dashboard`: patch, whitelabel-only table layout fix.