### PR TITLE
feat(dashboard): enable the Gitcoin whitelabel with full governance

### DIFF
--- a/.changeset/gitcoin-whitelabel-governance.md
+++ b/.changeset/gitcoin-whitelabel-governance.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": minor
+---
+
+Enable the Gitcoin whitelabel with full governance (create, vote, queue and execute proposals).

--- a/apps/dashboard/features/create-proposal/constants.ts
+++ b/apps/dashboard/features/create-proposal/constants.ts
@@ -6,7 +6,9 @@ export const BODY_CHAR_LIMIT = 100_000;
 export const BODY_WARNING_THRESHOLD = 95_000;
 
 export const canCreateProposalForDao = (daoId: DaoIdEnum | null | undefined) =>
-  daoId === DaoIdEnum.ENS || daoId === DaoIdEnum.SHU;
+  daoId === DaoIdEnum.ENS ||
+  daoId === DaoIdEnum.SHU ||
+  daoId === DaoIdEnum.GITCOIN;
 
 export interface SuggestedTransferToken {
   symbol: string;
@@ -35,6 +37,13 @@ export const SUGGESTED_TRANSFER_TOKENS: Partial<
     trustWalletToken("DAI", "0x6b175474e89094c44da98b954eedeac495271d0f"),
     trustWalletToken("WETH", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
     trustWalletToken("ENS", "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72"),
+  ],
+  [DaoIdEnum.GITCOIN]: [
+    trustWalletToken("USDT", "0xdac17f958d2ee523a2206206994597c13d831ec7"),
+    trustWalletToken("USDC", "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
+    trustWalletToken("DAI", "0x6b175474e89094c44da98b954eedeac495271d0f"),
+    trustWalletToken("WETH", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+    trustWalletToken("GTC", "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f"),
   ],
 };
 

--- a/apps/dashboard/shared/dao-config/gtc.ts
+++ b/apps/dashboard/shared/dao-config/gtc.ts
@@ -7,6 +7,7 @@ import { QUORUM_CALCULATION_TYPES } from "@/shared/constants/labels";
 import { RECOMMENDED_SETTINGS } from "@/shared/constants/recommended-settings";
 import type { DaoConfiguration } from "@/shared/dao-config/types";
 import { GitcoinOgIcon } from "@/shared/og/dao-og-icons";
+import { toAbsoluteUrl } from "@/shared/seo/site";
 import {
   RiskLevel,
   GovernanceImplementationEnum,
@@ -23,6 +24,8 @@ export const GTC: DaoConfiguration = {
   forumLink: "https://gov.gitcoin.co/",
   icon: GitcoinIcon,
   ogIcon: GitcoinOgIcon,
+  hostnames: ["gitcoin.gov.blockful.io"],
+  whitelabel: {},
   daoOverview: {
     token: "ERC20",
     chain: { ...mainnet, icon: MainnetIcon },
@@ -33,8 +36,8 @@ export const GTC: DaoConfiguration = {
       timelock: "0x57a8865cfB1eCEf7253c27da6B4BC3dAEE5Be518",
     },
     govPlatform: {
-      name: "Tally",
-      url: "https://tally.xyz/gov/gitcoin/proposal/",
+      name: "Anticapture",
+      url: toAbsoluteUrl("/gtc/proposals/"),
     },
     cancelFunction:
       "https://etherscan.io/address/0x57a8865cfB1eCEf7253c27da6B4BC3dAEE5Be518#writeContract#F2",


### PR DESCRIPTION
## What

- `gitcoin.gov.blockful.io` now resolves to the whitelabel shell (`hostnames` + `whitelabel` in dao-config)
- Gitcoin joins ENS and Shutter in `canCreateProposalForDao`, with suggested transfer tokens (USDT, USDC, DAI, WETH, GTC)
- `govPlatform` points at Anticapture instead of Tally, matching ENS and Shutter

No transaction-layer changes were needed: Gitcoin's "GTC Governor Bravo" is an OZ governor under the hood (hash proposal ids, GovernorCountingSimple tallies), so the existing OZ propose, castVote, queue and execute paths work unchanged.

## Validation

Full lifecycle PASS on an anvil mainnet fork via the governance fork test (#2133), running the dashboard's own transaction code with impersonated top delegates:

```
PASS delegates: 50 delegates with power on the fork, 5 above the 150,000 threshold
PASS propose: created via submitProposalRequest
PASS state:pending, state:active
PASS vote: 2 for (15,201,607), 1 against, 1 abstain via voteOnProposal
PASS tallies: on-chain tallies match the cast voting power exactly
PASS state:succeeded
PASS queue: proposal Queued via queueProposal
PASS execute: proposal Executed via executeProposal after the 2-day timelock
```

Typecheck, lint and the create-proposal + dao-config test suites (336 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)