### PR TITLE
fix(dashboard): stop retrying failed HTTP requests in React Query

### DIFF
--- a/.changeset/dashboard-query-retry.md
+++ b/.changeset/dashboard-query-retry.md
@@ -1,0 +1,6 @@
+---
+"@anticapture/dashboard": patch
+---
+
+Stop retrying failed HTTP requests in React Query (retry network errors once): each retry against a failing
+route counted toward the gateway circuit breaker, so one page view could take a DAO offline.

--- a/apps/dashboard/shared/providers/GlobalProviders.tsx
+++ b/apps/dashboard/shared/providers/GlobalProviders.tsx
@@ -13,8 +13,13 @@ import { setClientConfig } from "@anticapture/client";
 import { LoginProvider } from "@/shared/services/auth/LoginProvider";
 import { wagmiConfig } from "@/shared/services/wallet/wallet";
 import type { DaoIdEnum } from "@/shared/types/daos";
+import { shouldRetryQuery } from "@/shared/utils/query-retry";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: shouldRetryQuery },
+  },
+});
 
 export const GlobalProviders = ({
   children,

--- a/apps/dashboard/shared/utils/query-retry.test.ts
+++ b/apps/dashboard/shared/utils/query-retry.test.ts
@@ -1,0 +1,22 @@
+import { shouldRetryQuery } from "@/shared/utils/query-retry";
+
+describe("shouldRetryQuery", () => {
+  it("does not retry HTTP errors, whatever the status", () => {
+    expect(shouldRetryQuery(0, { status: 503 })).toBe(false);
+    expect(shouldRetryQuery(0, { status: 404 })).toBe(false);
+    expect(
+      shouldRetryQuery(0, Object.assign(new Error("x"), { status: 500 })),
+    ).toBe(false);
+  });
+
+  it("retries a network error once", () => {
+    const networkError = new TypeError("Failed to fetch");
+    expect(shouldRetryQuery(0, networkError)).toBe(true);
+    expect(shouldRetryQuery(1, networkError)).toBe(false);
+  });
+
+  it("treats unknown error shapes as retryable network errors", () => {
+    expect(shouldRetryQuery(0, undefined)).toBe(true);
+    expect(shouldRetryQuery(0, "boom")).toBe(true);
+  });
+});

--- a/apps/dashboard/shared/utils/query-retry.ts
+++ b/apps/dashboard/shared/utils/query-retry.ts
@@ -1,0 +1,21 @@
+/**
+ * Retry policy for React Query.
+ *
+ * The SDK rejects HTTP failures with an error carrying the response `status`.
+ * Those are deterministic: the gateway or the API already decided, and every
+ * retry against a failing route counts once more toward the gateway circuit
+ * breaker for that DAO (React Query's default is 3 retries, so one page view
+ * of a broken card produced four failures). Only network-level errors, which
+ * have no status, are retried, and only once.
+ */
+export const MAX_NETWORK_RETRIES = 1;
+
+export const isHttpError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  typeof (error as { status?: unknown }).status === "number";
+
+export const shouldRetryQuery = (
+  failureCount: number,
+  error: unknown,
+): boolean => !isHttpError(error) && failureCount < MAX_NETWORK_RETRIES;


### PR DESCRIPTION
## Contexto

Nas quedas de 26-28/08 o breaker do gateful abriu por DAO após 5 falhas consecutivas. O dashboard usa `new QueryClient()` sem configuração, e o padrão do React Query é **3 retries** com backoff. Uma única visita à página de Revenue do ENS (cuja rota `renewal-tenure` respondia 503) gerava 4 falhas em segundos, praticamente suficiente para derrubar o ENS inteiro sozinha.

## Mudança

- `shouldRetryQuery`: não re-tenta erros HTTP (o SDK rejeita com `status`); re-tenta erros de rede uma vez.
- Aplicado como `defaultOptions.queries.retry` no `QueryClient` global.

Relacionado: #2148 (breaker por rota e janela) e #2149 (rotas de terceiros deixam de responder 5xx).

## Verificação

- `jest shared/utils/query-retry.test.ts`: 3 testes passando
- `eslint` nos arquivos alterados: OK
- `tsc --noEmit`: sem erros nos arquivos alterados (o worktree não tem `@anticapture/client` buildado, então o typecheck completo reporta apenas erros pré-existentes desse pacote)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
