### PR TITLE
hotfix: apply vote-by-voter filtering and stop feed events gateway timeouts

### DIFF
--- a/.changeset/address-query-comma-lists.md
+++ b/.changeset/address-query-comma-lists.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/api": patch
+---
+
+Accept comma-delimited address lists in query params as documented.

--- a/.changeset/feed-address-filter-timeout.md
+++ b/.changeset/feed-address-filter-timeout.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/api": patch
+---
+
+Speed up the feed events address filter to stop gateway timeouts on large DAOs.

--- a/.changeset/mcp-array-params.md
+++ b/.changeset/mcp-array-params.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/client": patch
+---
+
+Send array query params as repeated params from the MCP server so filters are applied.

--- a/.changeset/votes-voter-filter.md
+++ b/.changeset/votes-voter-filter.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/api": patch
+---
+
+Apply the voterAddressIn filter on the all-votes endpoint.

--- a/apps/api/src/controllers/votes/onchainVotes.integration.test.ts
+++ b/apps/api/src/controllers/votes/onchainVotes.integration.test.ts
@@ -305,6 +305,51 @@ describe("Onchain Votes Controller", () => {
       const body = await res.json();
       expect(body).toEqual({ items: [FULL_VOTE_OBJECT], totalCount: 1 });
     });
+
+    it("should accept voterAddressIn filter", async () => {
+      await db.insert(proposalsOnchain).values(createProposal({ id: "1" }));
+      await db.insert(votesOnchain).values([
+        createVote({ proposalId: "1", voterAccountId: VOTER_ADDRESS }),
+        createVote({
+          proposalId: "1",
+          voterAccountId: SECOND_VOTER,
+          txHash: "0xdef456",
+        }),
+      ]);
+
+      const res = await app.request(`/votes?voterAddressIn=${VOTER_ADDRESS}`);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ totalCount: 1, items: [FULL_VOTE_OBJECT] });
+    });
+
+    it("should accept voterAddressIn as repeated and comma-delimited params", async () => {
+      await db.insert(proposalsOnchain).values(createProposal({ id: "1" }));
+      await db.insert(votesOnchain).values([
+        createVote({ proposalId: "1", voterAccountId: VOTER_ADDRESS }),
+        createVote({
+          proposalId: "1",
+          voterAccountId: SECOND_VOTER,
+          txHash: "0xdef456",
+        }),
+      ]);
+
+      for (const query of [
+        `voterAddressIn=${VOTER_ADDRESS}&voterAddressIn=${SECOND_VOTER}`,
+        `voterAddressIn=${VOTER_ADDRESS},${SECOND_VOTER}`,
+      ]) {
+        const res = await app.request(`/votes?${query}`);
+
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.totalCount).toBe(2);
+        const voters = body.items
+          .map((item: { voterAddress: string }) => item.voterAddress)
+          .sort();
+        expect(voters).toEqual([VOTER_ADDRESS, SECOND_VOTER].sort());
+      }
+    });
   });
 
   describe("GET /proposals/{id}/non-voters", () => {

--- a/apps/api/src/controllers/votes/onchainVotes.ts
+++ b/apps/api/src/controllers/votes/onchainVotes.ts
@@ -89,25 +89,7 @@ export function votes(app: Hono, service: VotesService) {
       },
     }),
     async (context) => {
-      const {
-        limit,
-        skip,
-        orderBy,
-        orderDirection,
-        fromDate,
-        toDate,
-        support,
-      } = context.req.valid("query");
-
-      const result = await service.getVotes({
-        limit,
-        skip,
-        orderBy,
-        orderDirection,
-        fromDate,
-        toDate,
-        support,
-      });
+      const result = await service.getVotes(context.req.valid("query"));
 
       return context.json(result);
     },

--- a/apps/api/src/mappers/shared.ts
+++ b/apps/api/src/mappers/shared.ts
@@ -137,7 +137,9 @@ export const AddressSchema = z
 export const AddressArraySchema = z.array(AddressSchema);
 
 export const AddressQueryArraySchema = z
-  .union([AddressSchema.transform((val) => [val]), AddressArraySchema])
+  .union([z.string(), z.array(z.string())])
+  .transform((value) => (normalizeQueryArray(value) ?? []).map(String))
+  .pipe(AddressArraySchema)
   .openapi({ type: "array", items: { type: "string" } });
 
 export const unixTimestampQueryParam = (description: string) =>

--- a/apps/api/src/mappers/shared.unit.test.ts
+++ b/apps/api/src/mappers/shared.unit.test.ts
@@ -75,6 +75,18 @@ describe("AddressQueryArraySchema", () => {
       AddressQueryArraySchema.parse([SAMPLE_ADDRESS, SAMPLE_ADDRESS_2]),
     ).toEqual([getAddress(SAMPLE_ADDRESS), getAddress(SAMPLE_ADDRESS_2)]);
   });
+
+  it("splits a comma-delimited string into addresses", () => {
+    expect(
+      AddressQueryArraySchema.parse(`${SAMPLE_ADDRESS},${SAMPLE_ADDRESS_2}`),
+    ).toEqual([getAddress(SAMPLE_ADDRESS), getAddress(SAMPLE_ADDRESS_2)]);
+  });
+
+  it("rejects when any comma-delimited element is invalid", () => {
+    expect(() =>
+      AddressQueryArraySchema.parse(`${SAMPLE_ADDRESS},bad`),
+    ).toThrow();
+  });
 });
 
 describe("normalizeQueryArray", () => {

--- a/apps/api/src/repositories/feed/feed.repository.unit.test.ts
+++ b/apps/api/src/repositories/feed/feed.repository.unit.test.ts
@@ -730,6 +730,19 @@ describe("FeedRepository", () => {
         });
       });
 
+      it("combines the address filter with a type filter", async () => {
+        const result = await repository.getFeedEvents(
+          defaultFeedParams({
+            address: VOTER as `0x${string}`,
+            type: [FeedEventType.VOTE, FeedEventType.TRANSFER],
+          }),
+          defaultThresholds(),
+        );
+
+        expect(result.items.map((i) => i.txHash)).toEqual(["0xv1"]);
+        expect(result.totalCount).toBe(1);
+      });
+
       it("returns nothing for an address not present in any event", async () => {
         expect(
           await getFilteredTxHashes(

--- a/apps/api/src/repositories/feed/feed.repository.unit.test.ts
+++ b/apps/api/src/repositories/feed/feed.repository.unit.test.ts
@@ -1,7 +1,7 @@
 import { PGlite } from "@electric-sql/pglite";
 import { pushSchema } from "drizzle-kit/api";
 import { drizzle } from "drizzle-orm/pglite";
-import { zeroAddress } from "viem";
+import { getAddress, zeroAddress } from "viem";
 
 import type { Drizzle } from "@/database";
 import * as schema from "@/database/schema";
@@ -594,12 +594,19 @@ describe("FeedRepository", () => {
     });
 
     describe("address filter", () => {
-      const DELEGATOR = "0xAaAaAAAaaAaAAaAaAaAAAAAaAAAAaaAAAAaAaAA1";
-      const DELEGATE = "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBb2";
-      const PREVIOUS_DELEGATE = "0xCcccCcCCcCCCCCcCcCcccCcCCCcCccccccCCCCc3";
-      const SENDER = "0xdDDDddDdDdddDDdDDDDdDDDDDDDddDDdDdDdDDd4";
-      const RECIPIENT = "0xEEEeEEEeeEeEeeEEEEeeeeEEeEeeeEEeEEeeEeE5";
-      const VOTER = "0xFFffFfFffFFFfffffFfFFFfFfffFfFFFFffFFF6";
+      // Source tables store viem-checksummed addresses (or, rarely,
+      // lowercase); the filter matches both forms by plain indexed equality.
+      const DELEGATOR = getAddress(
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+      );
+      const DELEGATE = getAddress("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2");
+      const PREVIOUS_DELEGATE = getAddress(
+        "0xccccccccccccccccccccccccccccccccccccccc3",
+      );
+      const SENDER = getAddress("0xddddddddddddddddddddddddddddddddddddddd4");
+      // Stored lowercase on purpose: covers the indexer's other storage form.
+      const RECIPIENT = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee5";
+      const VOTER = getAddress("0xfffffffffffffffffffffffffffffffffffffff6");
       const PROPOSER = "0x1234123412341234123412341234123412341234";
 
       beforeEach(async () => {
@@ -715,7 +722,8 @@ describe("FeedRepository", () => {
         });
       });
 
-      it("matches case-insensitively regardless of stored casing", async () => {
+      it("matches either stored form regardless of query casing", async () => {
+        // Stored checksummed, queried uppercase and lowercase.
         expect(
           await getFilteredTxHashes(
             DELEGATOR.toUpperCase().replace("0X", "0x"),
@@ -726,6 +734,11 @@ describe("FeedRepository", () => {
         });
         expect(await getFilteredTxHashes(VOTER.toLowerCase())).toEqual({
           txHashes: ["0xv1"],
+          totalCount: 1,
+        });
+        // Stored lowercase, queried checksummed.
+        expect(await getFilteredTxHashes(getAddress(RECIPIENT))).toEqual({
+          txHashes: ["0xt1"],
           totalCount: 1,
         });
       });

--- a/apps/api/src/repositories/feed/index.ts
+++ b/apps/api/src/repositories/feed/index.ts
@@ -70,12 +70,19 @@ export class FeedRepository {
       address,
     } = req;
 
-    const relevanceFilter = this.buildRelevanceFilter(type, valueThresholds);
+    const selectedTypes =
+      type && type.length > 0
+        ? type
+        : (Object.keys(valueThresholds) as FeedEventType[]);
+    const relevanceFilter = this.buildRelevanceFilter(
+      selectedTypes,
+      valueThresholds,
+    );
 
     const where = and(
       fromDate ? gte(feedEvent.timestamp, fromDate) : undefined,
       toDate ? lte(feedEvent.timestamp, toDate) : undefined,
-      address ? this.buildAddressFilter(address) : undefined,
+      address ? this.buildAddressFilter(address, selectedTypes) : undefined,
       relevanceFilter,
     );
 
@@ -433,60 +440,74 @@ export class FeedRepository {
   // feed_event has no account column, so addresses are matched in the source
   // table each event type is derived from, keyed by (tx_hash, log_index).
   // Lowercased on both sides because source tables may store checksummed
-  // addresses. feed_event columns use Drizzle refs so they follow whatever
-  // alias the query builder assigns (see the proposerVotingPower note above).
-  private buildAddressFilter(address: string): SQL {
+  // addresses. The subqueries are deliberately uncorrelated: Postgres runs
+  // each one once and hashes the result, instead of probing the source table
+  // for every feed_event row — correlated EXISTS here timed out on large
+  // DAOs. Only the branches for the requested event types are built, so a
+  // type-filtered request never scans the other source tables. feed_event
+  // columns use Drizzle refs so they follow whatever alias the query builder
+  // assigns (see the proposerVotingPower note above).
+  private buildAddressFilter(
+    address: string,
+    selectedTypes: FeedEventType[],
+  ): SQL | undefined {
     const addr = address.toLowerCase();
-    return sql`(
-      (${feedEvent.type} = 'DELEGATION' AND EXISTS (
-        SELECT 1 FROM delegations d
-        WHERE d.transaction_hash = ${feedEvent.txHash}
-          AND d.log_index = ${feedEvent.logIndex}
-          AND (
-            LOWER(d.delegator_account_id) = ${addr}
+    const types =
+      selectedTypes.length > 0
+        ? selectedTypes
+        : (Object.values(FeedEventType) as FeedEventType[]);
+
+    const branches: SQL[] = [];
+    if (types.includes(FeedEventType.DELEGATION)) {
+      branches.push(sql`(${feedEvent.type} = 'DELEGATION'
+        AND (${feedEvent.txHash}, ${feedEvent.logIndex}) IN (
+          SELECT d.transaction_hash, d.log_index FROM delegations d
+          WHERE LOWER(d.delegator_account_id) = ${addr}
             OR LOWER(d.delegate_account_id) = ${addr}
             OR LOWER(d.previous_delegate) = ${addr}
-          )
-      ))
-      OR (${feedEvent.type} = 'TRANSFER' AND EXISTS (
-        SELECT 1 FROM transfers t
-        WHERE t.transaction_hash = ${feedEvent.txHash}
-          AND t.log_index = ${feedEvent.logIndex}
-          AND (
-            LOWER(t.from_account_id) = ${addr}
+      ))`);
+    }
+    if (types.includes(FeedEventType.TRANSFER)) {
+      branches.push(sql`(${feedEvent.type} = 'TRANSFER'
+        AND (${feedEvent.txHash}, ${feedEvent.logIndex}) IN (
+          SELECT t.transaction_hash, t.log_index FROM transfers t
+          WHERE LOWER(t.from_account_id) = ${addr}
             OR LOWER(t.to_account_id) = ${addr}
-          )
-      ))
-      OR (${feedEvent.type} = 'VOTE' AND EXISTS (
-        SELECT 1 FROM votes_onchain v
-        WHERE v.tx_hash = ${feedEvent.txHash}
-          AND v.log_index = ${feedEvent.logIndex}
-          AND LOWER(v.voter_account_id) = ${addr}
-      ))
-      OR (${feedEvent.type} = 'PROPOSAL' AND EXISTS (
-        SELECT 1 FROM proposals_onchain p
-        WHERE p.tx_hash = ${feedEvent.txHash}
-          AND LOWER(p.proposer_account_id) = ${addr}
-      ))
-      OR (${feedEvent.type} = 'PROPOSAL_EXTENDED'
+      ))`);
+    }
+    if (types.includes(FeedEventType.VOTE)) {
+      branches.push(sql`(${feedEvent.type} = 'VOTE'
+        AND (${feedEvent.txHash}, ${feedEvent.logIndex}) IN (
+          SELECT v.tx_hash, v.log_index FROM votes_onchain v
+          WHERE LOWER(v.voter_account_id) = ${addr}
+      ))`);
+    }
+    if (types.includes(FeedEventType.PROPOSAL)) {
+      branches.push(sql`(${feedEvent.type} = 'PROPOSAL'
+        AND ${feedEvent.txHash} IN (
+          SELECT p.tx_hash FROM proposals_onchain p
+          WHERE LOWER(p.proposer_account_id) = ${addr}
+      ))`);
+    }
+    if (types.includes(FeedEventType.PROPOSAL_EXTENDED)) {
+      branches.push(sql`(${feedEvent.type} = 'PROPOSAL_EXTENDED'
         AND ${feedEvent.proposalId} IS NOT NULL
-        AND EXISTS (
-          SELECT 1 FROM proposals_onchain p
-          WHERE p.id = ${feedEvent.proposalId}
-            AND LOWER(p.proposer_account_id) = ${addr}
-      ))
-    )`;
+        AND ${feedEvent.proposalId} IN (
+          SELECT p.id FROM proposals_onchain p
+          WHERE LOWER(p.proposer_account_id) = ${addr}
+      ))`);
+    }
+
+    return branches.length > 0
+      ? sql`(${sql.join(branches, sql.raw(" OR "))})`
+      : undefined;
   }
 
   private buildRelevanceFilter(
-    types: FeedEventType[] | undefined,
+    selectedTypes: FeedEventType[],
     valueThresholds: Partial<Record<FeedEventType, bigint>>,
   ): SQL | undefined {
     const conditions: SQL[] = [];
-    const selectedTypes =
-      types && types.length > 0
-        ? types
-        : (Object.keys(valueThresholds) as FeedEventType[]);
 
     for (const eventType of selectedTypes) {
       const threshold = valueThresholds[eventType];

--- a/apps/api/src/repositories/feed/index.ts
+++ b/apps/api/src/repositories/feed/index.ts
@@ -11,6 +11,7 @@ import {
   sql,
 } from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
+import { getAddress } from "viem";
 import { z } from "zod";
 
 import {
@@ -88,8 +89,13 @@ export class FeedRepository {
 
     const orderByColumn =
       orderBy === "timestamp" ? feedEvent.timestamp : feedEvent.value;
-    const orderByFn =
-      orderDirection === "asc" ? asc(orderByColumn) : desc(orderByColumn);
+    // With an address filter the qualifying rows are usually far fewer than
+    // the limit, and walking the ordered index until enough matches
+    // accumulate degenerates into a scan of the whole index (15s on UNI).
+    // Sorting by an expression hides the index from the planner, so it
+    // filters first and sorts the small result instead.
+    const sortKey = address ? sql`${orderByColumn} + 0` : orderByColumn;
+    const orderByFn = orderDirection === "asc" ? asc(sortKey) : desc(sortKey);
 
     const [rows, totalCount] = await Promise.all([
       this.db.query.feedEvent.findMany({
@@ -439,19 +445,24 @@ export class FeedRepository {
 
   // feed_event has no account column, so addresses are matched in the source
   // table each event type is derived from, keyed by (tx_hash, log_index).
-  // Lowercased on both sides because source tables may store checksummed
-  // addresses. The subqueries are deliberately uncorrelated: Postgres runs
-  // each one once and hashes the result, instead of probing the source table
-  // for every feed_event row — correlated EXISTS here timed out on large
-  // DAOs. Only the branches for the requested event types are built, so a
-  // type-filtered request never scans the other source tables. feed_event
-  // columns use Drizzle refs so they follow whatever alias the query builder
-  // assigns (see the proposerVotingPower note above).
+  // The subqueries are deliberately uncorrelated: Postgres runs each one once
+  // and hashes the result, instead of probing the source table for every
+  // feed_event row — correlated EXISTS here timed out on large DAOs. Account
+  // columns are compared by plain equality against both address forms the
+  // indexer can write (viem-checksummed or lowercase) rather than
+  // LOWER(column): a LOWER() comparison cannot use the account indexes and
+  // forced a 380k-cost seq scan + per-row rescan of transfers on UNI, where
+  // the indexed form is a ~4k-cost BitmapOr. Only the branches for the
+  // requested event types are built, so a type-filtered request never scans
+  // the other source tables. feed_event columns use Drizzle refs so they
+  // follow whatever alias the query builder assigns (see the
+  // proposerVotingPower note above).
   private buildAddressFilter(
     address: string,
     selectedTypes: FeedEventType[],
   ): SQL | undefined {
-    const addr = address.toLowerCase();
+    const lower = address.toLowerCase();
+    const checksummed = getAddress(lower);
     const types =
       selectedTypes.length > 0
         ? selectedTypes
@@ -462,31 +473,31 @@ export class FeedRepository {
       branches.push(sql`(${feedEvent.type} = 'DELEGATION'
         AND (${feedEvent.txHash}, ${feedEvent.logIndex}) IN (
           SELECT d.transaction_hash, d.log_index FROM delegations d
-          WHERE LOWER(d.delegator_account_id) = ${addr}
-            OR LOWER(d.delegate_account_id) = ${addr}
-            OR LOWER(d.previous_delegate) = ${addr}
+          WHERE d.delegator_account_id IN (${lower}, ${checksummed})
+            OR d.delegate_account_id IN (${lower}, ${checksummed})
+            OR d.previous_delegate IN (${lower}, ${checksummed})
       ))`);
     }
     if (types.includes(FeedEventType.TRANSFER)) {
       branches.push(sql`(${feedEvent.type} = 'TRANSFER'
         AND (${feedEvent.txHash}, ${feedEvent.logIndex}) IN (
           SELECT t.transaction_hash, t.log_index FROM transfers t
-          WHERE LOWER(t.from_account_id) = ${addr}
-            OR LOWER(t.to_account_id) = ${addr}
+          WHERE t.from_account_id IN (${lower}, ${checksummed})
+            OR t.to_account_id IN (${lower}, ${checksummed})
       ))`);
     }
     if (types.includes(FeedEventType.VOTE)) {
       branches.push(sql`(${feedEvent.type} = 'VOTE'
         AND (${feedEvent.txHash}, ${feedEvent.logIndex}) IN (
           SELECT v.tx_hash, v.log_index FROM votes_onchain v
-          WHERE LOWER(v.voter_account_id) = ${addr}
+          WHERE v.voter_account_id IN (${lower}, ${checksummed})
       ))`);
     }
     if (types.includes(FeedEventType.PROPOSAL)) {
       branches.push(sql`(${feedEvent.type} = 'PROPOSAL'
         AND ${feedEvent.txHash} IN (
           SELECT p.tx_hash FROM proposals_onchain p
-          WHERE LOWER(p.proposer_account_id) = ${addr}
+          WHERE p.proposer_account_id IN (${lower}, ${checksummed})
       ))`);
     }
     if (types.includes(FeedEventType.PROPOSAL_EXTENDED)) {
@@ -494,7 +505,7 @@ export class FeedRepository {
         AND ${feedEvent.proposalId} IS NOT NULL
         AND ${feedEvent.proposalId} IN (
           SELECT p.id FROM proposals_onchain p
-          WHERE LOWER(p.proposer_account_id) = ${addr}
+          WHERE p.proposer_account_id IN (${lower}, ${checksummed})
       ))`);
     }
 

--- a/apps/api/src/repositories/votes/onchainVotes.ts
+++ b/apps/api/src/repositories/votes/onchainVotes.ts
@@ -40,6 +40,9 @@ export class VotesRepository {
         : undefined,
       req.toDate ? lte(votesOnchain.timestamp, BigInt(req.toDate)) : undefined,
       req.support ? eq(votesOnchain.support, req.support) : undefined,
+      req.voterAddressIn?.length
+        ? inArray(votesOnchain.voterAccountId, req.voterAddressIn)
+        : undefined,
     );
 
     const [items, totalCount] = await Promise.all([

--- a/packages/anticapture-client/src/configure-upstream-client.ts
+++ b/packages/anticapture-client/src/configure-upstream-client.ts
@@ -15,6 +15,11 @@ export function configureUpstreamClient(): void {
 
   setConfig({
     baseURL,
+    // Repeat array params (`type=VOTE&type=PROPOSAL`) instead of axios's
+    // default bracket form (`type[]=VOTE`), which the API does not parse —
+    // bracketed arrays were silently dropped, ignoring filters like
+    // `voterAddressIn` and `type`.
+    paramsSerializer: { indexes: null },
     headers: {
       "x-client-source": "anticapture-mcp",
       ...(useSharedKey ? { Authorization: `Bearer ${apiKey}` } : {}),


### PR DESCRIPTION
## Context

Reported by the Uniswap Foundation via the MCP: vote-by-voter filtering was ignored on `votes`, and `feed/events` returned 5xx. Investigation found three distinct bugs, all reproduced against production.

## Fixes

1. **`GET /{dao}/votes` ignored `voterAddressIn`** — the handler accepted the param in its schema but never passed it to the query, silently returning unfiltered votes. Reproduced live: filtering by one voter returned other voters. The filter is now applied (`inArray` on `voter_account_id`), matching the by-proposal endpoint that already worked.

2. **`feed/events` 504 on address-filtered queries** — `buildAddressFilter` ran a correlated `EXISTS` probe against the source tables for every `feed_event` row, which blew past the 15s upstream timeout on large DAOs (reproduced on UNI: `?address=...` → HTTP 504 in 15.2s). The filter now uses uncorrelated `IN` subqueries (one scan per source table, hashed by Postgres) and only builds the branches for the requested event types, so a `type=VOTE` request never touches the transfers table.

3. **MCP dropped every array query param** — the MCP's upstream axios client used the default serializer, emitting `type[]=VOTE` / `voterAddressIn[]=0x...`, which the API does not parse. Verified against production: `type[]=VOTE` returned TRANSFER events. The client now sends repeated params (`type=VOTE&type=PROPOSAL`), confirmed parsed correctly by the production API.

Also: address-list query params (`voterAddressIn`, `addresses`, `delegateAddressIn`, ...) now accept the comma-delimited form their OpenAPI descriptions already promised (previously a 400).

## Verification

- Full API suite: 1078/1078 passing, including new tests for the `/votes` filter (single, repeated, and comma forms), comma splitting in the shared mapper, and address+type feed filtering.
- Typecheck and lint clean on `@anticapture/api` and `@anticapture/client`.
- Axios serializer behavior verified directly (bracketed vs repeated output).
- After deploy, re-check the prod repro: `GET /uni/feed/events?address=0x8962...&limit=100` (was 504) and `GET /uni/votes?voterAddressIn=0x8962...` (was unfiltered).

No OpenAPI schema changes, so no client regen needed. Changesets included (3× api patch, 1× client patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)