### PR TITLE
fix: aave stakeholders timeouts and missing address column

### DIFF
--- a/.changeset/aave-delegates-address-column.md
+++ b/.changeset/aave-delegates-address-column.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Show the address column again on the Aave delegates table at desktop widths.

--- a/.changeset/aave-stakeholders-timeout.md
+++ b/.changeset/aave-stakeholders-timeout.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/api": patch
+---
+
+Fix the Aave stakeholders page timing out by scoping the voting-power and balance listing aggregations to the requested page.

--- a/apps/api/src/repositories/account-balance/aave.ts
+++ b/apps/api/src/repositories/account-balance/aave.ts
@@ -113,49 +113,121 @@ export class AAVEAccountBalanceRepository {
       amountfilter,
     );
 
-    const variations = this.queryFragments.variationCTE(
-      variationFromTimestamp,
-      variationToTimestamp,
-      filter,
-    );
-
-    const [totalCount] = await this.db
-      .select({
-        count: sql<number>`COUNT(DISTINCT ${variations.accountId})`.as("count"),
-      })
-      .from(variations);
-
-    const aggregated = this.db
-      .select({
-        accountId: variations.accountId,
-        delegate: sql<string>`MAX(${variations.delegate})`.as("delegate"),
-        currentBalance: sql<bigint>`SUM(${variations.currentBalance})`.as(
-          "current_balance",
-        ),
-        absoluteChange:
-          sql<string>`MAX(${variations.fromChange}::numeric) + MAX(${variations.toChange}::numeric)`.as(
-            "absolute_change",
-          ),
-      })
-      .from(variations)
-      .groupBy(variations.accountId)
-      .as("aggregated");
-
     const orderDirectionFn = orderDirection === "desc" ? desc : asc;
 
-    const orderByCriteria =
-      orderBy === "balance"
-        ? aggregated.currentBalance
-        : orderBy === "signedVariation"
-          ? sql`${aggregated.absoluteChange}::numeric`
-          : sql`ABS(${aggregated.absoluteChange}::numeric)`;
+    // Counting distinct accounts does not need the transfer aggregation the
+    // old variation CTE dragged in: the per-account transfer sums never add
+    // or remove accounts.
+    const countQuery = this.db
+      .select({
+        count: sql<number>`COUNT(DISTINCT ${accountBalance.accountId})`.as(
+          "count",
+        ),
+      })
+      .from(accountBalance)
+      .where(filter);
 
-    const result = await this.db
-      .select()
-      .from(aggregated)
-      .orderBy(orderDirectionFn(orderByCriteria))
-      .offset(skip)
-      .limit(limit);
+    // Aave holds hundreds of thousands of balances, so aggregating every
+    // transfer in the window for every account on every request times out
+    // the gateway. Group balances per account first; join the windowed
+    // transfer sums only when the ordering needs them, and otherwise compute
+    // them afterwards for just the returned page.
+    const aggregatedBalances = this.db
+      .select({
+        accountId: accountBalance.accountId,
+        delegate: sql<string>`MAX(${accountBalance.delegate})`.as("delegate"),
+        currentBalance: sql<bigint>`SUM(${accountBalance.balance})`.as(
+          "current_balance",
+        ),
+      })
+      .from(accountBalance)
+      .where(filter)
+      .groupBy(accountBalance.accountId)
+      .as("aggregated");
+
+    if (orderBy === "balance") {
+      const [page, [totalCount]] = await Promise.all([
+        this.db
+          .select()
+          .from(aggregatedBalances)
+          .orderBy(
+            orderDirectionFn(aggregatedBalances.currentBalance),
+            asc(aggregatedBalances.accountId),
+          )
+          .offset(skip)
+          .limit(limit),
+        countQuery,
+      ]);
+
+      const changes = await this.getTransferChangesByAccountIds(
+        page.map((row) => row.accountId),
+        variationFromTimestamp,
+        variationToTimestamp,
+      );
+
+      return {
+        items: page.map(({ accountId, delegate, currentBalance }) => {
+          const absoluteChange = changes.get(accountId) ?? 0n;
+          return {
+            accountId: accountId,
+            tokenId: getAddress(accountId),
+            delegate: getAddress(delegate as Address),
+            previousBalance: BigInt(currentBalance) - absoluteChange,
+            currentBalance: currentBalance,
+            absoluteChange: absoluteChange,
+            percentageChange: calculatePercentage(
+              currentBalance,
+              absoluteChange,
+            ),
+          };
+        }),
+        totalCount: Number(totalCount?.count ?? 0),
+      };
+    }
+
+    // Variation orderings need the windowed transfer sums up front, but the
+    // per-account sums are joined once per account instead of once per
+    // balance row like the old variation CTE did.
+    const transfersFrom = this.transfersFromSubquery(
+      variationFromTimestamp,
+      variationToTimestamp,
+    );
+    const transfersTo = this.transfersToSubquery(
+      variationFromTimestamp,
+      variationToTimestamp,
+    );
+
+    const absoluteChangeSql = sql<string>`COALESCE(${transfersFrom.fromAmount}, 0) + COALESCE(${transfersTo.toAmount}, 0)`;
+    const orderByCriteria =
+      orderBy === "signedVariation"
+        ? sql`${absoluteChangeSql}::numeric`
+        : sql`ABS(${absoluteChangeSql}::numeric)`;
+
+    const [result, [totalCount]] = await Promise.all([
+      this.db
+        .select({
+          accountId: aggregatedBalances.accountId,
+          delegate: aggregatedBalances.delegate,
+          currentBalance: aggregatedBalances.currentBalance,
+          absoluteChange: absoluteChangeSql.as("absolute_change"),
+        })
+        .from(aggregatedBalances)
+        .leftJoin(
+          transfersFrom,
+          eq(aggregatedBalances.accountId, transfersFrom.accountId),
+        )
+        .leftJoin(
+          transfersTo,
+          eq(aggregatedBalances.accountId, transfersTo.accountId),
+        )
+        .orderBy(
+          orderDirectionFn(orderByCriteria),
+          asc(aggregatedBalances.accountId),
+        )
+        .offset(skip)
+        .limit(limit),
+      countQuery,
+    ]);
 
     return {
       items: result.map(
@@ -171,6 +243,118 @@ export class AAVEAccountBalanceRepository {
       ),
       totalCount: Number(totalCount?.count ?? 0),
     };
+  }
+
+  /**
+   * Net transfer change (incoming minus outgoing) per account inside the
+   * window, computed only for the given accounts via the indexed
+   * from/to account columns.
+   */
+  private async getTransferChangesByAccountIds(
+    accountIds: Address[],
+    fromTimestamp: number | undefined,
+    toTimestamp: number | undefined,
+  ): Promise<Map<Address, bigint>> {
+    const changes = new Map<Address, bigint>();
+    if (!accountIds.length) return changes;
+
+    const timestampCriteria = (column: typeof transfer.timestamp) =>
+      and(
+        fromTimestamp ? gte(column, BigInt(fromTimestamp)) : undefined,
+        toTimestamp ? lte(column, BigInt(toTimestamp)) : undefined,
+      );
+
+    const [outgoing, incoming] = await Promise.all([
+      this.db
+        .select({
+          accountId: transfer.fromAccountId,
+          amount: sql<string>`SUM(${transfer.amount})`.as("from_amount"),
+        })
+        .from(transfer)
+        .where(
+          and(
+            inArray(transfer.fromAccountId, accountIds),
+            timestampCriteria(transfer.timestamp),
+          ),
+        )
+        .groupBy(transfer.fromAccountId),
+      this.db
+        .select({
+          accountId: transfer.toAccountId,
+          amount: sql<string>`SUM(${transfer.amount})`.as("to_amount"),
+        })
+        .from(transfer)
+        .where(
+          and(
+            inArray(transfer.toAccountId, accountIds),
+            timestampCriteria(transfer.timestamp),
+          ),
+        )
+        .groupBy(transfer.toAccountId),
+    ]);
+
+    for (const row of outgoing) {
+      changes.set(
+        row.accountId,
+        (changes.get(row.accountId) ?? 0n) - BigInt(row.amount),
+      );
+    }
+    for (const row of incoming) {
+      changes.set(
+        row.accountId,
+        (changes.get(row.accountId) ?? 0n) + BigInt(row.amount),
+      );
+    }
+
+    return changes;
+  }
+
+  private transfersFromSubquery(
+    fromTimestamp: number | undefined,
+    toTimestamp: number | undefined,
+  ) {
+    return this.db
+      .select({
+        accountId: transfer.fromAccountId,
+        fromAmount: sql<string>`-SUM(${transfer.amount})`.as("from_amount"),
+      })
+      .from(transfer)
+      .where(
+        and(
+          fromTimestamp
+            ? gte(transfer.timestamp, BigInt(fromTimestamp))
+            : undefined,
+          toTimestamp
+            ? lte(transfer.timestamp, BigInt(toTimestamp))
+            : undefined,
+        ),
+      )
+      .groupBy(transfer.fromAccountId)
+      .as("transfers_from");
+  }
+
+  private transfersToSubquery(
+    fromTimestamp: number | undefined,
+    toTimestamp: number | undefined,
+  ) {
+    return this.db
+      .select({
+        accountId: transfer.toAccountId,
+        toAmount: sql<string>`SUM(${transfer.amount})`.as("to_amount"),
+      })
+      .from(transfer)
+      .where(
+        and(
+          fromTimestamp
+            ? gte(transfer.timestamp, BigInt(fromTimestamp))
+            : undefined,
+          toTimestamp
+            ? lte(transfer.timestamp, BigInt(toTimestamp))
+            : undefined,
+        ),
+      )
+      .groupBy(transfer.toAccountId)
+      .as("transfers_to");
   }
 
   async getAccountBalanceWithVariation(

--- a/apps/api/src/repositories/voting-power/aave.ts
+++ b/apps/api/src/repositories/voting-power/aave.ts
@@ -96,55 +96,125 @@ export class AAVEVotingPowerRepository {
     fromDate?: number,
     toDate?: number,
   ): Promise<{ items: DBAccountPowerWithVariation[]; totalCount: number }> {
-    const balanceSubquery = this.db
-      .select({
-        accountId: accountBalance.accountId,
-        totalBalance: sql<string>`SUM(${accountBalance.balance})`.as(
-          "total_balance",
-        ),
-      })
-      .from(accountBalance)
-      .groupBy(accountBalance.accountId)
-      .as("balance");
+    const allAccountIds = this.allAccountIdsUnion();
+    const balanceSubquery = this.balanceSumSubquery();
+    const variationSubquery = this.variationSumSubquery(fromDate, toDate);
 
-    const allAccountIds = this.db
-      .selectDistinct({ accountId: accountPower.accountId })
-      .from(accountPower)
-      .union(
-        this.db
-          .selectDistinct({ accountId: accountBalance.accountId })
-          .from(accountBalance),
-      )
-      .as("all_accounts");
-
-    const variationSubquery = this.db
-      .select({
-        accountId: votingPowerHistory.accountId,
-        absoluteChange: sql<bigint>`SUM(${votingPowerHistory.delta})`.as(
-          "absolute_change",
-        ),
-      })
-      .from(votingPowerHistory)
-      .where(
-        and(
-          fromDate
-            ? gte(votingPowerHistory.timestamp, BigInt(fromDate))
-            : undefined,
-          toDate
-            ? lte(votingPowerHistory.timestamp, BigInt(toDate))
-            : undefined,
-        ),
-      )
-      .groupBy(votingPowerHistory.accountId)
-      .as("variation");
-
-    const combinedPowerSql = sql<bigint>`(COALESCE(${accountPower.votingPower}, 0) + COALESCE(${balanceSubquery.totalBalance}, 0))`;
     // Delegated voting power on its own, i.e. the combined total minus the
     // account's own balance. The amount filter targets this, matching both the
     // `votingPower` ordering below and what consumers render as delegation
     // received: filtering the combined total would let a large self balance
     // alone satisfy a minimum, or push a delegated account past a maximum.
     const delegatedPowerSql = sql<bigint>`COALESCE(${accountPower.votingPower}, 0)`;
+    const filter = this.filterToSql(
+      addresses,
+      amountFilter,
+      delegatedPowerSql,
+      sql`${allAccountIds.accountId}`,
+    );
+
+    // Aave has hundreds of thousands of accounts, so summing balances and
+    // voting-power deltas for every account on every request times out the
+    // gateway. Pick the page of accounts first, joining a full-table
+    // aggregation only when the requested ordering depends on it, and compute
+    // the remaining per-account values afterwards for just that page.
+    const needsBalanceAggregation =
+      orderBy === "total" || orderBy === "balance";
+    const needsVariationAggregation =
+      orderBy === "variation" || orderBy === "signedVariation";
+
+    const orderKeySql =
+      orderBy === "variation"
+        ? sql`ABS(COALESCE(${variationSubquery.absoluteChange}, 0))`
+        : orderBy === "signedVariation"
+          ? sql`COALESCE(${variationSubquery.absoluteChange}, 0)`
+          : orderBy === "total"
+            ? sql`(COALESCE(${accountPower.votingPower}, 0) + COALESCE(${balanceSubquery.totalBalance}, 0))`
+            : orderBy === "votingPower"
+              ? delegatedPowerSql
+              : orderBy === "balance"
+                ? sql`COALESCE(${balanceSubquery.totalBalance}, 0)`
+                : sql`COALESCE(${accountPower.delegationsCount}, 0)`;
+
+    const orderDirectionFn = orderDirection === "desc" ? desc : asc;
+
+    let pageQuery = this.db
+      .select({ accountId: allAccountIds.accountId })
+      .from(allAccountIds)
+      .leftJoin(
+        accountPower,
+        eq(allAccountIds.accountId, accountPower.accountId),
+      )
+      .$dynamic();
+    if (needsBalanceAggregation) {
+      pageQuery = pageQuery.leftJoin(
+        balanceSubquery,
+        eq(allAccountIds.accountId, balanceSubquery.accountId),
+      );
+    }
+    if (needsVariationAggregation) {
+      pageQuery = pageQuery.leftJoin(
+        variationSubquery,
+        eq(allAccountIds.accountId, variationSubquery.accountId),
+      );
+    }
+
+    const [page, [totalCount]] = await Promise.all([
+      pageQuery
+        .where(filter)
+        .orderBy(orderDirectionFn(orderKeySql), asc(allAccountIds.accountId))
+        .offset(skip)
+        .limit(limit),
+      this.db
+        .select({
+          count: sql<number>`COUNT(*)`.as("count"),
+        })
+        .from(allAccountIds)
+        .leftJoin(
+          accountPower,
+          eq(allAccountIds.accountId, accountPower.accountId),
+        )
+        .where(filter),
+    ]);
+
+    const pageAccountIds = page.map((row) => row.accountId);
+    const rows = pageAccountIds.length
+      ? await this.getVotingPowerRowsByAccountIds(
+          pageAccountIds,
+          fromDate,
+          toDate,
+        )
+      : [];
+    const rowsByAccountId = new Map(rows.map((row) => [row.accountId, row]));
+
+    return {
+      items: pageAccountIds.flatMap((accountId) => {
+        const row = rowsByAccountId.get(accountId);
+        return row ? [row] : [];
+      }),
+      totalCount: Number(totalCount?.count ?? 0),
+    };
+  }
+
+  /**
+   * Full voting-power rows (combined power, balance, variation) for a known
+   * set of accounts. All aggregations are scoped to those accounts, so this
+   * stays cheap regardless of table size.
+   */
+  private async getVotingPowerRowsByAccountIds(
+    accountIds: Address[],
+    fromDate?: number,
+    toDate?: number,
+  ): Promise<DBAccountPowerWithVariation[]> {
+    const pageAccounts = this.allAccountIdsUnion(accountIds);
+    const balanceSubquery = this.balanceSumSubquery(accountIds);
+    const variationSubquery = this.variationSumSubquery(
+      fromDate,
+      toDate,
+      accountIds,
+    );
+
+    const combinedPowerSql = sql<bigint>`(COALESCE(${accountPower.votingPower}, 0) + COALESCE(${balanceSubquery.totalBalance}, 0))`;
     const absoluteChangeSql = sql<bigint>`COALESCE(${variationSubquery.absoluteChange}, 0)`;
     const percentageChangeSql = sql<string>`
     CASE
@@ -155,26 +225,9 @@ export class AAVEVotingPowerRepository {
     END
   `;
 
-    const orderDirectionFn = orderDirection === "desc" ? desc : asc;
-    const orderSql = orderDirectionFn(
-      orderBy === "variation"
-        ? sql`ABS(COALESCE(${variationSubquery.absoluteChange}, 0))`
-        : orderBy === "signedVariation"
-          ? orderDirectionFn(
-              sql`COALESCE(${variationSubquery.absoluteChange}, 0)`,
-            )
-          : orderBy === "total"
-            ? combinedPowerSql
-            : orderBy === "votingPower"
-              ? delegatedPowerSql
-              : orderBy === "balance"
-                ? sql`COALESCE(${balanceSubquery.totalBalance}, 0)`
-                : sql`COALESCE(${accountPower.delegationsCount}, 0)`,
-    );
-
-    const items = await this.db
+    const rows = await this.db
       .select({
-        accountId: allAccountIds.accountId,
+        accountId: pageAccounts.accountId,
         daoId: accountPower.daoId,
         votingPower: combinedPowerSql,
         votesCount: accountPower.votesCount,
@@ -185,65 +238,95 @@ export class AAVEVotingPowerRepository {
         percentageChange: percentageChangeSql,
         balance: balanceSubquery.totalBalance,
       })
-      .from(allAccountIds)
+      .from(pageAccounts)
       .leftJoin(
         accountPower,
-        eq(allAccountIds.accountId, accountPower.accountId),
+        eq(pageAccounts.accountId, accountPower.accountId),
       )
       .leftJoin(
         balanceSubquery,
-        eq(allAccountIds.accountId, balanceSubquery.accountId),
+        eq(pageAccounts.accountId, balanceSubquery.accountId),
       )
       .leftJoin(
         variationSubquery,
-        eq(allAccountIds.accountId, variationSubquery.accountId),
-      )
-      .where(
-        this.filterToSql(
-          addresses,
-          amountFilter,
-          delegatedPowerSql,
-          sql`${allAccountIds.accountId}`,
-        ),
-      )
-      .orderBy(orderSql)
-      .offset(skip)
-      .limit(limit);
-
-    const [totalCount] = await this.db
-      .select({
-        count: sql<number>`COUNT(*)`.as("count"),
-      })
-      .from(allAccountIds)
-      .leftJoin(
-        accountPower,
-        eq(allAccountIds.accountId, accountPower.accountId),
-      )
-      .leftJoin(
-        balanceSubquery,
-        eq(allAccountIds.accountId, balanceSubquery.accountId),
-      )
-      .where(
-        this.filterToSql(
-          addresses,
-          amountFilter,
-          delegatedPowerSql,
-          sql`${allAccountIds.accountId}`,
-        ),
+        eq(pageAccounts.accountId, variationSubquery.accountId),
       );
 
-    return {
-      items: items.map((row) => ({
-        ...row,
-        daoId: row.daoId ?? "",
-        votesCount: row.votesCount ?? 0,
-        proposalsCount: row.proposalsCount ?? 0,
-        delegationsCount: row.delegationsCount ?? 0,
-        lastVoteTimestamp: row.lastVoteTimestamp ?? 0n,
-        balance: row.balance ? BigInt(row.balance) : undefined,
-      })),
-      totalCount: Number(totalCount?.count ?? 0),
-    };
+    return rows.map((row) => ({
+      ...row,
+      daoId: row.daoId ?? "",
+      votesCount: row.votesCount ?? 0,
+      proposalsCount: row.proposalsCount ?? 0,
+      delegationsCount: row.delegationsCount ?? 0,
+      lastVoteTimestamp: row.lastVoteTimestamp ?? 0n,
+      balance: row.balance ? BigInt(row.balance) : undefined,
+    }));
+  }
+
+  private allAccountIdsUnion(accountIds?: Address[]) {
+    return this.db
+      .selectDistinct({ accountId: accountPower.accountId })
+      .from(accountPower)
+      .where(
+        accountIds ? inArray(accountPower.accountId, accountIds) : undefined,
+      )
+      .union(
+        this.db
+          .selectDistinct({ accountId: accountBalance.accountId })
+          .from(accountBalance)
+          .where(
+            accountIds
+              ? inArray(accountBalance.accountId, accountIds)
+              : undefined,
+          ),
+      )
+      .as("all_accounts");
+  }
+
+  private balanceSumSubquery(accountIds?: Address[]) {
+    return this.db
+      .select({
+        accountId: accountBalance.accountId,
+        totalBalance: sql<string>`SUM(${accountBalance.balance})`.as(
+          "total_balance",
+        ),
+      })
+      .from(accountBalance)
+      .where(
+        accountIds ? inArray(accountBalance.accountId, accountIds) : undefined,
+      )
+      .groupBy(accountBalance.accountId)
+      .as("balance");
+  }
+
+  private variationSumSubquery(
+    fromDate?: number,
+    toDate?: number,
+    accountIds?: Address[],
+  ) {
+    return this.db
+      .select({
+        accountId: votingPowerHistory.accountId,
+        absoluteChange: sql<bigint>`SUM(${votingPowerHistory.delta})`.as(
+          "absolute_change",
+        ),
+      })
+      .from(votingPowerHistory)
+      .where(
+        and(
+          accountIds
+            ? inArray(votingPowerHistory.accountId, accountIds)
+            : undefined,
+          fromDate
+            ? gte(votingPowerHistory.timestamp, BigInt(fromDate))
+            : undefined,
+          toDate
+            ? lte(votingPowerHistory.timestamp, BigInt(toDate))
+            : undefined,
+        ),
+      )
+      .groupBy(votingPowerHistory.accountId)
+      .as("variation");
   }
 
   async getVotingPowersByAccountId(

--- a/apps/dashboard/app/aave/stakeholders/DelegationTable.tsx
+++ b/apps/dashboard/app/aave/stakeholders/DelegationTable.tsx
@@ -219,14 +219,16 @@ export function DelegationTable({ days }: { days: TimeInterval }) {
         }
 
         return (
-          <div className="group flex w-full items-center">
-            <EnsAvatar
-              address={address as Address}
-              size="sm"
-              variant="rounded"
-              isDashed={true}
-              nameClassName="[tr:hover_&]:border-primary"
-            />
+          <div className="group flex w-40 items-center lg:w-full">
+            <div className="min-w-0 flex-1">
+              <EnsAvatar
+                address={address as Address}
+                size="sm"
+                variant="rounded"
+                isDashed={true}
+                nameClassName="[tr:hover_&]:border-primary"
+              />
+            </div>
             {!isMobile && (
               <div className="flex items-center opacity-0 transition-opacity [tr:hover_&]:opacity-100">
                 <CopyAndPasteButton
@@ -262,9 +264,6 @@ export function DelegationTable({ days }: { days: TimeInterval }) {
           />
         </div>
       ),
-      meta: {
-        columnClassName: "w-40",
-      },
     },
     {
       accessorKey: "balance",


### PR DESCRIPTION
## Problem

[DEV-1167](https://app.clickup.com/t/86ak8ht2h): the Aave stakeholders page shows no addresses in production. Two independent causes:

1. **Backend**: `/aave/voting-powers` and `/aave/balances` take 6-15s cold and regularly exceed Gateful's upstream timeout, surfacing as 504 and leaving the table empty (reproduced via the dashboard proxy; ENS/UNI answer in ~0.3s).
2. **Frontend**: even when the data loads, at desktop widths (≥1024px) the delegates table renders avatars with no address text — reproduced on production at 1600px and confirmed in the DOM: the name span is present with the right text but 0px wide.

## Cause

**API** — the Aave-specific repositories aggregate the whole dataset on every request before paginating 20 rows:

- `voting-power/aave.ts` built a UNION of all ~788k account ids, a `SUM(balance)` over the entire `account_balance` table and a `SUM(delta)` over the windowed `voting_power_history`, joined them all, then ordered and took a page. The `COUNT` query repeated the same heavy joins (including one it never used) and ran sequentially after the page query.
- `account-balance/aave.ts` aggregated every transfer in the 90d window for every account even when ordering by balance, and its `COUNT` dragged the same transfer aggregation in for nothing.

**Dashboard** — the Aave-only `DelegationTable` copy dropped the `min-w-0 flex-1` wrapper around `EnsAvatar` and pinned the address column to `w-40` (160px). The hover controls (copy + Details) render with `opacity-0` but still occupy ~140px, so the name span (inside `min-w-0` + `overflow-hidden`) collapses to 0. Below `lg` the controls don't render (`isMobile`), which is why the bug only shows on desktop.

## Fix

- **API**: select the page of accounts first, joining a full-table aggregation only when the requested ordering depends on it, then compute the remaining per-account values for just the returned page through the indexed `account_id` columns. Count queries drop the aggregation joins they never needed and run in parallel with the page query. Also fixes a latent bug (`signedVariation` applied `desc()` twice, producing invalid SQL) and makes pagination stable with an `account_id` tiebreaker.
- **Dashboard**: mirror the shared `Delegates` address cell in the Aave copy — flexible address column, `w-40 lg:w-full` wrapper, and the name claiming the remaining space via `min-w-0 flex-1`.

## Verification

- Reproduced both symptoms beforehand: the 504 on `/aave/balances` plus 6-11s cold latencies, and the 0px-wide name span on production at 1600px.
- Full API suite (1078 tests), typecheck and lint pass; the Aave repository suites run the real SQL against PGlite.
- A throwaway old-vs-new benchmark on a seeded PGlite (75k balances, 15k powers, 120k history rows, 100k transfers) returned identical results for every ordering with the default views dropping 496ms → 199ms (delegates) and 389ms → 107ms (holders); gains should be larger on prod-size data since the old cost grows with table size and the new one is page-scoped.
- The dashboard fix reuses the exact cell structure of the shared `Delegates`/`TokenHolders` tables, verified working on production at 1600px (`nick.eth` renders with a flexible 330px cell on ENS). Dashboard typecheck and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)