### PR TITLE
revert: restore the Shutter DAO in the dashboard

### DIFF
--- a/.changeset/disable-shutter-dao.md
+++ b/.changeset/disable-shutter-dao.md
@@ -1,5 +1,0 @@
----
-"@anticapture/dashboard": patch
----
-
-Comment the Shutter DAO out of the dashboard DAO list.

--- a/.changeset/restore-shutter-dao.md
+++ b/.changeset/restore-shutter-dao.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Restore the Shutter DAO in the dashboard DAO list.

--- a/apps/dashboard/features/create-proposal/constants.ts
+++ b/apps/dashboard/features/create-proposal/constants.ts
@@ -7,7 +7,7 @@ export const BODY_WARNING_THRESHOLD = 95_000;
 
 export const canCreateProposalForDao = (daoId: DaoIdEnum | null | undefined) =>
   daoId === DaoIdEnum.ENS ||
-  // daoId === DaoIdEnum.SHU ||
+  daoId === DaoIdEnum.SHU ||
   daoId === DaoIdEnum.UNISWAP ||
   daoId === DaoIdEnum.TORN ||
   daoId === DaoIdEnum.COMP ||

--- a/apps/dashboard/features/create-proposal/utils/submitProposalRequest.test.ts
+++ b/apps/dashboard/features/create-proposal/utils/submitProposalRequest.test.ts
@@ -236,7 +236,7 @@ describe("submitProposalRequest (Tornado Cash)", () => {
   it("classifies only TORN as a Tornado DAO", () => {
     expect(isTornadoDao(DaoIdEnum.TORN)).toBe(true);
     expect(isTornadoDao(DaoIdEnum.ENS)).toBe(false);
-    expect(isTornadoDao(DaoIdEnum.UNISWAP)).toBe(false);
+    expect(isTornadoDao(DaoIdEnum.SHU)).toBe(false);
   });
 
   it("proposes with the executeProposal() action's address as the proposal contract", () => {

--- a/apps/dashboard/features/create-proposal/utils/submitProposalRequest.ts
+++ b/apps/dashboard/features/create-proposal/utils/submitProposalRequest.ts
@@ -162,8 +162,7 @@ const SAFE_OPERATION_CALL = 0;
 const AZORIUS_EMPTY_STRATEGY_DATA = "0x" as const;
 
 /** DAOs whose proposals go through an Azorius module rather than an OZ Governor. */
-// SHU, the only Azorius DAO, is disabled in DaoIdEnum.
-export const isAzoriusDao = (_daoId: DaoIdEnum) => false;
+export const isAzoriusDao = (daoId: DaoIdEnum) => daoId === DaoIdEnum.SHU;
 
 /** DAOs on Tornado Cash's custom stake-to-vote governance. */
 export const isTornadoDao = (daoId: DaoIdEnum) => daoId === DaoIdEnum.TORN;

--- a/apps/dashboard/features/dao-overview/components/DaoOverviewHeader.tsx
+++ b/apps/dashboard/features/dao-overview/components/DaoOverviewHeader.tsx
@@ -10,6 +10,7 @@ import type {
   DaoConfiguration,
   DaoOverviewConfig,
 } from "@/shared/dao-config/types";
+import { DaoIdEnum } from "@/shared/types/daos";
 import { cn } from "@/shared/utils";
 
 interface DaoOverviewHeaderProps {
@@ -61,7 +62,7 @@ export const DaoOverviewHeader = ({
             iconVariant="secondary"
             className="bg-surface-opacity text-primary h-5 rounded-full text-xs"
           >
-            1 {daoId} = ${lastPrice.toFixed(2)}
+            1 {daoId} = ${lastPrice.toFixed(daoId === DaoIdEnum.SHU ? 4 : 2)}
             {daoOverview.priceDisclaimer && (
               <TooltipInfo text={daoOverview.priceDisclaimer} />
             )}

--- a/apps/dashboard/features/governance/components/proposal-overview/ProposalHeader.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/ProposalHeader.tsx
@@ -184,8 +184,7 @@ const ProposalExecutionButtons = ({
 }) => {
   if (!address) return null;
 
-  // SHU is disabled in DaoIdEnum, so compare against its raw id.
-  const isShu = daoId.toUpperCase() === "SHU";
+  const isShu = daoId.toUpperCase() === DaoIdEnum.SHU;
   const isTorn = daoId.toUpperCase() === DaoIdEnum.TORN;
 
   return (

--- a/apps/dashboard/features/governance/components/proposal-overview/ProposalSection.tsx
+++ b/apps/dashboard/features/governance/components/proposal-overview/ProposalSection.tsx
@@ -661,8 +661,7 @@ const MobileBottomBar = ({
   } else if (address) {
     if (
       proposalStatus === "succeeded" &&
-      // SHU is disabled in DaoIdEnum, so compare against its raw id.
-      daoId.toUpperCase() !== "SHU"
+      daoId.toUpperCase() !== DaoIdEnum.SHU
     ) {
       content = (
         <Button className="flex w-full" onClick={onQueueClick}>
@@ -674,7 +673,7 @@ const MobileBottomBar = ({
       // Azorius (SHU) and Tornado (TORN) proposals are QUEUED while
       // timelocked and executing reverts until PENDING_EXECUTION
       (proposalStatus === "queued" &&
-        daoId.toUpperCase() !== "SHU" &&
+        daoId.toUpperCase() !== DaoIdEnum.SHU &&
         daoId.toUpperCase() !== DaoIdEnum.TORN)
     ) {
       content = (

--- a/apps/dashboard/features/governance/hooks/useCalldataReview.ts
+++ b/apps/dashboard/features/governance/hooks/useCalldataReview.ts
@@ -13,8 +13,7 @@ const TREE_URL =
 const REPO_DAO_DIR: Partial<Record<DaoIdEnum, string>> = {
   [DaoIdEnum.ENS]: "ens",
   [DaoIdEnum.UNISWAP]: "uniswap",
-  // SHU is disabled in DaoIdEnum.
-  // [DaoIdEnum.SHU]: "shutter",
+  [DaoIdEnum.SHU]: "shutter",
   [DaoIdEnum.TORN]: "tornado",
 };
 

--- a/apps/dashboard/features/governance/utils/submitGovernanceAction.ts
+++ b/apps/dashboard/features/governance/utils/submitGovernanceAction.ts
@@ -35,26 +35,25 @@ const TornGovernanceExecuteAbi = [
   },
 ] as const;
 
-// SHU is disabled in DaoIdEnum; restore this with the SHU case below.
-// const AzoriusExecuteAbi = [
-//   {
-//     name: "executeProposal",
-//     type: "function",
-//     stateMutability: "nonpayable",
-//     inputs: [
-//       { internalType: "uint32", name: "_proposalId", type: "uint32" },
-//       { internalType: "address[]", name: "_targets", type: "address[]" },
-//       { internalType: "uint256[]", name: "_values", type: "uint256[]" },
-//       { internalType: "bytes[]", name: "_data", type: "bytes[]" },
-//       {
-//         internalType: "enum Enum.Operation[]",
-//         name: "_operations",
-//         type: "uint8[]",
-//       },
-//     ],
-//     outputs: [],
-//   },
-// ] as const;
+const AzoriusExecuteAbi = [
+  {
+    name: "executeProposal",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      { internalType: "uint32", name: "_proposalId", type: "uint32" },
+      { internalType: "address[]", name: "_targets", type: "address[]" },
+      { internalType: "uint256[]", name: "_values", type: "uint256[]" },
+      { internalType: "bytes[]", name: "_data", type: "bytes[]" },
+      {
+        internalType: "enum Enum.Operation[]",
+        name: "_operations",
+        type: "uint8[]",
+      },
+    ],
+    outputs: [],
+  },
+] as const;
 
 export type GovernanceAction = "queue" | "execute";
 
@@ -122,31 +121,30 @@ const submitAction = async (
       hash = await client.writeContract(request);
       break;
     }
-    // SHU is disabled in DaoIdEnum.
-    // case DaoIdEnum.SHU: {
-    //   if (action === "queue") {
-    //     throw new Error("Queue is not supported for Azorius governance (SHU)");
-    //   }
-    //   // Azorius: executeProposal(proposalId, targets, values, data, operations)
-    //   // All operations are Call (0) for standard governance proposals
-    //   const operations = args.targets.map(() => 0);
-    //   const { request } = await client.simulateContract({
-    //     abi: AzoriusExecuteAbi,
-    //     address,
-    //     functionName: "executeProposal",
-    //     args: [
-    //       Number(args.proposalId),
-    //       args.targets,
-    //       args.values,
-    //       args.calldatas,
-    //       operations,
-    //     ],
-    //     account: args.account,
-    //     chain,
-    //   });
-    //   hash = await client.writeContract(request);
-    //   break;
-    // }
+    case DaoIdEnum.SHU: {
+      if (action === "queue") {
+        throw new Error("Queue is not supported for Azorius governance (SHU)");
+      }
+      // Azorius: executeProposal(proposalId, targets, values, data, operations)
+      // All operations are Call (0) for standard governance proposals
+      const operations = args.targets.map(() => 0);
+      const { request } = await client.simulateContract({
+        abi: AzoriusExecuteAbi,
+        address,
+        functionName: "executeProposal",
+        args: [
+          Number(args.proposalId),
+          args.targets,
+          args.values,
+          args.calldatas,
+          operations,
+        ],
+        account: args.account,
+        chain,
+      });
+      hash = await client.writeContract(request);
+      break;
+    }
     default: {
       if (action === "queue") {
         const { request } = await client.simulateContract({

--- a/apps/dashboard/features/governance/utils/voteOnProposal.ts
+++ b/apps/dashboard/features/governance/utils/voteOnProposal.ts
@@ -19,19 +19,18 @@ import {
   mapRelayerError,
 } from "@/shared/utils/gaslessRelayerError";
 
-// SHU is disabled in DaoIdEnum; restore this with the Azorius handler below.
-// const LinearVotingStrategyAbi = [
-//   {
-//     inputs: [
-//       { internalType: "uint32", name: "_proposalId", type: "uint32" },
-//       { internalType: "uint8", name: "_voteType", type: "uint8" },
-//     ],
-//     name: "vote",
-//     outputs: [],
-//     stateMutability: "nonpayable",
-//     type: "function",
-//   },
-// ] as const;
+const LinearVotingStrategyAbi = [
+  {
+    inputs: [
+      { internalType: "uint32", name: "_proposalId", type: "uint32" },
+      { internalType: "uint8", name: "_voteType", type: "uint8" },
+    ],
+    name: "vote",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+] as const;
 
 // Shared by OZ Governor (returns uint256) and GovernorBravo (returns void).
 // `outputs` must stay empty: Bravo's castVote returns no data, and declaring a
@@ -95,23 +94,22 @@ type VoteHandler = (
 /**
  * Azorius/Fractal: vote on LinearVotingStrategy. No reason support.
  */
-// SHU is disabled in DaoIdEnum.
-// const azoriusVoteHandler =
-//   (daoId: DaoIdEnum): VoteHandler =>
-//   async (client, params) => {
-//     const address =
-//       daoConfigByDaoId[daoId].daoOverview.contracts.votingStrategy;
-//     if (!address) throw new Error("Voting strategy address not found");
-//
-//     const { request } = await client.simulateContract({
-//       abi: LinearVotingStrategyAbi,
-//       address,
-//       functionName: "vote",
-//       args: [Number(params.proposalId), params.voteNumber],
-//       account: params.account,
-//     });
-//     return client.writeContract(request);
-//   };
+const azoriusVoteHandler =
+  (daoId: DaoIdEnum): VoteHandler =>
+  async (client, params) => {
+    const address =
+      daoConfigByDaoId[daoId].daoOverview.contracts.votingStrategy;
+    if (!address) throw new Error("Voting strategy address not found");
+
+    const { request } = await client.simulateContract({
+      abi: LinearVotingStrategyAbi,
+      address,
+      functionName: "vote",
+      args: [Number(params.proposalId), params.voteNumber],
+      account: params.account,
+    });
+    return client.writeContract(request);
+  };
 
 const TornGovernorVoteAbi = [
   {
@@ -265,9 +263,8 @@ function getVoteHandler(
     return gaslessVoteHandler(daoId);
   }
   switch (daoId) {
-    // SHU is disabled in DaoIdEnum.
-    // case DaoIdEnum.SHU:
-    //   return azoriusVoteHandler(daoId);
+    case DaoIdEnum.SHU:
+      return azoriusVoteHandler(daoId);
     case DaoIdEnum.TORN:
       return tornVoteHandler(daoId);
     default:

--- a/apps/dashboard/shared/types/daos.ts
+++ b/apps/dashboard/shared/types/daos.ts
@@ -7,7 +7,7 @@ export enum DaoIdEnum {
   NOUNS = "NOUNS",
   SCR = "SCR",
   OBOL = "OBOL",
-  // SHU = "SHU",
+  SHU = "SHU",
   // OPTIMISM = "OP",
   UNISWAP = "UNI",
   GITCOIN = "GTC",


### PR DESCRIPTION
Reverts #2138 (merge `93cf755a6`): the Shutter DAO is staying for now, so this restores it in the dashboard — `SHU` back in `DaoIdEnum`, the Azorius vote handler and governance-action paths un-commented, and Shutter back in the create-proposal allowlist.

One conflict resolved by hand: `create-proposal/constants.ts`, where the Uniswap whitelabel landed after the removal — both SHU and UNISWAP are kept. Everything merged since (Uniswap/Tornado/Compound/Gitcoin whitelabels, panel v2.1) is untouched, and `shared/dao-config/shu.ts` was never removed, so no further rewiring is needed.

Typecheck, lint, and tests pass on the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)