### PR TITLE
chore(client): add changeset so the relay queue/execute SDK rebuild publishes

### DIFF
--- a/.changeset/client-relay-enactment-endpoints.md
+++ b/.changeset/client-relay-enactment-endpoints.md
@@ -1,0 +1,8 @@
+---
+"@anticapture/client": minor
+---
+
+The generated SDK now covers the new POST /{dao}/relay/queue and
+POST /{dao}/relay/execute Gateful routes: relayQueue/relayExecute fetchers,
+React Query hooks, and request/response types are regenerated from the live
+spec and published to npm.


### PR DESCRIPTION
## Why

The current Version Packages PR (`changeset-release/dev`) consumes the changesets for the new relayer/gateful `POST /{dao}/relay/queue` and `POST /{dao}/relay/execute` endpoints, but leaves `@anticapture/client` at the already-published 2.0.1.

When the release reaches `main`, `release.yaml` rebuilds the client from Gateful's live OpenAPI spec (which now includes the relay routes) and then runs `changeset publish` — which skips the client because its version didn't change. npm consumers would not get the generated `relayQueue`/`relayExecute` fetchers, hooks, or types until an unrelated client bump.

## What

Adds a `@anticapture/client` minor changeset so the rolling Version Packages PR bumps the client to 2.1.0 and the rebuilt SDK actually publishes with this release.
