### PR TITLE
fix: PR #2139 review feedback (Tornado voter filter, relayer receipt errors)

### DIFF
--- a/.changeset/relayer-hold-lock-on-receipt-error.md
+++ b/.changeset/relayer-hold-lock-on-receipt-error.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/relayer": patch
+---
+
+Keep the enactment lock held when the post-broadcast receipt wait fails with an RPC error.

--- a/.changeset/torn-exclude-voter-from-delegated-vote.md
+++ b/.changeset/torn-exclude-voter-from-delegated-vote.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Exclude the voter's own address from the Tornado delegated-vote list so castDelegatedVote does not revert.

--- a/apps/dashboard/features/governance/components/modals/VotingModal.tsx
+++ b/apps/dashboard/features/governance/components/modals/VotingModal.tsx
@@ -10,6 +10,7 @@ import { LoadingComponent } from "@/features/governance/components/modals/Loadin
 import { VoteSuccessContent } from "@/features/governance/components/modals/VoteSuccessContent";
 import { VoteOption } from "@/features/governance/components/proposal-overview/VoteOption";
 import type { ProposalDetails } from "@/features/governance/types";
+import { buildTornDelegatedVoteFrom } from "@/features/governance/utils/tornDelegatedVote";
 import { voteOnProposal } from "@/features/governance/utils/voteOnProposal";
 import { BadgeStatus } from "@/shared/components/design-system/badges/badge-status/BadgeStatus";
 import { Button } from "@/shared/components/design-system/buttons/button/Button";
@@ -169,21 +170,10 @@ export const VotingModal = ({
   const tornDelegatedVoteAddresses = useMemo(() => {
     if (!isTorn || !address) return undefined;
 
-    const seen = new Set<string>();
-    const addresses = tornDelegators
-      .map((delegator) => delegator.delegatorAddress as Address)
-      .filter((delegatorAddress) => {
-        const normalized = delegatorAddress.toLowerCase();
-        if (seen.has(normalized)) return false;
-        seen.add(normalized);
-        return true;
-      });
-
-    // `from` lists ONLY accounts that delegated to the voter; the governor
-    // reverts on self-delegation, so the voter's own address must never appear
-    // here. A solo voter (verified empty list) goes through castVote instead,
-    // since castDelegatedVote rejects an empty `from`.
-    return addresses;
+    return buildTornDelegatedVoteFrom(
+      address,
+      tornDelegators.map((delegator) => delegator.delegatorAddress as Address),
+    );
   }, [address, isTorn, tornDelegators]);
 
   const { minVotingPower } = useRelayerConfig(daoId);

--- a/apps/dashboard/features/governance/utils/tornDelegatedVote.test.ts
+++ b/apps/dashboard/features/governance/utils/tornDelegatedVote.test.ts
@@ -1,0 +1,40 @@
+import type { Address } from "viem";
+
+import { buildTornDelegatedVoteFrom } from "@/features/governance/utils/tornDelegatedVote";
+
+const VOTER: Address = "0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa";
+const DELEGATOR_ONE: Address = "0xabcabcabcabcabcabcabcabcabcabcabcabcabca";
+const DELEGATOR_TWO: Address = "0x2222222222222222222222222222222222222222";
+
+describe("buildTornDelegatedVoteFrom", () => {
+  it("keeps delegators other than the voter", () => {
+    expect(
+      buildTornDelegatedVoteFrom(VOTER, [DELEGATOR_ONE, DELEGATOR_TWO]),
+    ).toEqual([DELEGATOR_ONE, DELEGATOR_TWO]);
+  });
+
+  it("excludes the voter regardless of casing", () => {
+    // The delegators query returns self-delegations (an undelegated account
+    // is recorded as its own delegate); castDelegatedVote reverts on them.
+    expect(
+      buildTornDelegatedVoteFrom(VOTER, [
+        DELEGATOR_ONE,
+        VOTER.toLowerCase() as Address,
+      ]),
+    ).toEqual([DELEGATOR_ONE]);
+  });
+
+  it("returns an empty list when the voter is the only entry, routing to castVote", () => {
+    expect(buildTornDelegatedVoteFrom(VOTER, [VOTER])).toEqual([]);
+  });
+
+  it("deduplicates delegators case-insensitively, keeping the first occurrence", () => {
+    expect(
+      buildTornDelegatedVoteFrom(VOTER, [
+        DELEGATOR_ONE,
+        "0xABCabcABCabcABCabcABCabcABCabcABCabcABCA" as Address,
+        DELEGATOR_TWO,
+      ]),
+    ).toEqual([DELEGATOR_ONE, DELEGATOR_TWO]);
+  });
+});

--- a/apps/dashboard/features/governance/utils/tornDelegatedVote.ts
+++ b/apps/dashboard/features/governance/utils/tornDelegatedVote.ts
@@ -1,0 +1,26 @@
+import type { Address } from "viem";
+
+/**
+ * Builds the `from` list for Tornado's castDelegatedVote: the voter's unique
+ * delegators, compared case-insensitively.
+ *
+ * The delegators query intentionally includes the voter itself (the
+ * TORNGovernor:Undelegated handler records an undelegated account as its own
+ * delegate), but the governor forbids self-delegation, so a `from` list
+ * containing the voter makes castDelegatedVote revert and blocks the vote.
+ * The voter's own address is therefore dropped here; when nothing remains the
+ * vote goes through castVote instead (castDelegatedVote rejects an empty
+ * `from`).
+ */
+export const buildTornDelegatedVoteFrom = (
+  voter: Address,
+  delegatorAddresses: Address[],
+): Address[] => {
+  const seen = new Set<string>([voter.toLowerCase()]);
+  return delegatorAddresses.filter((delegatorAddress) => {
+    const normalized = delegatorAddress.toLowerCase();
+    if (seen.has(normalized)) return false;
+    seen.add(normalized);
+    return true;
+  });
+};

--- a/apps/relayer/src/services/proposals/proposal-enactment.test.ts
+++ b/apps/relayer/src/services/proposals/proposal-enactment.test.ts
@@ -468,6 +468,44 @@ describe("ProposalEnactmentService in-flight dedup", () => {
     expect(sent).toHaveLength(2);
   });
 
+  it("keeps duplicates joined when the initial receipt wait throws", async () => {
+    let settle!: (outcome: ReceiptOutcome) => void;
+    let receiptCalls = 0;
+    const { service, sent } = createService({
+      governor: {
+        waitForReceipt: () => {
+          receiptCalls++;
+          if (receiptCalls === 1)
+            return Promise.reject(new Error("rpc unreachable"));
+          if (receiptCalls === 2)
+            return new Promise<ReceiptOutcome>((resolve) => {
+              settle = resolve;
+            });
+          return Promise.resolve<ReceiptOutcome>("success");
+        },
+      },
+    });
+
+    // The transaction was broadcast before the receipt poll failed, so the
+    // caller still gets the hash instead of an error.
+    await expect(service.queue(PROPOSAL_ID.toString())).resolves.toEqual({
+      txHash: TX_HASH,
+    });
+
+    // Its status is unknown, so a repeat joins the broadcast transaction
+    // instead of paying for a second one.
+    await expect(service.queue(PROPOSAL_ID.toString())).resolves.toEqual({
+      txHash: TX_HASH,
+    });
+    expect(sent).toHaveLength(1);
+
+    settle("success");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await service.queue(PROPOSAL_ID.toString());
+    expect(sent).toHaveLength(2);
+  });
+
   it("keeps the lock through a transient settlement poll error", async () => {
     let settle!: (outcome: ReceiptOutcome) => void;
     let receiptCalls = 0;

--- a/apps/relayer/src/services/proposals/proposal-enactment.ts
+++ b/apps/relayer/src/services/proposals/proposal-enactment.ts
@@ -15,6 +15,7 @@ import {
   SimulationRevertError,
   type EnactmentCall,
   type GovernorGateway,
+  type ReceiptOutcome,
 } from "@/services/chain/governor-gateway";
 import { RelayerSigner } from "@/signer/types";
 
@@ -27,9 +28,10 @@ export interface ProposalEnactmentConfig {
 
 type EnactmentAction = "queue" | "execute";
 
-// After a receipt timeout the in-flight lock is held through this many extra
-// receipt waits before giving up, so a transaction dropped from the mempool
-// cannot lock its proposal out of enactment forever.
+// After an unsettled broadcast (receipt timeout or failed poll) the in-flight
+// lock is held through this many extra receipt waits before giving up, so a
+// transaction dropped from the mempool cannot lock its proposal out of
+// enactment forever.
 const MAX_SETTLEMENT_WAITS = 4;
 
 const REQUIRED_STATE: Record<EnactmentAction, ProposalState> = {
@@ -79,8 +81,9 @@ export class ProposalEnactmentService {
         if (settled) {
           this.inflight.delete(key);
         } else {
-          // Receipt wait timed out: the transaction is still pending and the
-          // chain keeps reporting the proposal as actionable, so the lock
+          // The broadcast transaction has not settled (receipt timeout or
+          // failed poll): it may still be pending and the chain keeps
+          // reporting the proposal as actionable, so the lock
           // must outlive this request — duplicates join the broadcast
           // transaction instead of burning gas on a second one.
           void this.releaseWhenSettled(key, txHash);
@@ -203,15 +206,28 @@ export class ProposalEnactmentService {
       }),
     });
 
-    const outcome = await this.governor.waitForReceipt(txHash);
+    let outcome: ReceiptOutcome;
+    try {
+      outcome = await this.governor.waitForReceipt(txHash);
+      if (outcome === "timeout") {
+        this.logger.warn(
+          { proposalId, action: functionName, txHash },
+          "receipt wait timed out; transaction was broadcast",
+        );
+      }
+    } catch (err) {
+      // The transaction is already broadcast, so a failed receipt poll only
+      // leaves its status unknown. Rejecting here would release the in-flight
+      // lock through enact()'s error path and reopen the duplicate-broadcast
+      // window, so report it as unsettled and let the settlement hold decide.
+      this.logger.warn(
+        { proposalId, action: functionName, txHash, err },
+        "receipt wait failed; transaction was broadcast",
+      );
+      outcome = "timeout";
+    }
     if (outcome === "reverted") {
       throw Errors.TRANSACTION_REVERTED(txHash);
-    }
-    if (outcome === "timeout") {
-      this.logger.warn(
-        { proposalId, action: functionName, txHash },
-        "receipt wait timed out; transaction was broadcast",
-      );
     }
 
     this.logger.info(


### PR DESCRIPTION
Addresses the two open Codex review comments on #2139.

**`fix(dashboard)`: exclude the voter from Tornado delegated-vote addresses** (P1)
The delegators query intentionally returns self-delegations (the `TORNGovernor:Undelegated` handler records an account as its own delegate), but the governor forbids self-delegation, so a `from` list containing the connected wallet made `castDelegatedVote` revert and blocked the vote. The `from` list is now built by `buildTornDelegatedVoteFrom`, which drops the voter's own address case-insensitively (and keeps the existing dedup); a voter left with no delegators routes to `castVote`. Covered by unit tests.

**`fix(relayer)`: hold the enactment lock when the post-broadcast receipt wait throws** (P2)
When `sendTransaction` succeeded but the initial `waitForReceipt` threw a transient RPC error, `runEnactment` rejected and the rejection handler released the in-flight lock while the transaction could still be pending, so a retry could broadcast a duplicate. The failed poll is now treated as an unsettled broadcast: the caller still gets the tx hash, and the lock is handed to the existing bounded settlement hold (`releaseWhenSettled`). Covered by a new unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)