### PR TITLE
feat(dashboard): enable the Compound whitelabel with full governance

### DIFF
--- a/.changeset/compound-whitelabel-governance.md
+++ b/.changeset/compound-whitelabel-governance.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": minor
+---
+
+Enable the Compound whitelabel with full governance (create, vote, queue and execute proposals).

--- a/apps/dashboard/features/create-proposal/constants.ts
+++ b/apps/dashboard/features/create-proposal/constants.ts
@@ -6,7 +6,9 @@ export const BODY_CHAR_LIMIT = 100_000;
 export const BODY_WARNING_THRESHOLD = 95_000;
 
 export const canCreateProposalForDao = (daoId: DaoIdEnum | null | undefined) =>
-  daoId === DaoIdEnum.ENS || daoId === DaoIdEnum.SHU;
+  daoId === DaoIdEnum.ENS ||
+  daoId === DaoIdEnum.SHU ||
+  daoId === DaoIdEnum.COMP;
 
 export interface SuggestedTransferToken {
   symbol: string;
@@ -35,6 +37,13 @@ export const SUGGESTED_TRANSFER_TOKENS: Partial<
     trustWalletToken("DAI", "0x6b175474e89094c44da98b954eedeac495271d0f"),
     trustWalletToken("WETH", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
     trustWalletToken("ENS", "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72"),
+  ],
+  [DaoIdEnum.COMP]: [
+    trustWalletToken("USDT", "0xdac17f958d2ee523a2206206994597c13d831ec7"),
+    trustWalletToken("USDC", "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
+    trustWalletToken("DAI", "0x6b175474e89094c44da98b954eedeac495271d0f"),
+    trustWalletToken("WETH", "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+    trustWalletToken("COMP", "0xc00e94cb662c3520282e6f5717214004a7f26888"),
   ],
 };
 

--- a/apps/dashboard/shared/dao-config/comp.ts
+++ b/apps/dashboard/shared/dao-config/comp.ts
@@ -7,6 +7,7 @@ import { QUORUM_CALCULATION_TYPES } from "@/shared/constants/labels";
 import { RECOMMENDED_SETTINGS } from "@/shared/constants/recommended-settings";
 import type { DaoConfiguration } from "@/shared/dao-config/types";
 import { CompoundOgIcon } from "@/shared/og/dao-og-icons";
+import { toAbsoluteUrl } from "@/shared/seo/site";
 import {
   RiskLevel,
   GovernanceImplementationEnum,
@@ -24,6 +25,8 @@ export const COMP: DaoConfiguration = {
   forumLink: "https://www.comp.xyz/",
   icon: CompoundIcon,
   ogIcon: CompoundOgIcon,
+  hostnames: ["compound.gov.blockful.io"],
+  whitelabel: {},
 
   daoOverview: {
     token: "ERC20",
@@ -35,8 +38,8 @@ export const COMP: DaoConfiguration = {
       timelock: "0x6d903f6003cca6255D85CcA4D3B5E5146dC33925",
     },
     govPlatform: {
-      name: "Tally",
-      url: "https://tally.xyz/gov/compound/proposal/",
+      name: "Anticapture",
+      url: toAbsoluteUrl("/comp/proposals/"),
     },
     cancelFunction:
       "https://etherscan.io/address/0x6d903f6003cca6255D85CcA4D3B5E5146dC33925#writeContract#F5",


### PR DESCRIPTION
## What

- `compound.gov.blockful.io` now resolves to the whitelabel shell (`hostnames` + `whitelabel` in dao-config)
- Compound joins ENS and Shutter in `canCreateProposalForDao`, with suggested transfer tokens (USDT, USDC, DAI, WETH, COMP)
- `govPlatform` points at Anticapture instead of Tally, matching ENS and Shutter

No transaction-layer changes were needed: Compound's 2024 governor is an OZ v5 build (block-number clock, Compound Timelock, GovernorPreventLateQuorum), so the existing OZ propose, castVote, queue and execute paths work unchanged.

## Validation

Full lifecycle PASS on an anvil mainnet fork via the governance fork test (#2133), running the dashboard's own transaction code with impersonated top delegates:

```
PASS delegates: 50 delegates with power on the fork, 20 above the 25,000 threshold
PASS propose: proposal 597 created via submitProposalRequest
PASS state:pending, state:active
PASS vote: 2 for (2,344,367), 1 against, 1 abstain via voteOnProposal
PASS tallies: on-chain tallies match the cast voting power exactly
PASS late-quorum: cleared the GovernorPreventLateQuorum deadline extension
PASS state:succeeded
PASS queue: proposal Queued via queueProposal
PASS execute: proposal Executed via executeProposal after the 2-day timelock
```

Typecheck, lint and the create-proposal + dao-config test suites (336 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)