### PR TITLE
fix: match ens proposals by numeric

### DIFF
--- a/apps/dashboard/features/governance/hooks/useCalldataReview.test.ts
+++ b/apps/dashboard/features/governance/hooks/useCalldataReview.test.ts
@@ -16,6 +16,15 @@ describe("findCalldataReview", () => {
     ).toEqual(reviews[0]);
   });
 
+  it("matches when the title omits the EP prefix", () => {
+    expect(
+      findCalldataReview(reviews, {
+        id: "0xabc",
+        title: "[6.39][Executable] Do a thing",
+      }),
+    ).toEqual(reviews[0]);
+  });
+
   it("matches numbered folders by proposal id", () => {
     expect(
       findCalldataReview(reviews, { id: "93", title: "UNIfication" }),

--- a/apps/dashboard/features/governance/hooks/useCalldataReview.ts
+++ b/apps/dashboard/features/governance/hooks/useCalldataReview.ts
@@ -23,14 +23,16 @@ export type CalldataReview = { name: string; url: string };
  * Only unambiguous identifiers count — this badge is a trust signal, so a folder
  * whose name merely resembles the title must not claim a review:
  * - "93 - UNIfication", "67" -> proposal id
- * - "ep-6-39" -> the "[EP 6.39]" tag ENS proposals carry in their title
+ * - "ep-6-39" -> the "[EP 6.39]" / "[6.39]" tag ENS proposals carry in their title
+ *   (the "EP" is optional in practice: "[6.48][Executable] ...")
  * Free-form folder names (Shutter's "dsr-allocation") stay unmatched by design.
  */
 export const findCalldataReview = (
   reviews: CalldataReview[],
   proposal: { id: string; title: string },
 ): CalldataReview | undefined => {
-  const ep = proposal.title.match(/\bEP\s*(\d+)\.(\d+)\b/i);
+  // ponytail: the closing bracket is what keeps this from matching stray "1.5"s
+  const ep = proposal.title.match(/(?:EP\s*)?(\d+)\.(\d+)\s*\]/i);
   const epFolder = ep && `ep-${ep[1]}-${ep[2]}`;
 
   return reviews.find((review) => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a21bef2a7657f9827dac6c7740c2c11790abaa9e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->