### PR TITLE
fix: address PR #2139 review feedback and the panel E2E failure

### DIFF
--- a/.changeset/panel-review-a11y.md
+++ b/.changeset/panel-review-a11y.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Fix the panel risk heading level and enlarge the testimonial arrows' touch targets.

--- a/.changeset/relayer-hold-enactment-lock.md
+++ b/.changeset/relayer-hold-enactment-lock.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/relayer": patch
+---
+
+Keep queue/execute requests deduplicated while a broadcast transaction is still pending after a receipt timeout.

--- a/.changeset/torn-vote-submit-feedback.md
+++ b/.changeset/torn-vote-submit-feedback.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Show why the Tornado vote submit is disabled while delegators load or fail to load.

--- a/apps/dashboard/e2e/panel.spec.ts
+++ b/apps/dashboard/e2e/panel.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "./fixtures";
 
-/* Desktop width, but shorter than the table: the layout-sensitive tests below
- * all need the page to scroll vertically past the table. */
+/* Desktop width, but short: the layout-sensitive tests below all need the
+ * page to scroll vertically past the table. */
 const SHORT_DESKTOP_VIEWPORT = { width: 1920, height: 640 };
 
 test.describe("Panel page", () => {
@@ -89,11 +89,17 @@ test.describe("Panel page", () => {
     expect(footerBox).not.toBeNull();
     expect(tableBox!.y + tableBox!.height).toBeLessThanOrEqual(footerBox!.y);
 
-    // The table is no longer an inner scroll box: every row lays out at full
-    // height, past the bottom of this viewport, and `main` is what scrolls.
+    // The table is no longer an inner scroll box: its container never clips
+    // rows behind its own scrollbar (the row count alone sets its height,
+    // which may be under the viewport height as DAOs come and go), and
+    // `main` is what scrolls.
     await expect
-      .poll(() => tableContainer.evaluate((element) => element.clientHeight))
-      .toBeGreaterThan(SHORT_DESKTOP_VIEWPORT.height);
+      .poll(() =>
+        tableContainer.evaluate(
+          (element) => element.scrollHeight - element.clientHeight,
+        ),
+      )
+      .toBeLessThanOrEqual(0);
     await expect
       .poll(() =>
         page

--- a/apps/dashboard/features/governance/components/modals/VotingModal.tsx
+++ b/apps/dashboard/features/governance/components/modals/VotingModal.tsx
@@ -120,6 +120,7 @@ export const VotingModal = ({
     hasNextPage: hasMoreTornDelegators,
     fetchNextPage: fetchMoreTornDelegators,
     fetchingMore: isFetchingMoreTornDelegators,
+    refetch: refetchTornDelegators,
   } = useDelegators({
     daoId,
     address: address ?? "",
@@ -154,6 +155,16 @@ export const VotingModal = ({
     isLoadingTornDelegators ||
     isFetchingMoreTornDelegators ||
     !!hasMoreTornDelegators;
+
+  // Submit is held back while these are true, so each needs a visible
+  // explanation next to the button: a dead Submit with no reason reads as a
+  // bug to the voter.
+  const showTornDelegatorsError = isTorn && !!address && !!tornDelegatorsError;
+  const showTornDelegatorsLoading =
+    isTorn &&
+    !!address &&
+    !tornDelegatorsError &&
+    isTornDelegatorListIncomplete;
 
   const tornDelegatedVoteAddresses = useMemo(() => {
     if (!isTorn || !address) return undefined;
@@ -380,7 +391,24 @@ export const VotingModal = ({
       )}
 
       {!isSuccess && (
-        <div className="border-border-default flex justify-end gap-2 border-t px-4 py-3">
+        <div className="border-border-default flex items-center justify-end gap-2 border-t px-4 py-3">
+          {!isLoading && showTornDelegatorsError && (
+            <p className="text-error mr-auto text-xs leading-4">
+              Could not load your delegators, so voting is disabled.{" "}
+              <button
+                type="button"
+                onClick={() => refetchTornDelegators()}
+                className="cursor-pointer underline"
+              >
+                Retry
+              </button>
+            </p>
+          )}
+          {!isLoading && showTornDelegatorsLoading && (
+            <p className="text-secondary mr-auto text-xs leading-4">
+              Loading your delegators...
+            </p>
+          )}
           <Button variant="outline" onClick={onClose}>
             Cancel
           </Button>

--- a/apps/dashboard/features/panel/components/DaoProtectionLevels.tsx
+++ b/apps/dashboard/features/panel/components/DaoProtectionLevels.tsx
@@ -73,9 +73,11 @@ export const DaoProtectionLevels = () => {
 
   return (
     <div className="bg-surface-default flex w-full min-w-0 flex-1 flex-col justify-between gap-3.5 p-4">
-      <h3 className="text-primary text-alternative-sm tracking-alternative-sm font-mono font-medium uppercase leading-5">
+      {/* h2, not h3: this is the first heading after the page's h1, so the
+       * document outline must not skip a level. */}
+      <h2 className="text-primary text-alternative-sm tracking-alternative-sm font-mono font-medium uppercase leading-5">
         Governance risk, right now
-      </h3>
+      </h2>
 
       <div className="flex flex-col justify-center gap-3">
         {STAGE_BARS.map(

--- a/apps/dashboard/features/panel/components/TestimonialCarousel.tsx
+++ b/apps/dashboard/features/panel/components/TestimonialCarousel.tsx
@@ -33,7 +33,9 @@ export const TestimonialCarousel = () => {
         icon={ChevronLeft}
         variant="ghost"
         size="md"
-        className="size-9"
+        /* 44px, the minimum touch target: a mobile visitor taps these
+         * repeatedly to cycle the quotes. */
+        className="size-11"
         iconClassName="size-4"
         aria-label="Previous testimonial"
         disabled={!hasMultiple}
@@ -87,7 +89,9 @@ export const TestimonialCarousel = () => {
         icon={ChevronRight}
         variant="ghost"
         size="md"
-        className="size-9"
+        /* 44px, the minimum touch target: a mobile visitor taps these
+         * repeatedly to cycle the quotes. */
+        className="size-11"
         iconClassName="size-4"
         aria-label="Next testimonial"
         disabled={!hasMultiple}

--- a/apps/relayer/src/services/proposals/proposal-enactment.test.ts
+++ b/apps/relayer/src/services/proposals/proposal-enactment.test.ts
@@ -468,6 +468,43 @@ describe("ProposalEnactmentService in-flight dedup", () => {
     expect(sent).toHaveLength(2);
   });
 
+  it("keeps the lock through a transient settlement poll error", async () => {
+    let settle!: (outcome: ReceiptOutcome) => void;
+    let receiptCalls = 0;
+    const { service, sent } = createService({
+      governor: {
+        waitForReceipt: () => {
+          receiptCalls++;
+          if (receiptCalls === 1)
+            return Promise.resolve<ReceiptOutcome>("timeout");
+          if (receiptCalls === 2)
+            return Promise.reject(new Error("rpc unreachable"));
+          if (receiptCalls === 3)
+            return new Promise<ReceiptOutcome>((resolve) => {
+              settle = resolve;
+            });
+          return Promise.resolve<ReceiptOutcome>("success");
+        },
+      },
+    });
+
+    await service.queue(PROPOSAL_ID.toString());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The errored poll consumed an attempt but held the lock: the
+    // transaction's status is still unknown, so a repeat must not broadcast.
+    await expect(service.queue(PROPOSAL_ID.toString())).resolves.toEqual({
+      txHash: TX_HASH,
+    });
+    expect(sent).toHaveLength(1);
+
+    settle("success");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await service.queue(PROPOSAL_ID.toString());
+    expect(sent).toHaveLength(2);
+  });
+
   it("releases the lock when the transaction never settles", async () => {
     const { service, sent } = createService({
       governor: { waitForReceipt: async () => "timeout" },

--- a/apps/relayer/src/services/proposals/proposal-enactment.test.ts
+++ b/apps/relayer/src/services/proposals/proposal-enactment.test.ts
@@ -13,7 +13,10 @@ import {
 import { governorAbi, ProposalState } from "@/abi/governor";
 import { createLogger } from "@anticapture/observability";
 import { RelayError } from "@/errors";
-import type { GovernorGateway } from "@/services/chain/governor-gateway";
+import type {
+  GovernorGateway,
+  ReceiptOutcome,
+} from "@/services/chain/governor-gateway";
 import { SimulationRevertError } from "@/services/chain/governor-gateway";
 import { RelayerSigner } from "@/signer/types";
 
@@ -428,6 +431,53 @@ describe("ProposalEnactmentService in-flight dedup", () => {
     await service.queue(PROPOSAL_ID.toString());
     await service.queue(PROPOSAL_ID.toString());
 
+    expect(sent).toHaveLength(2);
+  });
+
+  it("keeps duplicates joined to the broadcast transaction after a receipt timeout", async () => {
+    let settle!: (outcome: ReceiptOutcome) => void;
+    const receipts: Promise<ReceiptOutcome>[] = [
+      Promise.resolve("timeout"),
+      new Promise((resolve) => {
+        settle = resolve;
+      }),
+    ];
+    let receiptCalls = 0;
+    const { service, sent } = createService({
+      governor: {
+        waitForReceipt: () =>
+          receipts[receiptCalls++] ?? Promise.resolve("success"),
+      },
+    });
+
+    await expect(service.queue(PROPOSAL_ID.toString())).resolves.toEqual({
+      txHash: TX_HASH,
+    });
+
+    // The transaction is still pending, so a repeat joins the broadcast
+    // transaction instead of paying for a second one.
+    await expect(service.queue(PROPOSAL_ID.toString())).resolves.toEqual({
+      txHash: TX_HASH,
+    });
+    expect(sent).toHaveLength(1);
+
+    settle("success");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await service.queue(PROPOSAL_ID.toString());
+    expect(sent).toHaveLength(2);
+  });
+
+  it("releases the lock when the transaction never settles", async () => {
+    const { service, sent } = createService({
+      governor: { waitForReceipt: async () => "timeout" },
+    });
+
+    await service.queue(PROPOSAL_ID.toString());
+    // Drain the bounded background waits holding the lock.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await service.queue(PROPOSAL_ID.toString());
     expect(sent).toHaveLength(2);
   });
 

--- a/apps/relayer/src/services/proposals/proposal-enactment.ts
+++ b/apps/relayer/src/services/proposals/proposal-enactment.ts
@@ -99,16 +99,22 @@ export class ProposalEnactmentService {
   private async releaseWhenSettled(key: string, txHash: Hash): Promise<void> {
     try {
       for (let attempt = 0; attempt < MAX_SETTLEMENT_WAITS; attempt++) {
-        if ((await this.governor.waitForReceipt(txHash)) !== "timeout") return;
+        // A failed poll leaves the transaction's status unknown, so it only
+        // consumes an attempt: releasing the lock on the first transient RPC
+        // error would reopen the duplicate-broadcast window this hold closes.
+        try {
+          if ((await this.governor.waitForReceipt(txHash)) !== "timeout")
+            return;
+        } catch (err) {
+          this.logger.warn(
+            { key, txHash, err },
+            "settlement wait failed; keeping the enactment lock",
+          );
+        }
       }
       this.logger.warn(
         { key, txHash },
         "transaction still unsettled after extended wait; releasing the enactment lock",
-      );
-    } catch (err) {
-      this.logger.warn(
-        { key, txHash, err },
-        "settlement wait failed; releasing the enactment lock",
       );
     } finally {
       this.inflight.delete(key);

--- a/apps/relayer/src/services/proposals/proposal-enactment.ts
+++ b/apps/relayer/src/services/proposals/proposal-enactment.ts
@@ -27,6 +27,11 @@ export interface ProposalEnactmentConfig {
 
 type EnactmentAction = "queue" | "execute";
 
+// After a receipt timeout the in-flight lock is held through this many extra
+// receipt waits before giving up, so a transaction dropped from the mempool
+// cannot lock its proposal out of enactment forever.
+const MAX_SETTLEMENT_WAITS = 4;
+
 const REQUIRED_STATE: Record<EnactmentAction, ProposalState> = {
   queue: ProposalState.Succeeded,
   execute: ProposalState.Queued,
@@ -69,17 +74,51 @@ export class ProposalEnactmentService {
     const pending = this.inflight.get(key);
     if (pending) return pending;
 
-    const run = this.runEnactment(action, proposalId).finally(() => {
-      this.inflight.delete(key);
-    });
+    const run = this.runEnactment(action, proposalId).then(
+      ({ txHash, settled }) => {
+        if (settled) {
+          this.inflight.delete(key);
+        } else {
+          // Receipt wait timed out: the transaction is still pending and the
+          // chain keeps reporting the proposal as actionable, so the lock
+          // must outlive this request — duplicates join the broadcast
+          // transaction instead of burning gas on a second one.
+          void this.releaseWhenSettled(key, txHash);
+        }
+        return { txHash };
+      },
+      (err) => {
+        this.inflight.delete(key);
+        throw err;
+      },
+    );
     this.inflight.set(key, run);
     return run;
+  }
+
+  private async releaseWhenSettled(key: string, txHash: Hash): Promise<void> {
+    try {
+      for (let attempt = 0; attempt < MAX_SETTLEMENT_WAITS; attempt++) {
+        if ((await this.governor.waitForReceipt(txHash)) !== "timeout") return;
+      }
+      this.logger.warn(
+        { key, txHash },
+        "transaction still unsettled after extended wait; releasing the enactment lock",
+      );
+    } catch (err) {
+      this.logger.warn(
+        { key, txHash, err },
+        "settlement wait failed; releasing the enactment lock",
+      );
+    } finally {
+      this.inflight.delete(key);
+    }
   }
 
   private async runEnactment(
     action: EnactmentAction,
     proposalId: string,
-  ): Promise<{ txHash: Hash }> {
+  ): Promise<{ txHash: Hash; settled: boolean }> {
     // Cheap on-chain guards first: spam against unknown or settled proposals
     // must not amplify into Anticapture API calls.
     const state = await this.governor.state(BigInt(proposalId));
@@ -132,7 +171,7 @@ export class ProposalEnactmentService {
     proposalId: string,
     functionName: EnactmentAction,
     call: EnactmentCall,
-  ): Promise<{ txHash: Hash }> {
+  ): Promise<{ txHash: Hash; settled: boolean }> {
     const relayerAddress = await this.signer.getAddress();
 
     const balance = await this.governor.ethBalance(relayerAddress);
@@ -173,7 +212,7 @@ export class ProposalEnactmentService {
       { proposalId, action: functionName, txHash },
       `proposal ${functionName} broadcast`,
     );
-    return { txHash };
+    return { txHash, settled: outcome === "success" };
   }
 
   /**


### PR DESCRIPTION
Fixes the Codex and UI review comments left on #2139, plus the failing Dashboard E2E check.

## Codex (relayer, P2)
- `ProposalEnactmentService` no longer drops the in-flight dedupe lock when the receipt wait times out: the lock is held (bounded to 4 extra receipt waits) until the broadcast transaction settles, so a repeated queue/execute request during that window joins the existing transaction instead of broadcasting a duplicate that reverts and wastes relayer gas. Covered by two new unit tests.

## UI review (isadorable)
- `DaoProtectionLevels`: heading bumped `h3` -> `h2` so the panel outline no longer skips a level after the page's `h1`.
- `TestimonialCarousel`: prev/next arrows enlarged from 36px to 44px to meet the minimum touch-target size.
- `VotingModal` (Tornado): the footer now explains a disabled Submit — "Loading your delegators..." while the delegator list pages in, and an error message with a Retry action when the fetch fails (previously the button just stayed dead with no feedback).

## Dashboard E2E
- `panel.spec.ts` assumed the Monitored DAOs table is taller than the 640px short viewport; commenting the Shutter DAO out of the list dropped the table to 613px and failed all retries. The assertion now checks the real invariant directly — the table container never clips rows behind an inner scrollbar (`scrollHeight <= clientHeight`) — so the test no longer breaks when DAOs come and go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)