### PR TITLE
feat(dashboard): show every monitored DAO on the panel

### DIFF
--- a/.changeset/panel-v21-table-scroll.md
+++ b/.changeset/panel-v21-table-scroll.md
@@ -2,4 +2,4 @@
 "@anticapture/dashboard": minor
 ---
 
-Show every monitored DAO on the panel instead of scrolling the table inside a fixed-height viewport — the homepage itself now scrolls.
+Show every monitored DAO on the panel: the homepage itself now scrolls and the table header stays pinned on desktop.

--- a/.changeset/panel-v21-table-scroll.md
+++ b/.changeset/panel-v21-table-scroll.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": minor
+---
+
+Show every monitored DAO on the panel instead of scrolling the table inside a fixed-height viewport — the homepage itself now scrolls.

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -51,12 +51,12 @@ export default function Home() {
     <div className="bg-surface-background dark flex h-screen overflow-hidden">
       <JsonLd data={softwareApplicationSchema} />
       <HeaderSidebar />
-      <main className="flex-1 overflow-auto lg:flex lg:min-h-0 lg:flex-col lg:overflow-hidden">
+      <main className="flex-1 overflow-auto">
         <div className="lg:hidden">
           <HeaderMobile className="fixed! top-0" />
         </div>
-        <div className="flex min-h-screen w-full flex-col items-center lg:h-full lg:min-h-0 lg:flex-1">
-          <div className="w-full flex-1 lg:flex lg:min-h-0 lg:flex-col">
+        <div className="flex min-h-screen w-full flex-col items-center">
+          <div className="w-full flex-1">
             <PanelSection />
           </div>
           <Footer />

--- a/apps/dashboard/e2e/panel.spec.ts
+++ b/apps/dashboard/e2e/panel.spec.ts
@@ -103,51 +103,67 @@ test.describe("Panel page", () => {
       .toBe(true);
   });
 
-  test("keeps the table header pinned while the desktop page scrolls", async ({
-    goto,
-    page,
-  }) => {
-    await page.setViewportSize(SHORT_DESKTOP_VIEWPORT);
-    await page.route("**/api/user/api/auth/get-session", (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: "null",
-      }),
-    );
-    await goto("/");
+  // 1024 exercises the lg band, where the sidebar is up but headers may
+  // wrap; 1920 exercises the roomy layout. The header must pin in both.
+  for (const width of [1024, SHORT_DESKTOP_VIEWPORT.width]) {
+    test(`keeps the table header pinned while the ${width}px desktop page scrolls`, async ({
+      goto,
+      page,
+    }) => {
+      await page.setViewportSize({
+        width,
+        height: SHORT_DESKTOP_VIEWPORT.height,
+      });
+      await page.route("**/api/user/api/auth/get-session", (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: "null",
+        }),
+      );
+      await goto("/");
 
-    await expect(page.locator("table thead").first()).toBeVisible({
-      timeout: 15_000,
-    });
-
-    // Metric cells stream in after load and keep growing the page, so the
-    // scroll, its precondition, and the header measurement all happen inside
-    // one polled evaluation: scroll `main` (the page scroller) to the bottom,
-    // confirm the table top actually left through the top of the scrollport,
-    // and read where the sticky header rests.
-    const positions = () =>
-      page.locator("main").evaluate((main) => {
-        main.scrollTop = main.scrollHeight;
-        const table = main.querySelector("table");
-        const thead = table?.querySelector("thead");
-        if (!table || !thead) return { tableTop: NaN, theadTop: NaN };
-        return {
-          tableTop: table.getBoundingClientRect().top,
-          theadTop: thead.getBoundingClientRect().top,
-        };
+      await expect(page.locator("table thead").first()).toBeVisible({
+        timeout: 15_000,
       });
 
-    await expect
-      .poll(async () => (await positions()).tableTop, { timeout: 15_000 })
-      .toBeLessThan(0);
+      // Metric cells stream in after load and keep growing the page, so the
+      // scroll, its precondition, and the header measurement all happen inside
+      // one polled evaluation: park the table top 150px above the scrollport
+      // of `main` (the page scroller) — never "scroll to bottom", sections
+      // after the table would push it entirely off screen — then read where
+      // the sticky header rests.
+      const positions = () =>
+        page.locator("main").evaluate((main) => {
+          const table = main.querySelector("table");
+          const thead = table?.querySelector("thead");
+          if (!table || !thead)
+            return { tableTop: NaN, theadTop: NaN, mainOverflowX: NaN };
+          main.scrollTop +=
+            table.getBoundingClientRect().top -
+            main.getBoundingClientRect().top +
+            150;
+          return {
+            tableTop: table.getBoundingClientRect().top,
+            theadTop: thead.getBoundingClientRect().top,
+            mainOverflowX: main.scrollWidth - main.clientWidth,
+          };
+        });
 
-    const { tableTop, theadTop } = await positions();
-    expect(tableTop).toBeLessThan(0);
-    // Pinned means resting at the top of the scrollport (sticky -top-px).
-    expect(theadTop).toBeGreaterThanOrEqual(-2);
-    expect(theadTop).toBeLessThanOrEqual(2);
-  });
+      await expect
+        .poll(async () => (await positions()).tableTop, { timeout: 15_000 })
+        .toBeLessThan(0);
+
+      const { tableTop, theadTop, mainOverflowX } = await positions();
+      expect(tableTop).toBeLessThan(0);
+      // Pinned means resting at the top of the scrollport (sticky -top-px).
+      expect(theadTop).toBeGreaterThanOrEqual(-2);
+      expect(theadTop).toBeLessThanOrEqual(2);
+      // The un-scrollported table must not leak a page-level horizontal
+      // scrollbar; column headers wrap below xl to keep this true.
+      expect(mainOverflowX).toBe(0);
+    });
+  }
 
   test("sortable column headers respond to clicks", async ({ goto, page }) => {
     await goto("/");

--- a/apps/dashboard/e2e/panel.spec.ts
+++ b/apps/dashboard/e2e/panel.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from "./fixtures";
 
+/* Desktop width, but shorter than the table: the layout-sensitive tests below
+ * all need the page to scroll vertically past the table. */
+const SHORT_DESKTOP_VIEWPORT = { width: 1920, height: 640 };
+
 test.describe("Panel page", () => {
   test(
     "renders the panel hero heading and description",
@@ -63,8 +67,7 @@ test.describe("Panel page", () => {
     goto,
     page,
   }) => {
-    const shortViewport = { width: 1920, height: 640 };
-    await page.setViewportSize(shortViewport);
+    await page.setViewportSize(SHORT_DESKTOP_VIEWPORT);
     await page.route("**/api/user/api/auth/get-session", (route) =>
       route.fulfill({
         status: 200,
@@ -90,7 +93,7 @@ test.describe("Panel page", () => {
     // height, past the bottom of this viewport, and `main` is what scrolls.
     await expect
       .poll(() => tableContainer.evaluate((element) => element.clientHeight))
-      .toBeGreaterThan(shortViewport.height);
+      .toBeGreaterThan(SHORT_DESKTOP_VIEWPORT.height);
     await expect
       .poll(() =>
         page
@@ -104,37 +107,46 @@ test.describe("Panel page", () => {
     goto,
     page,
   }) => {
-    // Short enough that the table cannot fit the viewport, so scrolling to
-    // the bottom pushes the table top past the top of the scrollport.
-    await page.setViewportSize({ width: 1920, height: 640 });
+    await page.setViewportSize(SHORT_DESKTOP_VIEWPORT);
+    await page.route("**/api/user/api/auth/get-session", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "null",
+      }),
+    );
     await goto("/");
 
-    const thead = page.locator("table thead").first();
-    await expect(thead).toBeVisible({ timeout: 15_000 });
-
-    // Scroll `main` (the page scroller) to the bottom: the rows leave through
-    // the top while the sticky header must stay pinned to the scrollport.
-    await page.locator("main").evaluate((main) => {
-      main.scrollTop = main.scrollHeight;
+    await expect(page.locator("table thead").first()).toBeVisible({
+      timeout: 15_000,
     });
 
-    // The table top must actually be above the scrollport for the header to
-    // have anything to pin against; the footer below the table ensures it.
+    // Metric cells stream in after load and keep growing the page, so the
+    // scroll, its precondition, and the header measurement all happen inside
+    // one polled evaluation: scroll `main` (the page scroller) to the bottom,
+    // confirm the table top actually left through the top of the scrollport,
+    // and read where the sticky header rests.
+    const positions = () =>
+      page.locator("main").evaluate((main) => {
+        main.scrollTop = main.scrollHeight;
+        const table = main.querySelector("table");
+        const thead = table?.querySelector("thead");
+        if (!table || !thead) return { tableTop: NaN, theadTop: NaN };
+        return {
+          tableTop: table.getBoundingClientRect().top,
+          theadTop: thead.getBoundingClientRect().top,
+        };
+      });
+
     await expect
-      .poll(() =>
-        page
-          .locator("table")
-          .first()
-          .evaluate((table) => table.getBoundingClientRect().top),
-      )
+      .poll(async () => (await positions()).tableTop, { timeout: 15_000 })
       .toBeLessThan(0);
 
-    await expect(thead).toBeVisible();
-    const theadBox = await thead.boundingBox();
-    expect(theadBox).not.toBeNull();
+    const { tableTop, theadTop } = await positions();
+    expect(tableTop).toBeLessThan(0);
     // Pinned means resting at the top of the scrollport (sticky -top-px).
-    expect(theadBox!.y).toBeGreaterThanOrEqual(-5);
-    expect(theadBox!.y).toBeLessThanOrEqual(5);
+    expect(theadTop).toBeGreaterThanOrEqual(-2);
+    expect(theadTop).toBeLessThanOrEqual(2);
   });
 
   test("sortable column headers respond to clicks", async ({ goto, page }) => {

--- a/apps/dashboard/e2e/panel.spec.ts
+++ b/apps/dashboard/e2e/panel.spec.ts
@@ -63,7 +63,8 @@ test.describe("Panel page", () => {
     goto,
     page,
   }) => {
-    await page.setViewportSize({ width: 1920, height: 640 });
+    const shortViewport = { width: 1920, height: 640 };
+    await page.setViewportSize(shortViewport);
     await page.route("**/api/user/api/auth/get-session", (route) =>
       route.fulfill({
         status: 200,
@@ -84,11 +85,17 @@ test.describe("Panel page", () => {
     expect(tableBox).not.toBeNull();
     expect(footerBox).not.toBeNull();
     expect(tableBox!.y + tableBox!.height).toBeLessThanOrEqual(footerBox!.y);
+
+    // The table is no longer an inner scroll box: every row lays out at full
+    // height, past the bottom of this viewport, and `main` is what scrolls.
+    await expect
+      .poll(() => tableContainer.evaluate((element) => element.clientHeight))
+      .toBeGreaterThan(shortViewport.height);
     await expect
       .poll(() =>
-        tableContainer.evaluate(
-          (element) => element.scrollHeight > element.clientHeight,
-        ),
+        page
+          .locator("main")
+          .evaluate((element) => element.scrollHeight > element.clientHeight),
       )
       .toBe(true);
   });

--- a/apps/dashboard/e2e/panel.spec.ts
+++ b/apps/dashboard/e2e/panel.spec.ts
@@ -100,6 +100,43 @@ test.describe("Panel page", () => {
       .toBe(true);
   });
 
+  test("keeps the table header pinned while the desktop page scrolls", async ({
+    goto,
+    page,
+  }) => {
+    // Short enough that the table cannot fit the viewport, so scrolling to
+    // the bottom pushes the table top past the top of the scrollport.
+    await page.setViewportSize({ width: 1920, height: 640 });
+    await goto("/");
+
+    const thead = page.locator("table thead").first();
+    await expect(thead).toBeVisible({ timeout: 15_000 });
+
+    // Scroll `main` (the page scroller) to the bottom: the rows leave through
+    // the top while the sticky header must stay pinned to the scrollport.
+    await page.locator("main").evaluate((main) => {
+      main.scrollTop = main.scrollHeight;
+    });
+
+    // The table top must actually be above the scrollport for the header to
+    // have anything to pin against; the footer below the table ensures it.
+    await expect
+      .poll(() =>
+        page
+          .locator("table")
+          .first()
+          .evaluate((table) => table.getBoundingClientRect().top),
+      )
+      .toBeLessThan(0);
+
+    await expect(thead).toBeVisible();
+    const theadBox = await thead.boundingBox();
+    expect(theadBox).not.toBeNull();
+    // Pinned means resting at the top of the scrollport (sticky -top-px).
+    expect(theadBox!.y).toBeGreaterThanOrEqual(-5);
+    expect(theadBox!.y).toBeLessThanOrEqual(5);
+  });
+
   test("sortable column headers respond to clicks", async ({ goto, page }) => {
     await goto("/");
     await expect(page.locator("table").first()).toBeVisible({

--- a/apps/dashboard/features/panel/PanelSection.tsx
+++ b/apps/dashboard/features/panel/PanelSection.tsx
@@ -8,17 +8,16 @@ import {
 
 export const PanelSection = () => {
   return (
-    <div className="mt-12 flex h-full w-full flex-col gap-5 px-4 py-5 lg:mt-0 lg:min-h-0 lg:gap-2 lg:p-5">
+    <div className="mt-12 flex w-full flex-col gap-5 px-4 py-5 lg:mt-0 lg:gap-2 lg:p-5">
       <PanelHero />
 
       <LatestFindingTicker />
 
-      <SubSectionsContainer className="gap-3 lg:min-h-0 lg:flex-1">
+      <SubSectionsContainer className="gap-3">
         <SubSection
           className="gap-0"
           subsectionTitle={"Monitored DAOs"}
           dateRange=""
-          contentClassName="lg:flex lg:flex-col lg:flex-1 lg:min-h-0"
         >
           <PanelTable />
         </SubSection>

--- a/apps/dashboard/features/panel/components/PanelTable.tsx
+++ b/apps/dashboard/features/panel/components/PanelTable.tsx
@@ -223,6 +223,11 @@ export const PanelTable = () => {
       data={allDaos}
       withSorting={true}
       wrapperClassName="min-h-[400px]"
+      /* On desktop the page (main) is the scroller, so the container must not
+       * be a scrollport or the sticky header would pin to it and scroll away.
+       * Mobile keeps the inner horizontal scroll: the header never pinned
+       * there, and HeaderMobile is fixed with no offset to pin under. */
+      containerClassName="lg:overflow-visible"
       stickyFirstColumn={true}
       pinRowsToBottom={(row) => row.isPartiallyIndexed}
       getRowClassName={(row, index, rows) => {

--- a/apps/dashboard/features/panel/components/PanelTable.tsx
+++ b/apps/dashboard/features/panel/components/PanelTable.tsx
@@ -222,8 +222,7 @@ export const PanelTable = () => {
       columns={panelColumns}
       data={allDaos}
       withSorting={true}
-      fillHeight={true}
-      wrapperClassName="min-h-[400px] lg:min-h-0"
+      wrapperClassName="min-h-[400px]"
       stickyFirstColumn={true}
       pinRowsToBottom={(row) => row.isPartiallyIndexed}
       getRowClassName={(row, index, rows) => {

--- a/apps/dashboard/features/panel/components/PanelTable.tsx
+++ b/apps/dashboard/features/panel/components/PanelTable.tsx
@@ -225,9 +225,12 @@ export const PanelTable = () => {
       wrapperClassName="min-h-[400px]"
       /* On desktop the page (main) is the scroller, so the container must not
        * be a scrollport or the sticky header would pin to it and scroll away.
-       * Mobile keeps the inner horizontal scroll: the header never pinned
-       * there, and HeaderMobile is fixed with no offset to pin under. */
-      containerClassName="lg:overflow-visible"
+       * xl, not lg: measured at 1024px the table runs 58px wider than the
+       * container and would leak a page-level horizontal scrollbar, so the
+       * 1024-1279px band keeps the inner scroll. Mobile keeps it too: the
+       * header never pinned there, and HeaderMobile is fixed with no
+       * specified offset to pin under. */
+      containerClassName="xl:overflow-visible"
       stickyFirstColumn={true}
       pinRowsToBottom={(row) => row.isPartiallyIndexed}
       getRowClassName={(row, index, rows) => {

--- a/apps/dashboard/features/panel/components/PanelTable.tsx
+++ b/apps/dashboard/features/panel/components/PanelTable.tsx
@@ -225,12 +225,12 @@ export const PanelTable = () => {
       wrapperClassName="min-h-[400px]"
       /* On desktop the page (main) is the scroller, so the container must not
        * be a scrollport or the sticky header would pin to it and scroll away.
-       * xl, not lg: measured at 1024px the table runs 58px wider than the
-       * container and would leak a page-level horizontal scrollbar, so the
-       * 1024-1279px band keeps the inner scroll. Mobile keeps it too: the
-       * header never pinned there, and HeaderMobile is fixed with no
-       * specified offset to pin under. */
-      containerClassName="xl:overflow-visible"
+       * Nothing may overflow the fixed-layout table at these widths, or a
+       * page-level horizontal scrollbar leaks: column headers wrap below xl
+       * for exactly that reason (see TitleUnderlined). Mobile keeps the inner
+       * scroll: the header never pinned there, and HeaderMobile is fixed with
+       * no specified offset to pin under. */
+      containerClassName="lg:overflow-visible"
       stickyFirstColumn={true}
       pinRowsToBottom={(row) => row.isPartiallyIndexed}
       getRowClassName={(row, index, rows) => {

--- a/apps/dashboard/features/panel/components/SortableColumnHeader.tsx
+++ b/apps/dashboard/features/panel/components/SortableColumnHeader.tsx
@@ -15,7 +15,10 @@ export const TitleUnderlined = ({
   return (
     <h4
       className={cn(
-        "text-table-header decoration-secondary/20 group-hover:decoration-primary hover:decoration-primary whitespace-nowrap text-right underline decoration-dashed underline-offset-[6px] transition-colors duration-300",
+        // lg:max-xl may wrap: the fixed-layout desktop table cannot fit the
+        // longest header on one line there, and un-wrappable text would
+        // overflow the table and leak a page-level horizontal scrollbar.
+        "text-table-header decoration-secondary/20 group-hover:decoration-primary hover:decoration-primary whitespace-nowrap text-right underline decoration-dashed underline-offset-[6px] transition-colors duration-300 lg:max-xl:whitespace-normal",
         className,
       )}
     >

--- a/apps/dashboard/shared/components/design-system/table/Table.tsx
+++ b/apps/dashboard/shared/components/design-system/table/Table.tsx
@@ -54,6 +54,7 @@ type ColumnDef<TData, TValue> = TanstackColumnDef<TData, TValue> & {
 interface DataTableProps<TData, TValue> {
   className?: string;
   columns: ColumnDef<TData, TValue>[];
+  containerClassName?: string;
   customEmptyState?: ReactNode;
   data: TData[];
   disableRowClick?: (row: TData) => boolean;
@@ -92,6 +93,7 @@ interface DataTableProps<TData, TValue> {
 export const Table = <TData, TValue>({
   className,
   columns,
+  containerClassName,
   customEmptyState,
   data,
   disableRowClick,
@@ -215,6 +217,7 @@ export const Table = <TData, TValue>({
         className={cn(
           "text-secondary lg:bg-surface-default bg-transparent",
           fillHeight && "flex h-full flex-col",
+          containerClassName,
         )}
         tableClassName={cn(
           "border-separate border-spacing-0",


### PR DESCRIPTION
Part 3/6 of the Panel v2.1 stack (DEV-1148). Base: `feat/panel-v2.1-ticker` (#2124).

## What changes

Section 3 of the spec: **the table itself is untouched** — same columns, tooltips, sorting. Only the wrapper changes, so all rows show instead of scrolling inside a fixed-height viewport:

- **`PanelTable.tsx`** — drop `fillHeight`, keep `min-h-[400px]` so empty/loading states don't collapse.
- **`PanelSection.tsx`** — drop the `lg:min-h-0` / `lg:flex-1` / `h-full` chain that constrained the section.
- **`app/page.tsx`** — `main` now scrolls at every breakpoint (it already did on mobile); the outer `h-screen overflow-hidden` stays so the sidebar remains fixed.

This is what makes room for the sections in parts 4–6; without it they'd be trapped below a locked viewport.

## Verification

`tsc --noEmit` clean · `eslint` clean · 527 tests / 54 suites pass · rendered locally at 1440px — all 12 DAOs visible, no inner scrollbar, page scrolls as one.