### PR TITLE
feat: add DISABLED_DAOS to hide a DAO without removing its code

### DIFF
--- a/.changeset/disabled-daos-env.md
+++ b/.changeset/disabled-daos-env.md
@@ -1,0 +1,8 @@
+---
+"@anticapture/dashboard": minor
+"@anticapture/gateful": minor
+"@anticapture/client": minor
+---
+
+Add a DISABLED_DAOS env (NEXT_PUBLIC_DISABLED_DAOS on the dashboard) that hides
+the listed DAOs from the dashboard, gateway, and MCP without removing their code.

--- a/apps/dashboard/app/aave/stakeholders/AaveStakeholders.tsx
+++ b/apps/dashboard/app/aave/stakeholders/AaveStakeholders.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { Suspense } from "react";
+
+import { parseAsStringEnum, useQueryState } from "nuqs";
+
+import { TabButton } from "@/features/holders-and-delegates/components/TabButton";
+import { TokenHolders } from "@/features/holders-and-delegates/token-holder";
+import { Footer } from "@/shared/components/design-system/footer";
+import { SwitcherDate } from "@/shared/components";
+import { ReportPanelButton } from "@/shared/components/report/ReportPanelButton";
+import { DaoIdEnum } from "@/shared/types/daos";
+import { TimeInterval } from "@/shared/types/enums";
+import { HeaderDAOSidebar, HeaderSidebar, StickyPageHeader } from "@/widgets";
+import { HeaderMobile } from "@/widgets/HeaderMobile";
+
+import { DelegationTable } from "@/app/aave/stakeholders/DelegationTable";
+import { TheSectionLayout } from "@/shared/components/containers/TheSectionLayout";
+import { SubSectionsContainer } from "@/shared/components/design-system/section";
+import { PAGES_CONSTANTS } from "@/shared/constants/pages-constants";
+import { UserCheck } from "lucide-react";
+
+type TabId = "delegates" | "tokenHolders";
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: "tokenHolders", label: "TOKEN HOLDERS" },
+  { id: "delegates", label: "DELEGATES" },
+];
+
+function AavePageContent() {
+  const defaultDays = TimeInterval.NINETY_DAYS;
+  const [days, setDays] = useQueryState(
+    "days",
+    parseAsStringEnum(Object.values(TimeInterval)).withDefault(defaultDays),
+  );
+  // Enum parsed like the shared section: a stale `?tab=foo` would otherwise
+  // render Delegates with neither tab button highlighted.
+  const [activeTab, setActiveTab] = useQueryState(
+    "tab",
+    parseAsStringEnum<TabId>(["tokenHolders", "delegates"]).withDefault(
+      "delegates",
+    ),
+  );
+
+  const setDrawerAddress = useQueryState("drawerAddress")[1];
+  const setCurrentAddressFilter = useQueryState("address")[1];
+  const setSortOrder = useQueryState("sort")[1];
+  const setSortBy = useQueryState("sortBy")[1];
+  const setMinValue = useQueryState("minValue")[1];
+  const setMaxValue = useQueryState("maxValue")[1];
+
+  const cleanupFilters = () => {
+    setDrawerAddress(null);
+    setCurrentAddressFilter(null);
+    setSortOrder(null);
+    setSortBy(null);
+    setMinValue(null);
+    setMaxValue(null);
+  };
+
+  const handleTabChange = (tab: TabId) => {
+    cleanupFilters();
+    setActiveTab(tab);
+  };
+
+  return (
+    <div className="bg-surface-background dark relative mx-auto flex h-screen max-w-screen-2xl">
+      <div className="active relative hidden h-screen lg:flex">
+        <div className="w-17 h-full shrink-0 overflow-y-auto">
+          <HeaderSidebar />
+        </div>
+        <div className="h-full shrink-0">
+          <HeaderDAOSidebar />
+        </div>
+      </div>
+      <main className="h-screen flex-1 overflow-auto">
+        <div className="lg:hidden">
+          <HeaderMobile />
+          <StickyPageHeader withMobileMenu={false} />
+        </div>
+        <div className="flex w-full flex-col items-center lg:h-screen">
+          <div className="w-full flex-1">
+            <TheSectionLayout
+              title={PAGES_CONSTANTS.holdersAndDelegates.title}
+              icon={<UserCheck className="section-layout-icon" />}
+              description={PAGES_CONSTANTS.holdersAndDelegates.description}
+            >
+              <SubSectionsContainer>
+                <div className="flex w-full items-center justify-between">
+                  <div className="flex gap-2">
+                    {TABS.map((tab) => (
+                      <TabButton
+                        key={tab.id}
+                        id={tab.id}
+                        label={tab.label}
+                        activeTab={activeTab}
+                        setActiveTab={handleTabChange}
+                      />
+                    ))}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <SwitcherDate
+                      defaultValue={days || defaultDays}
+                      setTimeInterval={setDays}
+                    />
+                    <ReportPanelButton
+                      panel={
+                        activeTab === "delegates"
+                          ? "Delegates"
+                          : "Token Holders"
+                      }
+                    />
+                  </div>
+                </div>
+                {activeTab === "delegates" ? (
+                  <DelegationTable days={days || defaultDays} />
+                ) : (
+                  <TokenHolders
+                    days={days || defaultDays}
+                    daoId={DaoIdEnum.AAVE}
+                    showTokenName={false}
+                  />
+                )}
+              </SubSectionsContainer>
+            </TheSectionLayout>
+          </div>
+          <Footer />
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export const AaveStakeholders = () => (
+  <Suspense>
+    <AavePageContent />
+  </Suspense>
+);

--- a/apps/dashboard/app/aave/stakeholders/page.tsx
+++ b/apps/dashboard/app/aave/stakeholders/page.tsx
@@ -1,140 +1,15 @@
-"use client";
+import { notFound } from "next/navigation";
 
-import { Suspense } from "react";
+import { ALL_DAOS, DaoIdEnum } from "@/shared/types/daos";
 
-import { parseAsStringEnum, useQueryState } from "nuqs";
+import { AaveStakeholders } from "@/app/aave/stakeholders/AaveStakeholders";
 
-import { TabButton } from "@/features/holders-and-delegates/components/TabButton";
-import { TokenHolders } from "@/features/holders-and-delegates/token-holder";
-import { Footer } from "@/shared/components/design-system/footer";
-import { SwitcherDate } from "@/shared/components";
-import { ReportPanelButton } from "@/shared/components/report/ReportPanelButton";
-import { DaoIdEnum } from "@/shared/types/daos";
-import { TimeInterval } from "@/shared/types/enums";
-import { HeaderDAOSidebar, HeaderSidebar, StickyPageHeader } from "@/widgets";
-import { HeaderMobile } from "@/widgets/HeaderMobile";
-
-import { DelegationTable } from "@/app/aave/stakeholders/DelegationTable";
-import { TheSectionLayout } from "@/shared/components/containers/TheSectionLayout";
-import { SubSectionsContainer } from "@/shared/components/design-system/section";
-import { PAGES_CONSTANTS } from "@/shared/constants/pages-constants";
-import { UserCheck } from "lucide-react";
-
-type TabId = "delegates" | "tokenHolders";
-
-const TABS: { id: TabId; label: string }[] = [
-  { id: "tokenHolders", label: "TOKEN HOLDERS" },
-  { id: "delegates", label: "DELEGATES" },
-];
-
-function AavePageContent() {
-  const defaultDays = TimeInterval.NINETY_DAYS;
-  const [days, setDays] = useQueryState(
-    "days",
-    parseAsStringEnum(Object.values(TimeInterval)).withDefault(defaultDays),
-  );
-  // Enum parsed like the shared section: a stale `?tab=foo` would otherwise
-  // render Delegates with neither tab button highlighted.
-  const [activeTab, setActiveTab] = useQueryState(
-    "tab",
-    parseAsStringEnum<TabId>(["tokenHolders", "delegates"]).withDefault(
-      "delegates",
-    ),
-  );
-
-  const setDrawerAddress = useQueryState("drawerAddress")[1];
-  const setCurrentAddressFilter = useQueryState("address")[1];
-  const setSortOrder = useQueryState("sort")[1];
-  const setSortBy = useQueryState("sortBy")[1];
-  const setMinValue = useQueryState("minValue")[1];
-  const setMaxValue = useQueryState("maxValue")[1];
-
-  const cleanupFilters = () => {
-    setDrawerAddress(null);
-    setCurrentAddressFilter(null);
-    setSortOrder(null);
-    setSortBy(null);
-    setMinValue(null);
-    setMaxValue(null);
-  };
-
-  const handleTabChange = (tab: TabId) => {
-    cleanupFilters();
-    setActiveTab(tab);
-  };
-
-  return (
-    <div className="bg-surface-background dark relative mx-auto flex h-screen max-w-screen-2xl">
-      <div className="active relative hidden h-screen lg:flex">
-        <div className="w-17 h-full shrink-0 overflow-y-auto">
-          <HeaderSidebar />
-        </div>
-        <div className="h-full shrink-0">
-          <HeaderDAOSidebar />
-        </div>
-      </div>
-      <main className="h-screen flex-1 overflow-auto">
-        <div className="lg:hidden">
-          <HeaderMobile />
-          <StickyPageHeader withMobileMenu={false} />
-        </div>
-        <div className="flex w-full flex-col items-center lg:h-screen">
-          <div className="w-full flex-1">
-            <TheSectionLayout
-              title={PAGES_CONSTANTS.holdersAndDelegates.title}
-              icon={<UserCheck className="section-layout-icon" />}
-              description={PAGES_CONSTANTS.holdersAndDelegates.description}
-            >
-              <SubSectionsContainer>
-                <div className="flex w-full items-center justify-between">
-                  <div className="flex gap-2">
-                    {TABS.map((tab) => (
-                      <TabButton
-                        key={tab.id}
-                        id={tab.id}
-                        label={tab.label}
-                        activeTab={activeTab}
-                        setActiveTab={handleTabChange}
-                      />
-                    ))}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <SwitcherDate
-                      defaultValue={days || defaultDays}
-                      setTimeInterval={setDays}
-                    />
-                    <ReportPanelButton
-                      panel={
-                        activeTab === "delegates"
-                          ? "Delegates"
-                          : "Token Holders"
-                      }
-                    />
-                  </div>
-                </div>
-                {activeTab === "delegates" ? (
-                  <DelegationTable days={days || defaultDays} />
-                ) : (
-                  <TokenHolders
-                    days={days || defaultDays}
-                    daoId={DaoIdEnum.AAVE}
-                    showTokenName={false}
-                  />
-                )}
-              </SubSectionsContainer>
-            </TheSectionLayout>
-          </div>
-          <Footer />
-        </div>
-      </main>
-    </div>
-  );
-}
-
+// This static segment wins over the `[daoId]` route, so it must repeat the
+// disabled-DAO check that route's layout does — otherwise
+// NEXT_PUBLIC_DISABLED_DAOS=AAVE would 404 every Aave route except this one.
 export default function AavePage() {
-  return (
-    <Suspense>
-      <AavePageContent />
-    </Suspense>
-  );
+  if (!ALL_DAOS.includes(DaoIdEnum.AAVE)) {
+    notFound();
+  }
+  return <AaveStakeholders />;
 }

--- a/apps/dashboard/app/llms.txt/route.ts
+++ b/apps/dashboard/app/llms.txt/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from "next/server";
 
-import daoConfigByDaoId from "@/shared/dao-config";
 import { getSiteUrl } from "@/shared/seo/site";
+import { ALL_DAOS } from "@/shared/types/daos";
 
 export function GET() {
   const baseUrl = getSiteUrl();
-  const daoUrls = Object.keys(daoConfigByDaoId)
-    .map((daoId) => `${baseUrl}/${daoId.toLowerCase()}`)
-    .join("\n");
+  const daoUrls = ALL_DAOS.map(
+    (daoId) => `${baseUrl}/${daoId.toLowerCase()}`,
+  ).join("\n");
 
   const body = [
     "# Anticapture",

--- a/apps/dashboard/app/sitemap.ts
+++ b/apps/dashboard/app/sitemap.ts
@@ -1,8 +1,7 @@
 import type { MetadataRoute } from "next";
 
-import daoConfigByDaoId from "@/shared/dao-config";
 import { getSiteUrl } from "@/shared/seo/site";
-import type { DaoIdEnum } from "@/shared/types/daos";
+import { ALL_DAOS, type DaoIdEnum } from "@/shared/types/daos";
 import {
   type OffchainProposalsPathParams,
   type ProposalsPathParams,
@@ -132,7 +131,7 @@ export async function getAllProposalPaths(
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = getSiteUrl();
-  const daoIds = Object.keys(daoConfigByDaoId).map((id) => id.toLowerCase());
+  const daoIds = ALL_DAOS.map((id) => id.toLowerCase());
 
   const staticEntries: MetadataRoute.Sitemap = STATIC_ROUTES.map((route) => ({
     url: `${baseUrl}${route}`,

--- a/apps/dashboard/features/panel/components/DaoProtectionLevels.tsx
+++ b/apps/dashboard/features/panel/components/DaoProtectionLevels.tsx
@@ -14,7 +14,7 @@ import {
   fieldsToArray,
   getDaoStageFromFields,
 } from "@/shared/dao-config/utils";
-import { DaoIdEnum } from "@/shared/types/daos";
+import { ALL_DAOS } from "@/shared/types/daos";
 import { Stage } from "@/shared/types/enums/Stage";
 
 const chartConfig: ChartConfig = {
@@ -28,7 +28,7 @@ export const DaoProtectionLevels = () => {
   // Calculate stage distribution from real DAO data
   const stageData = useMemo(() => {
     // Get all DAOs
-    const daoIds = Object.values(DaoIdEnum);
+    const daoIds = ALL_DAOS;
 
     // Count DAOs by stage
     const stageCounts = {
@@ -94,7 +94,7 @@ export const DaoProtectionLevels = () => {
 
   // Calculate total monitored DAOs
   const totalMonitored = useMemo(() => {
-    return Object.values(DaoIdEnum).length;
+    return ALL_DAOS.length;
   }, []);
 
   return (

--- a/apps/dashboard/features/panel/components/PanelTable.tsx
+++ b/apps/dashboard/features/panel/components/PanelTable.tsx
@@ -19,7 +19,8 @@ import {
 import { Table } from "@/shared/components/design-system/table/Table";
 import { Tooltip } from "@/shared/components/design-system/tooltips/Tooltip";
 import daoConfigByDaoId from "@/shared/dao-config";
-import { DaoIdEnum } from "@/shared/types/daos";
+import type { DaoIdEnum } from "@/shared/types/daos";
+import { ALL_DAOS } from "@/shared/types/daos";
 import { BadgeStatus } from "@/shared/components/design-system/badges";
 
 type PanelDao = {
@@ -49,15 +50,13 @@ export const PanelTable = () => {
   const attackProfitabilitySort = useRef<Record<number, number>>({});
   const activeTokensSort = useRef<Record<number, number>>({});
 
-  const allDaos = Object.values(DaoIdEnum)
-    .map((daoId) => ({
-      dao: daoId,
-      isPartiallyIndexed: !daoConfigByDaoId[daoId].governanceImplementation,
-    }))
-    .sort(
-      (daoA, daoB) =>
-        Number(daoA.isPartiallyIndexed) - Number(daoB.isPartiallyIndexed),
-    );
+  const allDaos = ALL_DAOS.map((daoId) => ({
+    dao: daoId,
+    isPartiallyIndexed: !daoConfigByDaoId[daoId].governanceImplementation,
+  })).sort(
+    (daoA, daoB) =>
+      Number(daoA.isPartiallyIndexed) - Number(daoB.isPartiallyIndexed),
+  );
 
   const panelColumns: ColumnDef<PanelDao>[] = [
     {

--- a/apps/dashboard/shared/components/dropdowns/HeaderDAOSidebarDropdown.tsx
+++ b/apps/dashboard/shared/components/dropdowns/HeaderDAOSidebarDropdown.tsx
@@ -6,7 +6,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { DaoAvatarIcon } from "@/shared/components/icons";
 import daoConfigByDaoId from "@/shared/dao-config";
-import { DaoIdEnum } from "@/shared/types/daos";
+import type { DaoIdEnum } from "@/shared/types/daos";
+import { ALL_DAOS } from "@/shared/types/daos";
 import { cn } from "@/shared/utils/";
 import { getDaoNavigationPath } from "@/shared/utils/dao-navigation";
 
@@ -79,13 +80,11 @@ export const HeaderDAOSidebarDropdown = ({
 
   const dropdownItemsRef = useRef<DropdownItem[] | null>(null);
   if (!dropdownItemsRef.current) {
-    dropdownItemsRef.current = Object.values(DaoIdEnum).map(
-      (daoIdValue, index) => ({
-        id: index,
-        daoId: daoIdValue,
-        label: daoConfigByDaoId[daoIdValue].name,
-      }),
-    );
+    dropdownItemsRef.current = ALL_DAOS.map((daoIdValue, index) => ({
+      id: index,
+      daoId: daoIdValue,
+      label: daoConfigByDaoId[daoIdValue].name,
+    }));
   }
   const dropdownItems = dropdownItemsRef.current;
 

--- a/apps/dashboard/shared/types/daos.ts
+++ b/apps/dashboard/shared/types/daos.ts
@@ -14,7 +14,20 @@ export enum DaoIdEnum {
   TORN = "TORN",
 }
 
-export const ALL_DAOS = Object.values(DaoIdEnum);
+// Comma-separated DAO ids hidden from the whole app (e.g. "SHU" or "shu,torn").
+// The DAO's config and code paths stay in place, but it disappears from every
+// list and its routes 404, so an environment can hide a DAO without deleting it.
+// NEXT_PUBLIC_ so the value is inlined into the client bundle at build time.
+const DISABLED_DAOS = new Set(
+  (process.env.NEXT_PUBLIC_DISABLED_DAOS ?? "")
+    .split(",")
+    .map((daoId) => daoId.trim().toUpperCase())
+    .filter(Boolean),
+);
+
+export const ALL_DAOS = Object.values(DaoIdEnum).filter(
+  (daoId) => !DISABLED_DAOS.has(daoId),
+);
 
 export const isDaoIdEnum = (daoId: string): daoId is DaoIdEnum =>
   (ALL_DAOS as readonly string[]).includes(daoId);

--- a/apps/dashboard/shared/utils/whitelabel.ts
+++ b/apps/dashboard/shared/utils/whitelabel.ts
@@ -1,6 +1,6 @@
 import daoConfigByDaoId from "@/shared/dao-config";
 import type { DaoConfiguration } from "@/shared/dao-config/types";
-import type { DaoIdEnum } from "@/shared/types/daos";
+import { ALL_DAOS, type DaoIdEnum } from "@/shared/types/daos";
 
 export const WHITELABEL_ROUTES = {
   proposals: "proposals",
@@ -18,10 +18,12 @@ export const WHITELABEL_ROUTES = {
 export type WhitelabelRouteSlug =
   (typeof WHITELABEL_ROUTES)[keyof typeof WHITELABEL_ROUTES];
 
-const NORMALIZED_HOSTNAME_TO_DAO_ID = Object.entries(daoConfigByDaoId).reduce(
-  (acc, [daoId, daoConfig]) => {
-    daoConfig.hostnames?.forEach((hostname) => {
-      acc[hostname.toLowerCase()] = daoId as DaoIdEnum;
+// Built from ALL_DAOS (not the raw config map) so a disabled DAO's whitelabel
+// hostname stops resolving along with the rest of its routes.
+const NORMALIZED_HOSTNAME_TO_DAO_ID = ALL_DAOS.reduce(
+  (acc, daoId) => {
+    daoConfigByDaoId[daoId].hostnames?.forEach((hostname) => {
+      acc[hostname.toLowerCase()] = daoId;
     });
 
     return acc;

--- a/apps/gateful/src/config.test.ts
+++ b/apps/gateful/src/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { envSchema } from "./config";
+import { envSchema, loadDaoMap, parseDisabledDaos } from "./config";
 
 describe("envSchema TOKEN_SERVICE_URL normalization", () => {
   it.each([
@@ -29,5 +29,30 @@ describe("envSchema TOKEN_SERVICE_URL normalization", () => {
         TOKEN_SERVICE_API_KEY: "internal-key",
       }),
     ).toThrow();
+  });
+});
+
+describe("DISABLED_DAOS", () => {
+  it("parses a comma-separated list case-insensitively", () => {
+    expect(parseDisabledDaos(" SHU , torn ")).toEqual(new Set(["shu", "torn"]));
+    expect(parseDisabledDaos(undefined)).toEqual(new Set());
+    expect(parseDisabledDaos("")).toEqual(new Set());
+  });
+
+  it("drops disabled DAOs from the DAO map while keeping the rest", () => {
+    const source = {
+      DAO_API_ENS: "http://api-ens:42069",
+      DAO_API_SHU: "http://api-shu:42069",
+    };
+    const map = loadDaoMap("DAO_API_", source, new Set(["shu"]));
+    expect(map.get("ens")).toBe("http://api-ens:42069");
+    expect(map.has("shu")).toBe(false);
+  });
+
+  it("keeps every registered DAO when nothing is disabled", () => {
+    const source = { DAO_API_SHU: "http://api-shu:42069" };
+    expect(loadDaoMap("DAO_API_", source).get("shu")).toBe(
+      "http://api-shu:42069",
+    );
   });
 });

--- a/apps/gateful/src/config.test.ts
+++ b/apps/gateful/src/config.test.ts
@@ -55,4 +55,14 @@ describe("DISABLED_DAOS", () => {
       "http://api-shu:42069",
     );
   });
+
+  it("ignores a disabled DAO's malformed URL instead of failing startup", () => {
+    const source = {
+      DAO_API_ENS: "http://api-ens:42069",
+      DAO_API_SHU: "not a url",
+    };
+    const map = loadDaoMap("DAO_API_", source, new Set(["shu"]));
+    expect(map.get("ens")).toBe("http://api-ens:42069");
+    expect(map.has("shu")).toBe(false);
+  });
 });

--- a/apps/gateful/src/config.ts
+++ b/apps/gateful/src/config.ts
@@ -73,12 +73,14 @@ export function loadDaoMap(
 
   for (const [key, value] of Object.entries(source)) {
     if (key.startsWith(prefix) && value) {
+      const daoName = key.replace(prefix, "").toLowerCase();
+      // Skip before validating: a disabled DAO's registration is ignored
+      // entirely, so even a stale or malformed URL must not block startup.
+      if (disabledDaos.has(daoName)) continue;
       const parsed = urlSchema.safeParse(value);
       if (!parsed.success) {
         throw new Error(`Invalid URL for ${key}: ${parsed.error.message}`);
       }
-      const daoName = key.replace(prefix, "").toLowerCase();
-      if (disabledDaos.has(daoName)) continue;
       result.set(daoName, parsed.data);
     }
   }

--- a/apps/gateful/src/config.ts
+++ b/apps/gateful/src/config.ts
@@ -39,6 +39,10 @@ export const envSchema = z
     CIRCUIT_BREAKER_MAX_COOLDOWN_MS: z.coerce.number().default(2_400_000),
     REDIS_URL: z.string().optional(),
     RAILWAY_GIT_COMMIT_SHA: z.string().optional(),
+    // Comma-separated DAO ids (e.g. "shu" or "shu,torn") whose DAO_API_* /
+    // DAO_RELAYER_* registrations are ignored. Lets an environment keep a
+    // DAO's services running while removing it from the public gateway.
+    DISABLED_DAOS: z.string().optional(),
   })
   .refine((env) => !env.TOKEN_SERVICE_URL || !!env.TOKEN_SERVICE_API_KEY, {
     message: "TOKEN_SERVICE_API_KEY is required when TOKEN_SERVICE_URL is set",
@@ -51,9 +55,18 @@ export const envSchema = z
     },
   );
 
-function loadDaoMap(
+export const parseDisabledDaos = (value: string | undefined): Set<string> =>
+  new Set(
+    (value ?? "")
+      .split(",")
+      .map((dao) => dao.trim().toLowerCase())
+      .filter(Boolean),
+  );
+
+export function loadDaoMap(
   prefix: string,
   source: Record<string, string | undefined> = process.env,
+  disabledDaos: ReadonlySet<string> = new Set(),
 ): Map<string, string> {
   const result = new Map<string, string>();
   const urlSchema = z.url();
@@ -65,6 +78,7 @@ function loadDaoMap(
         throw new Error(`Invalid URL for ${key}: ${parsed.error.message}`);
       }
       const daoName = key.replace(prefix, "").toLowerCase();
+      if (disabledDaos.has(daoName)) continue;
       result.set(daoName, parsed.data);
     }
   }
@@ -73,6 +87,7 @@ function loadDaoMap(
 }
 
 const env = envSchema.parse(process.env);
+const disabledDaos = parseDisabledDaos(env.DISABLED_DAOS);
 
 export const config = {
   port: env.PORT,
@@ -88,8 +103,8 @@ export const config = {
   metricsToken: env.GATEFUL_METRICS_TOKEN,
   redisUrl: env.REDIS_URL,
   commitSha: env.RAILWAY_GIT_COMMIT_SHA,
-  daoApis: loadDaoMap("DAO_API_"),
-  daoRelayers: loadDaoMap("DAO_RELAYER_"),
+  daoApis: loadDaoMap("DAO_API_", process.env, disabledDaos),
+  daoRelayers: loadDaoMap("DAO_RELAYER_", process.env, disabledDaos),
   circuitBreaker: {
     failureThreshold: env.CIRCUIT_BREAKER_FAILURE_THRESHOLD,
     cooldownMs: env.CIRCUIT_BREAKER_COOLDOWN_MS,

--- a/apps/gateful/src/middlewares/cache.test.ts
+++ b/apps/gateful/src/middlewares/cache.test.ts
@@ -156,4 +156,29 @@ describe("cacheMiddleware", () => {
 
     expect(redis.store.size).toBe(0);
   });
+
+  // -------------------------------------------------------------------------
+  // Enabled DAO set change → cached entries orphaned
+  // -------------------------------------------------------------------------
+
+  it("does not serve entries cached under a different enabled DAO set", async () => {
+    const handler = vi.fn(defaultHandler);
+    const daoApis = new Map([
+      ["ens", "http://ens"],
+      ["shu", "http://shu"],
+    ]);
+    const before = buildApp(redis, handler, daoApis);
+
+    await before.request("/test"); // primes the cache with shu enabled
+    expect(redis.store.size).toBe(1);
+
+    // Same Redis, but shu is now disabled — the old entry must not be a hit.
+    const daoApisWithoutShu = new Map([["ens", "http://ens"]]);
+    const after = buildApp(redis, handler, daoApisWithoutShu);
+
+    const res = await after.request("/test");
+
+    expect((await readResponse(res)).cacheStatus).toBe(null);
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/gateful/src/middlewares/cache.ts
+++ b/apps/gateful/src/middlewares/cache.ts
@@ -31,11 +31,17 @@ export function cacheMiddleware(
   redis: CacheStore,
   daoApis: Map<string, string>,
 ) {
+  // Namespace keys by the enabled DAO set: entries cached before a DAO was
+  // disabled (its /{dao}/* responses, or a /daos listing that names it) must
+  // become unreachable on the next deploy rather than surviving until their
+  // upstream max-age (up to an hour) expires.
+  const daoNamespace = [...daoApis.keys()].sort().join(",");
+
   return async (c: Context, next: Next) => {
     // Only cache GET requests.
     if (c.req.method !== "GET") return next();
 
-    const key = c.req.url;
+    const key = `${daoNamespace}|${c.req.url}`;
 
     // Normalize the path to a fixed-cardinality label: "/<dao>/*" keeps the
     // DAO segment (useful for per-DAO cache panels) while collapsing all

--- a/packages/anticapture-client/src/create-mcp-server.ts
+++ b/packages/anticapture-client/src/create-mcp-server.ts
@@ -181,7 +181,25 @@ import {
 } from "../generated/zod.ts";
 import { Address } from "../generated/models.ts";
 
-const DAO_ALL = [
+// Comma-separated DAO ids (e.g. "shu" or "shu,torn") removed from every MCP
+// tool's accepted `dao` values. The generated handlers stay in place; the DAO
+// just stops being reachable through this server.
+const DISABLED_DAOS = new Set(
+  (process.env.DISABLED_DAOS ?? "")
+    .split(",")
+    .map((dao) => dao.trim().toLowerCase())
+    .filter(Boolean),
+);
+
+const withoutDisabled = <T extends string>(daos: readonly T[]): [T, ...T[]] => {
+  const enabled = daos.filter((dao) => !DISABLED_DAOS.has(dao));
+  if (enabled.length === 0) {
+    throw new Error("DISABLED_DAOS disables every DAO; nothing left to serve.");
+  }
+  return enabled as [T, ...T[]];
+};
+
+const DAO_ALL = withoutDisabled([
   "aave",
   "comp",
   "ens",
@@ -193,8 +211,8 @@ const DAO_ALL = [
   "scr",
   "shu",
   "uni",
-] as const;
-const DAO_NO_AAVE = [
+] as const);
+const DAO_NO_AAVE = withoutDisabled([
   "comp",
   "ens",
   "fluid",
@@ -205,8 +223,8 @@ const DAO_NO_AAVE = [
   "scr",
   "shu",
   "uni",
-] as const;
-const DAO_OFFCHAIN = ["comp", "ens", "gtc", "uni"] as const;
+] as const);
+const DAO_OFFCHAIN = withoutDisabled(["comp", "ens", "gtc", "uni"] as const);
 
 export function createMcpServer(): McpServer {
   const server = new McpServer({

--- a/packages/anticapture-client/src/create-mcp-server.ts
+++ b/packages/anticapture-client/src/create-mcp-server.ts
@@ -191,13 +191,12 @@ const DISABLED_DAOS = new Set(
     .filter(Boolean),
 );
 
-const withoutDisabled = <T extends string>(daos: readonly T[]): [T, ...T[]] => {
-  const enabled = daos.filter((dao) => !DISABLED_DAOS.has(dao));
-  if (enabled.length === 0) {
-    throw new Error("DISABLED_DAOS disables every DAO; nothing left to serve.");
-  }
-  return enabled as [T, ...T[]];
-};
+// The tuple cast is a lie when a whole subset is disabled, but a safe one:
+// zod v4 accepts an empty enum and then rejects every value, so the affected
+// tools become uncallable instead of the server failing to start. Only an
+// empty DAO_ALL (checked below) is fatal.
+const withoutDisabled = <T extends string>(daos: readonly T[]): [T, ...T[]] =>
+  daos.filter((dao) => !DISABLED_DAOS.has(dao)) as [T, ...T[]];
 
 const DAO_ALL = withoutDisabled([
   "aave",
@@ -225,6 +224,10 @@ const DAO_NO_AAVE = withoutDisabled([
   "uni",
 ] as const);
 const DAO_OFFCHAIN = withoutDisabled(["comp", "ens", "gtc", "uni"] as const);
+
+if (DAO_ALL.length === 0) {
+  throw new Error("DISABLED_DAOS disables every DAO; nothing left to serve.");
+}
 
 export function createMcpServer(): McpServer {
   const server = new McpServer({


### PR DESCRIPTION
## Task

Closes [DEV-1155 Disable Shutter entirely in production](https://app.clickup.com/t/86ak1jkc3)

## What

One env var per surface hides any DAO from the public product while its services keep running. Built to remove Shutter from production while its indexer and API keep working on dev.

- **Dashboard**: `NEXT_PUBLIC_DISABLED_DAOS` (e.g. `SHU` or `shu,torn`) filters `ALL_DAOS` at its single source. Routes 404, and the panel table, protection-levels chart, DAO switcher, sitemap, llms.txt, and whitelabel hostname map all drop the DAO. The config map stays complete, so lookups never break.
- **Gateful**: `DISABLED_DAOS` ignores the DAO's `DAO_API_*` / `DAO_RELAYER_*` registrations, removing it from `/daos`, the OpenAPI spec, and all proxied routes.
- **MCP server**: `DISABLED_DAOS` removes the DAO from every tool's accepted `dao` values, failing fast if everything is disabled.

No code paths were removed; `apps/api`, the indexer, and the offchain-indexer are untouched.

## Rollout

Set on production only (leave unset on dev so Shutter keeps working there):
- Dashboard: `NEXT_PUBLIC_DISABLED_DAOS=SHU` (build-time, needs a redeploy)
- Gateful / MCP: `DISABLED_DAOS=shu`

The shutter whitelabel domain was already removed separately.

## Verification

- Dashboard running with `NEXT_PUBLIC_DISABLED_DAOS=SHU`: `/shutter` and `/shutter/proposals` return 404, `/ens` stays 200, panel HTML has zero Shutter mentions, llms.txt has no `/shu` URL.
- Gateful: new unit tests for `parseDisabledDaos` and `loadDaoMap` filtering pass (8/8).
- MCP: server creates with `DISABLED_DAOS=shu`; disabling every DAO throws at startup.
- `tsc --noEmit` clean on dashboard, gateful, and the client package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)