### PR TITLE
feat(relayer): proposal lifecycle keeper for queue() and execute() (DEV-700)

### DIFF
--- a/apps/relayer/.env.example
+++ b/apps/relayer/.env.example
@@ -23,5 +23,16 @@ MIN_VOTING_POWER=1000000000000000000000
 MAX_VOTES_PER_ADDRESS_PER_MONTH=3
 MAX_DELEGATIONS_PER_ADDRESS_PER_MONTH=3
 
+# Proposal lifecycle keeper — pays gas to queue()/execute() succeeded proposals.
+# Off by default. KEEPER_START_BLOCK (required when enabled) is the first block
+# scanned for ProposalCreated logs; set it to a block before the oldest proposal
+# the keeper should manage.
+KEEPER_ENABLED=false
+KEEPER_START_BLOCK=
+KEEPER_POLL_INTERVAL_SECONDS=300
+KEEPER_QUEUE_DELAY_SECONDS=1800
+KEEPER_EXECUTION_DELAY_SECONDS=1800
+KEEPER_MAX_BLOCK_RANGE=10000
+
 # Server
 PORT=3002

--- a/apps/relayer/e2e/keeper.test.ts
+++ b/apps/relayer/e2e/keeper.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  type Address,
+  createTestClient,
+  createWalletClient,
+  encodeFunctionData,
+  http,
+  parseEther,
+  parseUnits,
+  publicActions,
+} from "viem";
+import { mainnet } from "viem/chains";
+
+import { governorAbi, ProposalState } from "@/abi/governor";
+import { erc20VotesAbi } from "@/abi/token";
+import { createLogger } from "@anticapture/observability";
+import { createLocalSigner } from "@/signer/local-signer";
+import {
+  ProposalLifecycleService,
+  type KeeperStorage,
+  type TrackedProposal,
+} from "@/services/keeper/proposal-lifecycle";
+
+import {
+  FORK_BLOCK,
+  GOVERNOR_ADDRESS,
+  PROPOSER_ADDRESS,
+  RELAYER_ADDRESS,
+  RELAYER_KEY,
+  TEST_USER_ADDRESS,
+  TOKEN_ADDRESS,
+  startAnvil,
+  stopAnvil,
+  createClients,
+  selfDelegate,
+  createNoOpProposal,
+  activateProposal,
+} from "./helpers";
+
+const silentLogger = createLogger("keeper-e2e");
+silentLogger.level = "silent";
+
+// ENS quorum is 1% of supply (1M ENS); vote with buffer above it. The shared
+// WHALE (a Binance hot wallet) can't cover this, so quorum-scale funding comes
+// from the ENS DAO timelock, which has held several million ENS since launch.
+const ENS_TIMELOCK: Address = "0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7";
+const QUORUM_VOTES = parseUnits("1200000", 18);
+
+class InMemoryKeeperStorage implements KeeperStorage {
+  cursor: bigint | null = null;
+  proposals = new Map<string, TrackedProposal>();
+
+  async getCursor(): Promise<bigint | null> {
+    return this.cursor;
+  }
+  async setCursor(block: bigint): Promise<void> {
+    this.cursor = block;
+  }
+  async putProposal(proposal: TrackedProposal): Promise<void> {
+    this.proposals.set(proposal.proposalId, proposal);
+  }
+  async listProposals(): Promise<TrackedProposal[]> {
+    return [...this.proposals.values()];
+  }
+  async removeProposal(proposalId: string): Promise<void> {
+    this.proposals.delete(proposalId);
+  }
+}
+
+type TestClient = ReturnType<typeof createClients>["testClient"];
+
+/**
+ * Like createClients().testClient, but with a 60s transport timeout: this
+ * suite mines a whole voting period, and big anvil_mine batches on a fork
+ * outlive viem's default 10s.
+ */
+function createPatientTestClient(rpcUrl: string): TestClient {
+  return createTestClient({
+    mode: "anvil",
+    transport: http(rpcUrl, { timeout: 60_000 }),
+    chain: mainnet,
+  }).extend(publicActions);
+}
+
+/** Mines in chunks so no single anvil_mine call outlives the HTTP timeout. */
+async function mineBlocks(
+  testClient: TestClient,
+  blocks: number,
+): Promise<void> {
+  const CHUNK = 5_000;
+  for (let mined = 0; mined < blocks; mined += CHUNK) {
+    await testClient.mine({ blocks: Math.min(CHUNK, blocks - mined) });
+  }
+}
+
+async function fundFromTimelock(
+  testClient: TestClient,
+  rpcUrl: string,
+  recipient: Address,
+  amount: bigint,
+): Promise<void> {
+  await testClient.setBalance({
+    address: ENS_TIMELOCK,
+    value: parseEther("1"),
+  });
+  await testClient.impersonateAccount({ address: ENS_TIMELOCK });
+  const timelock = createWalletClient({
+    account: ENS_TIMELOCK,
+    transport: http(rpcUrl),
+    chain: mainnet,
+  });
+  const hash = await timelock.sendTransaction({
+    to: TOKEN_ADDRESS,
+    data: encodeFunctionData({
+      abi: erc20VotesAbi,
+      functionName: "transfer",
+      args: [recipient, amount],
+    }),
+  });
+  await testClient.waitForTransactionReceipt({ hash });
+  await testClient.mine({ blocks: 1 });
+}
+
+async function castVoteFor(
+  testClient: TestClient,
+  rpcUrl: string,
+  proposalId: bigint,
+): Promise<void> {
+  const wallet = createWalletClient({
+    account: { address: TEST_USER_ADDRESS, type: "json-rpc" },
+    transport: http(rpcUrl),
+    chain: mainnet,
+  });
+  const hash = await wallet.writeContract({
+    address: GOVERNOR_ADDRESS,
+    abi: governorAbi,
+    functionName: "castVote",
+    args: [proposalId, 1],
+  });
+  await testClient.waitForTransactionReceipt({ hash });
+  await testClient.mine({ blocks: 1 });
+}
+
+async function proposalState(
+  testClient: TestClient,
+  proposalId: bigint,
+): Promise<number> {
+  return testClient.readContract({
+    address: GOVERNOR_ADDRESS,
+    abi: governorAbi,
+    functionName: "state",
+    args: [proposalId],
+  });
+}
+
+describe("proposal lifecycle keeper", () => {
+  let rpcUrl: string;
+  let testClient: TestClient;
+  let proposalId: bigint;
+  let keeper: ProposalLifecycleService;
+  let storage: InMemoryKeeperStorage;
+
+  beforeAll(async () => {
+    rpcUrl = await startAnvil();
+    testClient = createPatientTestClient(rpcUrl);
+
+    await testClient.setBalance({
+      address: RELAYER_ADDRESS,
+      value: parseEther("10"),
+    });
+
+    // Voter: enough ENS to clear the 1M quorum on its own.
+    // Proposer: clears ENS's 100K proposal threshold with buffer.
+    await fundFromTimelock(testClient, rpcUrl, TEST_USER_ADDRESS, QUORUM_VOTES);
+    await fundFromTimelock(
+      testClient,
+      rpcUrl,
+      PROPOSER_ADDRESS,
+      parseUnits("250000", 18),
+    );
+
+    // Self-delegate BEFORE the proposal snapshot so voting-power checkpoints
+    // exist at the snapshot block.
+    await selfDelegate(testClient, rpcUrl, TEST_USER_ADDRESS);
+    await selfDelegate(testClient, rpcUrl, PROPOSER_ADDRESS);
+
+    proposalId = await createNoOpProposal(testClient, rpcUrl, PROPOSER_ADDRESS);
+    const { votingPeriod } = await activateProposal(testClient, proposalId);
+
+    // Pass the proposal: vote FOR above quorum, then mine past the deadline.
+    await castVoteFor(testClient, rpcUrl, proposalId);
+    await mineBlocks(testClient, Number(votingPeriod) + 1);
+
+    expect(await proposalState(testClient, proposalId)).toBe(
+      ProposalState.Succeeded,
+    );
+
+    storage = new InMemoryKeeperStorage();
+    keeper = new ProposalLifecycleService(
+      testClient,
+      createLocalSigner(RELAYER_KEY, mainnet, rpcUrl),
+      storage,
+      {
+        governorAddress: GOVERNOR_ADDRESS,
+        startBlock: BigInt(FORK_BLOCK),
+        // Delays are wall-clock; the forked chain's timestamps are far in the
+        // past, so both gates pass immediately — delay gating is unit-tested.
+        queueDelaySeconds: 1800,
+        executionDelaySeconds: 1800,
+        minBalanceWei: parseEther("0.1").valueOf(),
+        // one getLogs call over the whole local range
+        maxBlockRange: 1_000_000n,
+      },
+      undefined,
+      silentLogger,
+    );
+    // Mining ~1 voting period (tens of thousands of blocks) on a fork is slow.
+  }, 600_000);
+
+  afterAll(async () => {
+    await stopAnvil();
+  });
+
+  it("queues a succeeded proposal and executes it after the timelock", async () => {
+    // Tick 1: discovers the proposal from logs and queues it.
+    await keeper.tick();
+    expect(await proposalState(testClient, proposalId)).toBe(
+      ProposalState.Queued,
+    );
+
+    // Cross the timelock eta on-chain.
+    const eta = await testClient.readContract({
+      address: GOVERNOR_ADDRESS,
+      abi: governorAbi,
+      functionName: "proposalEta",
+      args: [proposalId],
+    });
+    const { timestamp } = await testClient.getBlock();
+    await testClient.increaseTime({
+      seconds: Number(eta - timestamp) + 60,
+    });
+    await testClient.mine({ blocks: 1 });
+
+    // Tick 2: executes.
+    await keeper.tick();
+    expect(await proposalState(testClient, proposalId)).toBe(
+      ProposalState.Executed,
+    );
+
+    // Tick 3: executed proposals are untracked.
+    await keeper.tick();
+    expect(await storage.listProposals()).toEqual([]);
+  }, 120_000);
+});

--- a/apps/relayer/src/env.ts
+++ b/apps/relayer/src/env.ts
@@ -50,6 +50,27 @@ const envSchema = z.object({
     .positive()
     .optional(),
 
+  // Proposal lifecycle keeper — pays gas to queue()/execute() succeeded
+  // proposals. Off by default; KEEPER_START_BLOCK is required when enabled.
+  KEEPER_ENABLED: z
+    .enum(["true", "false"])
+    .default("false")
+    .transform((v) => v === "true"),
+  KEEPER_START_BLOCK: z.coerce.bigint().nonnegative().optional(),
+  KEEPER_POLL_INTERVAL_SECONDS: z.coerce.number().int().positive().default(300),
+  KEEPER_QUEUE_DELAY_SECONDS: z.coerce
+    .number()
+    .int()
+    .nonnegative()
+    .default(1800),
+  KEEPER_EXECUTION_DELAY_SECONDS: z.coerce
+    .number()
+    .int()
+    .nonnegative()
+    .default(1800),
+  // Widest fromBlock..toBlock span per log scan; RPC providers cap this.
+  KEEPER_MAX_BLOCK_RANGE: z.coerce.bigint().positive().default(10_000n),
+
   PORT: z.coerce.number().default(3002),
 
   // Injected by Railway. Reported on /health so gateful — which merges this
@@ -60,4 +81,9 @@ const envSchema = z.object({
   OTEL_EXPORTER_OTLP_ENDPOINT: z.url().optional(),
 });
 
-export const env = envSchema.parse(process.env);
+export const env = envSchema
+  .refine((e) => !e.KEEPER_ENABLED || e.KEEPER_START_BLOCK !== undefined, {
+    message: "KEEPER_START_BLOCK is required when KEEPER_ENABLED=true",
+    path: ["KEEPER_START_BLOCK"],
+  })
+  .parse(process.env);

--- a/apps/relayer/src/index.ts
+++ b/apps/relayer/src/index.ts
@@ -27,6 +27,9 @@ import {
   resolveRelayLimits,
 } from "@/services/guards/rate-limiter";
 import { ChainStateService } from "@/services/chain/chain-state";
+import { RedisKeeperStorage } from "@/repository/keeper-storage";
+import { startKeeperLoop } from "@/services/keeper/keeper-loop";
+import { ProposalLifecycleService } from "@/services/keeper/proposal-lifecycle";
 import { RelayService } from "@/services/relay";
 import { SignatureVerifier } from "@/services/guards/signature-verifier";
 import { createLocalSigner } from "@/signer/local-signer";
@@ -108,6 +111,38 @@ async function main() {
       tokenAddress,
     ),
   );
+
+  // --- Proposal lifecycle keeper ---
+  if (env.KEEPER_ENABLED) {
+    const keeperStartBlock = env.KEEPER_START_BLOCK;
+    if (keeperStartBlock === undefined) {
+      // unreachable: the env schema rejects KEEPER_ENABLED without a start block
+      throw new Error("KEEPER_START_BLOCK is required when KEEPER_ENABLED");
+    }
+    const keeperStorage = wrapWithTracing(
+      new RedisKeeperStorage(redis, env.DAO_NAME, governorAddress),
+    );
+    const keeper = wrapWithTracing(
+      new ProposalLifecycleService(publicClient, signer, keeperStorage, {
+        governorAddress,
+        startBlock: keeperStartBlock,
+        queueDelaySeconds: env.KEEPER_QUEUE_DELAY_SECONDS,
+        executionDelaySeconds: env.KEEPER_EXECUTION_DELAY_SECONDS,
+        minBalanceWei: BigInt(env.MIN_RELAYER_BALANCE_WEI),
+        maxBlockRange: env.KEEPER_MAX_BLOCK_RANGE,
+      }),
+    );
+    startKeeperLoop(keeper, env.KEEPER_POLL_INTERVAL_SECONDS * 1000, logger);
+    logger.info(
+      {
+        startBlock: keeperStartBlock.toString(),
+        pollIntervalSeconds: env.KEEPER_POLL_INTERVAL_SECONDS,
+        queueDelaySeconds: env.KEEPER_QUEUE_DELAY_SECONDS,
+        executionDelaySeconds: env.KEEPER_EXECUTION_DELAY_SECONDS,
+      },
+      "Proposal lifecycle keeper started",
+    );
+  }
 
   // --- App ---
   const app = new Hono({

--- a/apps/relayer/src/repository/keeper-storage.test.ts
+++ b/apps/relayer/src/repository/keeper-storage.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getAddress, keccak256, toBytes } from "viem";
+
+import type { TrackedProposal } from "@/services/keeper/proposal-lifecycle";
+
+import { RedisKeeperStorage, type KeeperRedisClient } from "./keeper-storage";
+
+const DAO = "ens";
+const GOVERNOR = getAddress("0x323A76393544d5ecca80cd6ef2A560C6a395b7E3");
+
+class FakeRedis implements KeeperRedisClient {
+  strings = new Map<string, string>();
+  hashes = new Map<string, Map<string, string>>();
+
+  async get(key: string): Promise<string | null> {
+    return this.strings.get(key) ?? null;
+  }
+  async set(key: string, value: string): Promise<unknown> {
+    this.strings.set(key, value);
+    return "OK";
+  }
+  async hSet(key: string, field: string, value: string): Promise<number> {
+    const hash = this.hashes.get(key) ?? new Map<string, string>();
+    hash.set(field, value);
+    this.hashes.set(key, hash);
+    return 1;
+  }
+  async hGetAll(key: string): Promise<Record<string, string>> {
+    return Object.fromEntries(this.hashes.get(key) ?? []);
+  }
+  async hDel(key: string, field: string): Promise<number> {
+    return this.hashes.get(key)?.delete(field) ? 1 : 0;
+  }
+}
+
+const PROPOSAL: TrackedProposal = {
+  proposalId: "42",
+  targets: [getAddress("0x2222222222222222222222222222222222222222")],
+  values: ["1000000000000000000"],
+  calldatas: ["0xdeadbeef"],
+  descriptionHash: keccak256(toBytes("hello")),
+  endBlock: "12345678",
+};
+
+let redis: FakeRedis;
+let storage: RedisKeeperStorage;
+
+beforeEach(() => {
+  redis = new FakeRedis();
+  storage = new RedisKeeperStorage(redis, DAO, GOVERNOR);
+});
+
+describe("cursor", () => {
+  it("returns null when no cursor has been stored", async () => {
+    expect(await storage.getCursor()).toBeNull();
+  });
+
+  it("round-trips the cursor as a bigint", async () => {
+    await storage.setCursor(23456789n);
+    expect(await storage.getCursor()).toBe(23456789n);
+  });
+});
+
+describe("proposals", () => {
+  it("lists nothing when empty", async () => {
+    expect(await storage.listProposals()).toEqual([]);
+  });
+
+  it("round-trips a tracked proposal", async () => {
+    await storage.putProposal(PROPOSAL);
+    expect(await storage.listProposals()).toEqual([PROPOSAL]);
+  });
+
+  it("removes a proposal by id", async () => {
+    await storage.putProposal(PROPOSAL);
+    await storage.removeProposal("42");
+    expect(await storage.listProposals()).toEqual([]);
+  });
+
+  it("scopes keys by dao and governor", async () => {
+    await storage.putProposal(PROPOSAL);
+    const other = new RedisKeeperStorage(redis, "uniswap", GOVERNOR);
+    expect(await other.listProposals()).toEqual([]);
+  });
+});

--- a/apps/relayer/src/repository/keeper-storage.ts
+++ b/apps/relayer/src/repository/keeper-storage.ts
@@ -1,0 +1,63 @@
+import { getAddress } from "viem";
+import type { Address } from "viem";
+
+import type {
+  KeeperStorage,
+  TrackedProposal,
+} from "@/services/keeper/proposal-lifecycle";
+
+export interface KeeperRedisClient {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<unknown>;
+  hSet(key: string, field: string, value: string): Promise<number>;
+  hGetAll(key: string): Promise<Record<string, string>>;
+  hDel(key: string, field: string): Promise<number>;
+}
+
+/**
+ * Redis-backed keeper state: a block cursor marking how far ProposalCreated
+ * logs have been scanned, and a hash of tracked proposals keyed by proposal id.
+ * TrackedProposal stores bigints as decimal strings, so plain JSON round-trips.
+ */
+export class RedisKeeperStorage implements KeeperStorage {
+  private readonly cursorKey: string;
+  private readonly proposalsKey: string;
+
+  constructor(
+    private redis: KeeperRedisClient,
+    daoName: string,
+    governorAddress: Address,
+  ) {
+    const base = `keeper:${daoName}:${getAddress(governorAddress)}`;
+    this.cursorKey = `${base}:cursor`;
+    this.proposalsKey = `${base}:proposals`;
+  }
+
+  async getCursor(): Promise<bigint | null> {
+    const raw = await this.redis.get(this.cursorKey);
+    return raw === null ? null : BigInt(raw);
+  }
+
+  async setCursor(block: bigint): Promise<void> {
+    await this.redis.set(this.cursorKey, block.toString());
+  }
+
+  async putProposal(proposal: TrackedProposal): Promise<void> {
+    await this.redis.hSet(
+      this.proposalsKey,
+      proposal.proposalId,
+      JSON.stringify(proposal),
+    );
+  }
+
+  async listProposals(): Promise<TrackedProposal[]> {
+    const entries = await this.redis.hGetAll(this.proposalsKey);
+    return Object.values(entries).map(
+      (raw) => JSON.parse(raw) as TrackedProposal,
+    );
+  }
+
+  async removeProposal(proposalId: string): Promise<void> {
+    await this.redis.hDel(this.proposalsKey, proposalId);
+  }
+}

--- a/apps/relayer/src/services/keeper/keeper-loop.test.ts
+++ b/apps/relayer/src/services/keeper/keeper-loop.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { createLogger } from "@anticapture/observability";
+
+import { startKeeperLoop } from "./keeper-loop";
+
+const silentLogger = createLogger("keeper-loop-test");
+silentLogger.level = "silent";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("startKeeperLoop", () => {
+  it("ticks immediately and then on every interval", async () => {
+    const tick = vi.fn().mockResolvedValue(undefined);
+
+    const loop = startKeeperLoop({ tick }, 1000, silentLogger);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(tick).toHaveBeenCalledTimes(3);
+
+    loop.stop();
+  });
+
+  it("skips a scheduled tick while the previous one is still running", async () => {
+    let release!: () => void;
+    const tick = vi
+      .fn()
+      .mockImplementation(
+        () => new Promise<void>((resolve) => (release = resolve)),
+      );
+
+    const loop = startKeeperLoop({ tick }, 1000, silentLogger);
+    await vi.advanceTimersByTimeAsync(0);
+    // first tick hangs across two intervals
+    await vi.advanceTimersByTimeAsync(2500);
+    expect(tick).toHaveBeenCalledTimes(1);
+
+    release();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(tick).toHaveBeenCalledTimes(2);
+
+    loop.stop();
+  });
+
+  it("keeps ticking after a tick rejects", async () => {
+    const tick = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("rpc down"))
+      .mockResolvedValue(undefined);
+
+    const loop = startKeeperLoop({ tick }, 1000, silentLogger);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(tick).toHaveBeenCalledTimes(2);
+
+    loop.stop();
+  });
+
+  it("stops ticking after stop()", async () => {
+    const tick = vi.fn().mockResolvedValue(undefined);
+
+    const loop = startKeeperLoop({ tick }, 1000, silentLogger);
+    await vi.advanceTimersByTimeAsync(0);
+    loop.stop();
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(tick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/relayer/src/services/keeper/keeper-loop.ts
+++ b/apps/relayer/src/services/keeper/keeper-loop.ts
@@ -1,0 +1,44 @@
+import type { Logger } from "@anticapture/observability";
+
+export interface Tickable {
+  tick(): Promise<void>;
+}
+
+export interface KeeperLoop {
+  stop(): void;
+}
+
+/**
+ * Runs the keeper on a fixed interval: one tick immediately on start, then
+ * one per interval. A tick that outlives the interval causes the overlapping
+ * runs to be skipped rather than piled up (one in-flight tick at a time).
+ */
+export function startKeeperLoop(
+  keeper: Tickable,
+  intervalMs: number,
+  logger: Logger,
+): KeeperLoop {
+  let running = false;
+
+  const runOnce = async () => {
+    if (running) return;
+    running = true;
+    try {
+      await keeper.tick();
+    } catch (err) {
+      logger.error({ err }, "keeper: tick failed");
+    } finally {
+      running = false;
+    }
+  };
+
+  // fire-and-forget: errors are handled inside runOnce
+  void runOnce();
+  const timer = setInterval(() => void runOnce(), intervalMs);
+
+  return {
+    stop() {
+      clearInterval(timer);
+    },
+  };
+}

--- a/apps/relayer/src/services/keeper/proposal-lifecycle.test.ts
+++ b/apps/relayer/src/services/keeper/proposal-lifecycle.test.ts
@@ -1,0 +1,395 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  Address,
+  encodeFunctionData,
+  getAddress,
+  Hash,
+  Hex,
+  keccak256,
+  toBytes,
+} from "viem";
+
+import { createLogger } from "@anticapture/observability";
+
+import { governorAbi, ProposalState } from "@/abi/governor";
+import { RelayerSigner } from "@/signer/types";
+
+const silentLogger = createLogger("keeper-test");
+silentLogger.level = "silent";
+
+import {
+  ProposalLifecycleService,
+  type KeeperChainReader,
+  type KeeperStorage,
+  type TrackedProposal,
+} from "./proposal-lifecycle";
+
+const GOVERNOR = getAddress("0x323A76393544d5ecca80cd6ef2A560C6a395b7E3");
+const RELAYER = getAddress("0x1111111111111111111111111111111111111111");
+const TARGET = getAddress("0x2222222222222222222222222222222222222222");
+
+const QUEUE_DELAY = 1800;
+const EXECUTION_DELAY = 1800;
+const MIN_BALANCE = 10n ** 17n; // 0.1 ETH
+const START_BLOCK = 50n;
+
+/** now() fixed at a round epoch so delay math is easy to follow. */
+const NOW = 1_700_000_000;
+
+interface FakeProposalChainState {
+  state?: number;
+  eta?: bigint;
+}
+
+class FakeChain {
+  latestBlock = 100n;
+  balance = 10n ** 18n; // 1 ETH
+  /** block number → timestamp (seconds) */
+  blockTimestamps = new Map<bigint, bigint>();
+  /** proposalId → on-chain state */
+  proposals = new Map<bigint, FakeProposalChainState>();
+  /** args recorded from getContractEvents calls */
+  eventQueries: { fromBlock: bigint; toBlock: bigint }[] = [];
+  /** events returned by the next getContractEvents call */
+  pendingEvents: { args: Record<string, unknown> }[] = [];
+  /** functionName of calls that were simulated */
+  simulated: string[] = [];
+  simulateError: Error | null = null;
+
+  reader: KeeperChainReader = {
+    getBlockNumber: async () => this.latestBlock,
+    getBlock: async ({ blockNumber }: { blockNumber?: bigint } = {}) => {
+      const timestamp = this.blockTimestamps.get(blockNumber ?? -1n);
+      if (timestamp === undefined) {
+        throw new Error(`no timestamp configured for block ${blockNumber}`);
+      }
+      return { timestamp } as Awaited<
+        ReturnType<KeeperChainReader["getBlock"]>
+      >;
+    },
+    getContractEvents: async (params: {
+      fromBlock?: unknown;
+      toBlock?: unknown;
+    }) => {
+      this.eventQueries.push({
+        fromBlock: params.fromBlock as bigint,
+        toBlock: params.toBlock as bigint,
+      });
+      const events = this.pendingEvents;
+      this.pendingEvents = [];
+      return events as Awaited<
+        ReturnType<KeeperChainReader["getContractEvents"]>
+      >;
+    },
+    readContract: async (params: {
+      functionName: string;
+      args?: readonly unknown[];
+    }) => {
+      const proposalId = params.args?.[0] as bigint;
+      const proposal = this.proposals.get(proposalId);
+      if (!proposal) throw new Error(`unknown proposal ${proposalId}`);
+      if (params.functionName === "state") return proposal.state;
+      if (params.functionName === "proposalEta") return proposal.eta ?? 0n;
+      throw new Error(`unexpected readContract ${params.functionName}`);
+    },
+    simulateContract: async (params: { functionName: string }) => {
+      if (this.simulateError) throw this.simulateError;
+      this.simulated.push(params.functionName);
+      return {} as Awaited<ReturnType<KeeperChainReader["simulateContract"]>>;
+    },
+    getBalance: async () => this.balance,
+    waitForTransactionReceipt: async () =>
+      ({ status: "success" }) as Awaited<
+        ReturnType<KeeperChainReader["waitForTransactionReceipt"]>
+      >,
+  } as unknown as KeeperChainReader;
+}
+
+class FakeStorage implements KeeperStorage {
+  cursor: bigint | null = null;
+  proposals = new Map<string, TrackedProposal>();
+
+  async getCursor(): Promise<bigint | null> {
+    return this.cursor;
+  }
+  async setCursor(block: bigint): Promise<void> {
+    this.cursor = block;
+  }
+  async putProposal(proposal: TrackedProposal): Promise<void> {
+    this.proposals.set(proposal.proposalId, proposal);
+  }
+  async listProposals(): Promise<TrackedProposal[]> {
+    return [...this.proposals.values()];
+  }
+  async removeProposal(proposalId: string): Promise<void> {
+    this.proposals.delete(proposalId);
+  }
+}
+
+class FakeSigner implements RelayerSigner {
+  sent: { to: Address; data: Hex }[] = [];
+  error: Error | null = null;
+
+  async getAddress(): Promise<Address> {
+    return RELAYER;
+  }
+  async sendTransaction(tx: { to: Address; data: Hex }): Promise<Hash> {
+    if (this.error) throw this.error;
+    this.sent.push(tx);
+    return "0xtxhash" as Hash;
+  }
+}
+
+/** A tracked proposal already persisted in storage, as if discovered earlier. */
+function trackedProposal(
+  overrides: Partial<TrackedProposal> = {},
+): TrackedProposal {
+  return {
+    proposalId: "1",
+    targets: [TARGET],
+    values: ["0"],
+    calldatas: ["0x"],
+    descriptionHash: keccak256(toBytes("a proposal")),
+    endBlock: "90",
+    ...overrides,
+  };
+}
+
+function createdEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    args: {
+      proposalId: 1n,
+      targets: [TARGET],
+      values: [0n],
+      calldatas: ["0x" as Hex],
+      description: "a proposal",
+      endBlock: 90n,
+      ...overrides,
+    },
+  };
+}
+
+let chain: FakeChain;
+let storage: FakeStorage;
+let signer: FakeSigner;
+let service: ProposalLifecycleService;
+
+beforeEach(() => {
+  chain = new FakeChain();
+  storage = new FakeStorage();
+  signer = new FakeSigner();
+  service = new ProposalLifecycleService(
+    chain.reader,
+    signer,
+    storage,
+    {
+      governorAddress: GOVERNOR,
+      startBlock: START_BLOCK,
+      queueDelaySeconds: QUEUE_DELAY,
+      executionDelaySeconds: EXECUTION_DELAY,
+      minBalanceWei: MIN_BALANCE,
+    },
+    () => NOW,
+    silentLogger,
+  );
+});
+
+describe("queueing", () => {
+  it("queues a succeeded proposal once the queue delay has passed", async () => {
+    await storage.putProposal(trackedProposal());
+    chain.proposals.set(1n, { state: ProposalState.Succeeded });
+    // voting ended exactly queueDelay ago
+    chain.blockTimestamps.set(90n, BigInt(NOW - QUEUE_DELAY));
+
+    await service.tick();
+
+    expect(chain.simulated).toEqual(["queue"]);
+    expect(signer.sent).toEqual([
+      {
+        to: GOVERNOR,
+        data: encodeFunctionData({
+          abi: governorAbi,
+          functionName: "queue",
+          args: [[TARGET], [0n], ["0x"], keccak256(toBytes("a proposal"))],
+        }),
+      },
+    ]);
+  });
+
+  it("does not queue before the queue delay has passed", async () => {
+    await storage.putProposal(trackedProposal());
+    chain.proposals.set(1n, { state: ProposalState.Succeeded });
+    chain.blockTimestamps.set(90n, BigInt(NOW - QUEUE_DELAY + 1));
+
+    await service.tick();
+
+    expect(signer.sent).toEqual([]);
+  });
+});
+
+describe("execution", () => {
+  it("executes a queued proposal once eta plus the execution delay has passed", async () => {
+    await storage.putProposal(trackedProposal());
+    chain.proposals.set(1n, {
+      state: ProposalState.Queued,
+      eta: BigInt(NOW - EXECUTION_DELAY),
+    });
+
+    await service.tick();
+
+    expect(chain.simulated).toEqual(["execute"]);
+    expect(signer.sent).toEqual([
+      {
+        to: GOVERNOR,
+        data: encodeFunctionData({
+          abi: governorAbi,
+          functionName: "execute",
+          args: [[TARGET], [0n], ["0x"], keccak256(toBytes("a proposal"))],
+        }),
+      },
+    ]);
+  });
+
+  it("does not execute before eta plus the execution delay", async () => {
+    await storage.putProposal(trackedProposal());
+    chain.proposals.set(1n, {
+      state: ProposalState.Queued,
+      eta: BigInt(NOW - EXECUTION_DELAY + 1),
+    });
+
+    await service.tick();
+
+    expect(signer.sent).toEqual([]);
+  });
+});
+
+describe("untracking", () => {
+  it.each([
+    ["canceled", ProposalState.Canceled],
+    ["defeated", ProposalState.Defeated],
+    ["expired", ProposalState.Expired],
+    ["executed", ProposalState.Executed],
+  ])("stops tracking a %s proposal", async (_label, state) => {
+    await storage.putProposal(trackedProposal());
+    chain.proposals.set(1n, { state });
+
+    await service.tick();
+
+    expect(await storage.listProposals()).toEqual([]);
+    expect(signer.sent).toEqual([]);
+  });
+
+  it("keeps tracking pending and active proposals", async () => {
+    await storage.putProposal(trackedProposal());
+    chain.proposals.set(1n, { state: ProposalState.Pending });
+
+    await service.tick();
+
+    expect(await storage.listProposals()).toEqual([trackedProposal()]);
+  });
+});
+
+describe("safety", () => {
+  it("skips broadcasting when the relayer balance is below the minimum", async () => {
+    chain.balance = MIN_BALANCE - 1n;
+    await storage.putProposal(trackedProposal());
+    chain.proposals.set(1n, { state: ProposalState.Succeeded });
+    chain.blockTimestamps.set(90n, BigInt(NOW - QUEUE_DELAY));
+
+    await service.tick();
+
+    expect(chain.simulated).toEqual([]);
+    expect(signer.sent).toEqual([]);
+    // still tracked — retried once the wallet is topped up
+    expect(await storage.listProposals()).toEqual([trackedProposal()]);
+  });
+
+  it("does not broadcast when simulation reverts, and keeps tracking", async () => {
+    chain.simulateError = new Error("execution reverted");
+    await storage.putProposal(trackedProposal());
+    chain.proposals.set(1n, { state: ProposalState.Succeeded });
+    chain.blockTimestamps.set(90n, BigInt(NOW - QUEUE_DELAY));
+
+    await service.tick();
+
+    expect(signer.sent).toEqual([]);
+    expect(await storage.listProposals()).toEqual([trackedProposal()]);
+  });
+
+  it("processes remaining proposals when one fails", async () => {
+    chain.simulateError = null;
+    await storage.putProposal(trackedProposal({ proposalId: "1" }));
+    await storage.putProposal(trackedProposal({ proposalId: "2" }));
+    // proposal 1 blows up on the state read; proposal 2 should still be executed
+    chain.proposals.set(2n, {
+      state: ProposalState.Queued,
+      eta: BigInt(NOW - EXECUTION_DELAY),
+    });
+
+    await service.tick();
+
+    expect(chain.simulated).toEqual(["execute"]);
+    expect(signer.sent).toHaveLength(1);
+  });
+});
+
+describe("discovery", () => {
+  it("tracks proposals from ProposalCreated events and advances the cursor", async () => {
+    chain.pendingEvents = [createdEvent()];
+    chain.proposals.set(1n, { state: ProposalState.Active });
+
+    await service.tick();
+
+    expect(chain.eventQueries).toEqual([
+      { fromBlock: START_BLOCK, toBlock: 100n },
+    ]);
+    expect(await storage.listProposals()).toEqual([trackedProposal()]);
+    expect(storage.cursor).toBe(101n);
+  });
+
+  it("splits log scans into chunks of maxBlockRange", async () => {
+    service = new ProposalLifecycleService(
+      chain.reader,
+      signer,
+      storage,
+      {
+        governorAddress: GOVERNOR,
+        startBlock: START_BLOCK,
+        queueDelaySeconds: QUEUE_DELAY,
+        executionDelaySeconds: EXECUTION_DELAY,
+        minBalanceWei: MIN_BALANCE,
+        maxBlockRange: 20n,
+      },
+      () => NOW,
+      silentLogger,
+    );
+    chain.latestBlock = 100n; // 51 blocks from START_BLOCK (50) inclusive
+
+    await service.tick();
+
+    expect(chain.eventQueries).toEqual([
+      { fromBlock: 50n, toBlock: 69n },
+      { fromBlock: 70n, toBlock: 89n },
+      { fromBlock: 90n, toBlock: 100n },
+    ]);
+    expect(storage.cursor).toBe(101n);
+  });
+
+  it("resumes scanning from the stored cursor", async () => {
+    storage.cursor = 80n;
+
+    await service.tick();
+
+    expect(chain.eventQueries).toEqual([{ fromBlock: 80n, toBlock: 100n }]);
+  });
+
+  it("does not scan when the cursor is ahead of the chain head", async () => {
+    storage.cursor = 101n;
+    chain.latestBlock = 100n;
+
+    await service.tick();
+
+    expect(chain.eventQueries).toEqual([]);
+    expect(storage.cursor).toBe(101n);
+  });
+});

--- a/apps/relayer/src/services/keeper/proposal-lifecycle.ts
+++ b/apps/relayer/src/services/keeper/proposal-lifecycle.ts
@@ -1,0 +1,231 @@
+import {
+  Address,
+  encodeFunctionData,
+  Hex,
+  keccak256,
+  toBytes,
+  type PublicActions,
+} from "viem";
+
+import { createLogger, type Logger } from "@anticapture/observability";
+
+import { governorAbi, ProposalState } from "@/abi/governor";
+import { RelayerSigner } from "@/signer/types";
+
+/**
+ * Narrow interface covering only the viem actions the keeper uses.
+ * A real PublicClient satisfies this via structural subtyping.
+ */
+export type KeeperChainReader = Pick<
+  PublicActions,
+  | "getBlockNumber"
+  | "getBlock"
+  | "getContractEvents"
+  | "readContract"
+  | "simulateContract"
+  | "getBalance"
+  | "waitForTransactionReceipt"
+>;
+
+/**
+ * A proposal the keeper is watching, with everything needed to call
+ * queue()/execute(). bigints are stored as decimal strings so the
+ * record round-trips through JSON (Redis).
+ */
+export interface TrackedProposal {
+  proposalId: string;
+  targets: Address[];
+  values: string[];
+  calldatas: Hex[];
+  descriptionHash: Hex;
+  endBlock: string;
+}
+
+export interface KeeperStorage {
+  getCursor(): Promise<bigint | null>;
+  setCursor(block: bigint): Promise<void>;
+  putProposal(proposal: TrackedProposal): Promise<void>;
+  listProposals(): Promise<TrackedProposal[]>;
+  removeProposal(proposalId: string): Promise<void>;
+}
+
+export interface KeeperConfig {
+  governorAddress: Address;
+  /** First block scanned for ProposalCreated when no cursor is stored yet. */
+  startBlock: bigint;
+  queueDelaySeconds: number;
+  executionDelaySeconds: number;
+  /** Below this relayer balance the keeper logs and skips broadcasting. */
+  minBalanceWei: bigint;
+  /** Widest fromBlock..toBlock span per getLogs call; RPC providers cap this. */
+  maxBlockRange?: bigint;
+}
+
+const DEFAULT_MAX_BLOCK_RANGE = 10_000n;
+
+/**
+ * Watches Governor proposals and pays the gas nobody else will:
+ * queue() once a proposal succeeds and execute() once its timelock
+ * delay passes, each after a configurable grace delay.
+ */
+export class ProposalLifecycleService {
+  constructor(
+    private chain: KeeperChainReader,
+    private signer: RelayerSigner,
+    private storage: KeeperStorage,
+    private config: KeeperConfig,
+    /** Unix seconds; injectable for tests. */
+    private now: () => number = () => Math.floor(Date.now() / 1000),
+    private logger: Logger = createLogger("relayer-keeper"),
+  ) {}
+
+  async tick(): Promise<void> {
+    await this.discoverProposals();
+    const tracked = await this.storage.listProposals();
+    for (const proposal of tracked) {
+      try {
+        await this.processProposal(proposal);
+      } catch (err) {
+        this.logger.error(
+          { err, proposalId: proposal.proposalId },
+          "keeper: failed to process proposal",
+        );
+      }
+    }
+  }
+
+  private async discoverProposals(): Promise<void> {
+    const latest = await this.chain.getBlockNumber();
+    const cursor = (await this.storage.getCursor()) ?? this.config.startBlock;
+    if (latest < cursor) return;
+
+    const maxRange = this.config.maxBlockRange ?? DEFAULT_MAX_BLOCK_RANGE;
+    for (let fromBlock = cursor; fromBlock <= latest; fromBlock += maxRange) {
+      const toBlock =
+        fromBlock + maxRange - 1n < latest ? fromBlock + maxRange - 1n : latest;
+      await this.scanRange(fromBlock, toBlock);
+      // persist progress per chunk so a long backfill resumes where it stopped
+      await this.storage.setCursor(toBlock + 1n);
+    }
+  }
+
+  private async scanRange(fromBlock: bigint, toBlock: bigint): Promise<void> {
+    const events = await this.chain.getContractEvents({
+      address: this.config.governorAddress,
+      abi: governorAbi,
+      eventName: "ProposalCreated",
+      fromBlock,
+      toBlock,
+    });
+
+    for (const event of events) {
+      const args = event.args as {
+        proposalId: bigint;
+        targets: readonly Address[];
+        values: readonly bigint[];
+        calldatas: readonly Hex[];
+        description: string;
+        endBlock: bigint;
+      };
+      await this.storage.putProposal({
+        proposalId: args.proposalId.toString(),
+        targets: [...args.targets],
+        values: args.values.map((v) => v.toString()),
+        calldatas: [...args.calldatas],
+        descriptionHash: keccak256(toBytes(args.description)),
+        endBlock: args.endBlock.toString(),
+      });
+    }
+  }
+
+  private async processProposal(proposal: TrackedProposal): Promise<void> {
+    const state = await this.chain.readContract({
+      address: this.config.governorAddress,
+      abi: governorAbi,
+      functionName: "state",
+      args: [BigInt(proposal.proposalId)],
+    });
+
+    const terminalStates = [
+      ProposalState.Canceled,
+      ProposalState.Defeated,
+      ProposalState.Expired,
+      ProposalState.Executed,
+    ];
+    if (terminalStates.includes(state)) {
+      await this.storage.removeProposal(proposal.proposalId);
+      return;
+    }
+
+    if (state === ProposalState.Succeeded) {
+      const { timestamp: votingEnd } = await this.chain.getBlock({
+        blockNumber: BigInt(proposal.endBlock),
+      });
+      if (
+        BigInt(this.now()) >=
+        votingEnd + BigInt(this.config.queueDelaySeconds)
+      ) {
+        await this.broadcast(proposal, "queue");
+      }
+      return;
+    }
+
+    if (state === ProposalState.Queued) {
+      const eta = await this.chain.readContract({
+        address: this.config.governorAddress,
+        abi: governorAbi,
+        functionName: "proposalEta",
+        args: [BigInt(proposal.proposalId)],
+      });
+      if (
+        BigInt(this.now()) >=
+        eta + BigInt(this.config.executionDelaySeconds)
+      ) {
+        await this.broadcast(proposal, "execute");
+      }
+    }
+  }
+
+  private async broadcast(
+    proposal: TrackedProposal,
+    functionName: "queue" | "execute",
+  ): Promise<void> {
+    const relayerAddress = await this.signer.getAddress();
+
+    const balance = await this.chain.getBalance({ address: relayerAddress });
+    if (balance < this.config.minBalanceWei) {
+      this.logger.error(
+        {
+          proposalId: proposal.proposalId,
+          action: functionName,
+          balance: balance.toString(),
+          minBalanceWei: this.config.minBalanceWei.toString(),
+        },
+        "keeper: relayer balance below minimum, skipping broadcast",
+      );
+      return;
+    }
+
+    const args = [
+      proposal.targets,
+      proposal.values.map(BigInt),
+      proposal.calldatas,
+      proposal.descriptionHash,
+    ] as const;
+
+    await this.chain.simulateContract({
+      address: this.config.governorAddress,
+      abi: governorAbi,
+      functionName,
+      args,
+      account: relayerAddress,
+    });
+
+    const hash = await this.signer.sendTransaction({
+      to: this.config.governorAddress,
+      data: encodeFunctionData({ abi: governorAbi, functionName, args }),
+    });
+
+    await this.chain.waitForTransactionReceipt({ hash });
+  }
+}


### PR DESCRIPTION
## Summary

ENS DAO proposals stall in `Succeeded`/`Queued` for days because `queue()`/`execute()` on the Governor are permissionless and nobody pays the gas ([DEV-700](https://app.clickup.com/t/86ahgvag1)).

This adds an **opt-in keeper loop** to the relayer that watches Governor proposals and pays that gas:

- `state == Succeeded` and `now >= votingEnd + KEEPER_QUEUE_DELAY_SECONDS` (default 1800) → `queue()`
- `state == Queued` and `now >= proposalEta + KEEPER_EXECUTION_DELAY_SECONDS` (default 1800) → `execute()`

Architecture decision (ticket open question #1): implemented as a **self-contained poller inside the relayer** rather than relayer endpoints triggered by notification-system. The anticapture REST API doesn't expose `targets/values/calldatas` (which `queue()`/`execute()` need), so the relayer would have to read chain logs anyway — doing it directly avoids a cross-service dependency and removes the endpoint-auth question entirely (no new public surface).

## How it works

`ProposalLifecycleService.tick()` (every `KEEPER_POLL_INTERVAL_SECONDS`, default 300):
1. **Discover** — scan `ProposalCreated` logs from a Redis-persisted block cursor (chunked by `KEEPER_MAX_BLOCK_RANGE` for RPC provider limits; cursor advances per chunk so long backfills resume).
2. **Track** — store proposal id, targets, values, calldatas, descriptionHash, endBlock in Redis.
3. **Act** — read `state()` per proposal; simulate then broadcast `queue()`/`execute()` when due; untrack on terminal states.

Safety rails:
- Skips broadcasting (logs an error) when the relayer balance is below `MIN_RELAYER_BALANCE_WEI` — funding alerts ride the existing `/balance` monitoring.
- Failed simulation → no tx, proposal stays tracked and retries next tick.
- One failing proposal never blocks the rest; a failing tick never kills the loop; ticks don't overlap.
- Off by default (`KEEPER_ENABLED=false`); `KEEPER_START_BLOCK` required when enabled.

## Testing

- **Unit: 26 new tests** (57 total green) covering discovery/cursor/chunking, queue/execute delay gates, terminal-state untracking, balance guard, simulation-revert handling, failure isolation, Redis storage round-trips, loop overlap/error behavior.
- **E2e** (`e2e/keeper.test.ts`): full lifecycle on an anvil mainnet fork — propose → vote past quorum → Succeeded → `tick()` queues → timelock elapses → `tick()` executes → untracked. Quorum-scale funding impersonates the ENS DAO timelock (the shared Binance whale no longer holds 1M+ ENS).
  - ⚠️ **Not verified locally end-to-end**: every archive-RPC key in my local envs is stale (Chainstack/Alchemy 401, dev eRPC domain removed). Please run `pnpm test:e2e e2e/keeper.test.ts` with a working archive `RPC_URL`. Note it mines a full voting period (~46k blocks), so the suite takes several minutes.

## Deploy notes

- New env vars documented in `.env.example`; keeper stays off everywhere until `KEEPER_ENABLED=true` + `KEEPER_START_BLOCK` are set (pick a block before the oldest proposal the keeper should manage — proposals created before the start block are never tracked, including already-queued ones).
- `execute()` gas is proposal-dependent; there's deliberately no gas-price ceiling in v1 — flagging for review whether we want one before enabling in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)