### PR TITLE
fix(api): apply lean projection in proposal search and by-id queries

### DIFF
--- a/.changeset/lean-proposal-projection.md
+++ b/.changeset/lean-proposal-projection.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/api": patch
+---
+
+Push the `lean` query param down to SQL for `GET /proposals/search` and `GET /proposals/{id}`, so description/calldatas/values/targets are no longer selected just to be dropped by the mapper. Response shape is unchanged.

--- a/.changeset/mcp-lean-input-schema.md
+++ b/.changeset/mcp-lean-input-schema.md
@@ -1,0 +1,5 @@
+---
+"@anticapture/client": patch
+---
+
+Stop advertising `lean` on the MCP proposal tools. Those tools always call the REST endpoints with `lean=true`, so the parameter was accepted from callers and then silently overridden. It's now omitted from the input schemas (and dropped entirely from the by-id tools, where it was the only param).

--- a/.changeset/mcp-lean-input-schema.md
+++ b/.changeset/mcp-lean-input-schema.md
@@ -2,4 +2,4 @@
 "@anticapture/client": patch
 ---
 
-Stop advertising `lean` on the MCP proposal tools. Those tools always call the REST endpoints with `lean=true`, so the parameter was accepted from callers and then silently overridden. It's now omitted from the input schemas (and dropped entirely from the by-id tools, where it was the only param).
+Make `lean` an honored default on the MCP proposal tools instead of a hardcoded override. The tools used to force `lean: true` while still advertising the param with `default: false`, so a caller asking for the full payload was silently ignored. They now re-declare `lean` with a `true` default (keeping MCP responses small) and pass the caller's value through, so `lean: false` returns the full proposal — calldatas, values, targets and description/body.

--- a/apps/api/src/controllers/proposals/onchainProposals.ts
+++ b/apps/api/src/controllers/proposals/onchainProposals.ts
@@ -117,6 +117,7 @@ export function proposals(
           query,
           skip,
           limit,
+          lean,
         }),
         service.getSearchProposalsCount(query),
       ]);
@@ -173,7 +174,7 @@ export function proposals(
       const { id } = context.req.valid("param");
       const { lean } = context.req.valid("query");
 
-      const proposal = await service.getProposalById(id);
+      const proposal = await service.getProposalById(id, lean);
 
       if (!proposal) {
         return context.json(

--- a/apps/api/src/repositories/drizzle/index.ts
+++ b/apps/api/src/repositories/drizzle/index.ts
@@ -213,19 +213,26 @@ export class DrizzleRepository {
       .offset(skip);
   }
 
-  async getProposalById(proposalId: string): Promise<DBProposal | undefined> {
-    return await this.db.query.proposalsOnchain.findFirst({
-      where: eq(proposalsOnchain.id, proposalId),
-    });
+  async getProposalById(
+    proposalId: string,
+    lean: boolean = false,
+  ): Promise<DBProposal | undefined> {
+    const [proposal] = await this.db
+      .select(this.proposalSelectFields(lean))
+      .from(proposalsOnchain)
+      .where(eq(proposalsOnchain.id, proposalId))
+      .limit(1);
+    return proposal;
   }
 
   async searchProposals(
     query: string,
     skip: number,
     limit: number,
+    lean: boolean = false,
   ): Promise<DBProposal[]> {
     return await this.db
-      .select()
+      .select(this.proposalSelectFields(lean))
       .from(proposalsOnchain)
       .where(this.buildProposalSearchWhere(query))
       .orderBy(desc(proposalsOnchain.timestamp))

--- a/apps/api/src/services/proposals/onchainProposals.ts
+++ b/apps/api/src/services/proposals/onchainProposals.ts
@@ -18,9 +18,13 @@ export interface ProposalsRepository {
     query: string,
     skip: number,
     limit: number,
+    lean?: boolean,
   ): Promise<DBProposal[]>;
   getSearchProposalsCount(query: string): Promise<number>;
-  getProposalById(proposalId: string): Promise<DBProposal | undefined>;
+  getProposalById(
+    proposalId: string,
+    lean?: boolean,
+  ): Promise<DBProposal | undefined>;
 }
 
 export class ProposalsService {
@@ -167,18 +171,25 @@ export class ProposalsService {
     query,
     skip = 0,
     limit = 10,
-  }: Omit<ProposalSearchRequest, "lean">): Promise<DBProposal[]> {
+    lean = false,
+  }: Omit<ProposalSearchRequest, "lean"> & {
+    lean?: boolean;
+  }): Promise<DBProposal[]> {
     const proposals = await this.proposalsRepo.searchProposals(
       query,
       skip,
       limit,
+      lean,
     );
 
     return this.hydrateProposalsStatus(proposals);
   }
 
-  async getProposalById(proposalId: string): Promise<DBProposal | undefined> {
-    const proposal = await this.proposalsRepo.getProposalById(proposalId);
+  async getProposalById(
+    proposalId: string,
+    lean: boolean = false,
+  ): Promise<DBProposal | undefined> {
+    const proposal = await this.proposalsRepo.getProposalById(proposalId, lean);
 
     if (!proposal) {
       return undefined;

--- a/apps/api/src/services/proposals/onchainProposals.unit.test.ts
+++ b/apps/api/src/services/proposals/onchainProposals.unit.test.ts
@@ -86,15 +86,24 @@ function createStubRepo(): ProposalsRepository & {
       return stub.proposals;
     },
     getProposalsCount: async () => stub.count,
-    searchProposals: async (query: string) => {
+    searchProposals: async (
+      query: string,
+      _skip: number,
+      _limit: number,
+      lean?: boolean,
+    ) => {
       stub.lastSearchQueryArg = query;
+      stub.lastLeanArg = lean;
       return stub.proposals;
     },
     getSearchProposalsCount: async (query: string) => {
       stub.lastSearchQueryArg = query;
       return stub.searchCount;
     },
-    getProposalById: async () => stub.byId,
+    getProposalById: async (_proposalId: string, lean?: boolean) => {
+      stub.lastLeanArg = lean;
+      return stub.byId;
+    },
   };
   return stub;
 }
@@ -322,6 +331,14 @@ describe("ProposalsService", () => {
       );
     });
 
+    it("should forward lean to the repository", async () => {
+      repo.byId = createMockProposal();
+
+      await service.getProposalById("1", true);
+
+      expect(repo.lastLeanArg).toBe(true);
+    });
+
     it("should return undefined when not found", async () => {
       const result = await service.getProposalById("999");
 
@@ -342,6 +359,7 @@ describe("ProposalsService", () => {
       });
 
       expect(repo.lastSearchQueryArg).toBe("refresh");
+      expect(repo.lastLeanArg).toBe(false);
       expect(result).toEqual([
         createMockProposal({
           title: "Treasury Refresh",

--- a/packages/anticapture-client/src/create-mcp-server.ts
+++ b/packages/anticapture-client/src/create-mcp-server.ts
@@ -3,11 +3,11 @@
  * entrypoints. McpServer only supports one active transport at a time, so the
  * HTTP server needs a fresh instance per session.
  *
- * This is a curated tool set: proposal-related tools call the regular
- * endpoints with `lean=true` to drop heavy execution-payload fields and keep
- * payloads small for LLM clients. Since that override is unconditional, `lean`
- * is omitted from those tools' input schemas rather than advertised as a knob
- * the caller can set; the REST endpoints remain the way to get full payloads. The generated kubb server (generated/mcp/
+ * This is a curated tool set: proposal-related tools default `lean` to true to
+ * drop heavy execution-payload fields and keep payloads small for LLM clients.
+ * The REST endpoints default it to false, so these tools re-declare the param
+ * with the flipped default; callers that need the full payload (calldatas,
+ * values, targets, description/body) can still pass `lean: false`. The generated kubb server (generated/mcp/
  * server.ts) exposes every endpoint one-to-one and is no longer used; it
  * remains as a reference for the available handlers and schemas.
  */
@@ -207,6 +207,23 @@ const DAO_NO_AAVE = [
   "uni",
 ] as const;
 const DAO_OFFCHAIN = ["comp", "ens", "gtc", "uni"] as const;
+
+/**
+ * `lean`, but defaulting to true — the opposite of the REST default. Keeps MCP
+ * responses small without making the full payload unreachable.
+ */
+const leanParam = (omitted: string) =>
+  z
+    .union([z.boolean(), z.enum(["0", "1", "true", "false"])])
+    .default(true)
+    .describe(
+      `When true, omit ${omitted} to reduce response size. Defaults to true for MCP tools; pass false for the full payload. Accepts true/false/1/0.`,
+    );
+
+const onchainLeanParam = leanParam(
+  "execution-payload fields (calldatas, values, targets) and the proposal description",
+);
+const offchainLeanParam = leanParam("the proposal `body`");
 
 export function createMcpServer(): McpServer {
   const server = new McpServer({
@@ -567,48 +584,52 @@ export function createMcpServer(): McpServer {
   server.registerTool(
     "proposals",
     {
-      title: "Get proposals (lean)",
+      title: "Get proposals",
       description:
-        "Returns a list of proposals without execution-payload fields (calldatas/values/targets) to keep payloads small for LLM clients. Call the REST endpoint /{dao}/proposals with lean=false if you need the full payload.",
+        "Returns a list of proposals. Execution-payload fields (calldatas/values/targets) and descriptions are omitted by default to keep payloads small; pass lean: false for the full payload.",
       outputSchema: { data: proposalsQueryResponseSchema },
       inputSchema: {
         dao: z.enum(DAO_NO_AAVE),
-        params: proposalsQueryParamsSchema.omit({ lean: true }),
+        params: proposalsQueryParamsSchema.extend({
+          lean: onchainLeanParam,
+        }),
       },
     },
-    async ({ dao, params }) =>
-      proposalsHandler({ dao, params: { ...params, lean: true } }),
+    async ({ dao, params }) => proposalsHandler({ dao, params }),
   );
 
   server.registerTool(
     "searchProposals",
     {
-      title: "Search proposals (lean)",
+      title: "Search proposals",
       description:
-        "Returns proposals whose title or identifier partially matches the query, without execution-payload fields (calldatas/values/targets).",
+        "Returns proposals whose title or identifier partially matches the query. Execution-payload fields (calldatas/values/targets) and descriptions are omitted by default; pass lean: false for the full payload.",
       outputSchema: { data: searchProposalsQueryResponseSchema },
       inputSchema: {
         dao: z.enum(DAO_NO_AAVE),
-        params: searchProposalsQueryParamsSchema.omit({ lean: true }),
+        params: searchProposalsQueryParamsSchema.extend({
+          lean: onchainLeanParam,
+        }),
       },
     },
-    async ({ dao, params }) =>
-      searchProposalsHandler({ dao, params: { ...params, lean: true } }),
+    async ({ dao, params }) => searchProposalsHandler({ dao, params }),
   );
 
   server.registerTool(
     "proposal",
     {
-      title: "Get a proposal by ID (lean)",
+      title: "Get a proposal by ID",
       description:
-        "Returns a single proposal by its ID without execution-payload fields (calldatas/values/targets). Call the REST endpoint /{dao}/proposals/{id} with lean=false if you need the full payload.",
+        "Returns a single proposal by its ID. Execution-payload fields (calldatas/values/targets) and the description are omitted by default; pass lean: false for the full payload.",
       outputSchema: { data: proposalQueryResponseSchema },
       inputSchema: {
         dao: z.enum(DAO_NO_AAVE),
         id: z.string(),
+        params: z.object({ lean: onchainLeanParam }).optional(),
       },
     },
-    async ({ dao, id }) => proposalHandler({ dao, id, params: { lean: true } }),
+    async ({ dao, id, params }) =>
+      proposalHandler({ dao, id, params: { lean: true, ...params } }),
   );
 
   server.registerTool(
@@ -926,52 +947,56 @@ export function createMcpServer(): McpServer {
   server.registerTool(
     "offchainProposals",
     {
-      title: "Get offchain proposals (lean)",
+      title: "Get offchain proposals",
       description:
-        "Returns a list of offchain (Snapshot) proposals without the markdown body to keep payloads small for LLM clients. Call the REST endpoint /{dao}/offchain/proposals with lean=false if you need the body.",
+        "Returns a list of offchain (Snapshot) proposals. The markdown body is omitted by default to keep payloads small; pass lean: false to include it.",
       outputSchema: { data: offchainProposalsQueryResponseSchema },
       inputSchema: {
         dao: z.enum(DAO_OFFCHAIN),
-        params: offchainProposalsQueryParamsSchema.omit({ lean: true }),
+        params: offchainProposalsQueryParamsSchema.extend({
+          lean: offchainLeanParam,
+        }),
       },
     },
-    async ({ dao, params }) =>
-      offchainProposalsHandler({ dao, params: { ...params, lean: true } }),
+    async ({ dao, params }) => offchainProposalsHandler({ dao, params }),
   );
 
   server.registerTool(
     "offchainSearchProposals",
     {
-      title: "Search offchain proposals (lean)",
+      title: "Search offchain proposals",
       description:
-        "Returns offchain proposals whose title or identifier partially matches the query, without the markdown body.",
+        "Returns offchain proposals whose title or identifier partially matches the query. The markdown body is omitted by default; pass lean: false to include it.",
       outputSchema: { data: offchainSearchProposalsQueryResponseSchema },
       inputSchema: {
         dao: z.enum(DAO_OFFCHAIN),
-        params: offchainSearchProposalsQueryParamsSchema.omit({ lean: true }),
+        params: offchainSearchProposalsQueryParamsSchema.extend({
+          lean: offchainLeanParam,
+        }),
       },
     },
-    async ({ dao, params }) =>
-      offchainSearchProposalsHandler({
-        dao,
-        params: { ...params, lean: true },
-      }),
+    async ({ dao, params }) => offchainSearchProposalsHandler({ dao, params }),
   );
 
   server.registerTool(
     "offchainProposalById",
     {
-      title: "Get an offchain proposal by ID (lean)",
+      title: "Get an offchain proposal by ID",
       description:
-        "Returns a single offchain (Snapshot) proposal by its ID without the markdown body. Call the REST endpoint /{dao}/offchain/proposals/{id} with lean=false if you need the body.",
+        "Returns a single offchain (Snapshot) proposal by its ID. The markdown body is omitted by default; pass lean: false to include it.",
       outputSchema: { data: offchainProposalByIdQueryResponseSchema },
       inputSchema: {
         dao: z.enum(DAO_OFFCHAIN),
         id: z.string(),
+        params: z.object({ lean: offchainLeanParam }).optional(),
       },
     },
-    async ({ dao, id }) =>
-      offchainProposalByIdHandler({ dao, id, params: { lean: true } }),
+    async ({ dao, id, params }) =>
+      offchainProposalByIdHandler({
+        dao,
+        id,
+        params: { lean: true, ...params },
+      }),
   );
 
   server.registerTool(

--- a/packages/anticapture-client/src/create-mcp-server.ts
+++ b/packages/anticapture-client/src/create-mcp-server.ts
@@ -5,7 +5,9 @@
  *
  * This is a curated tool set: proposal-related tools call the regular
  * endpoints with `lean=true` to drop heavy execution-payload fields and keep
- * payloads small for LLM clients. The generated kubb server (generated/mcp/
+ * payloads small for LLM clients. Since that override is unconditional, `lean`
+ * is omitted from those tools' input schemas rather than advertised as a knob
+ * the caller can set; the REST endpoints remain the way to get full payloads. The generated kubb server (generated/mcp/
  * server.ts) exposes every endpoint one-to-one and is no longer used; it
  * remains as a reference for the available handlers and schemas.
  */
@@ -135,7 +137,6 @@ import {
   historicalVotingPowerQueryResponseSchema,
   lastUpdateQueryParamsSchema,
   lastUpdateQueryResponseSchema,
-  offchainProposalByIdQueryParamsSchema,
   offchainProposalByIdQueryResponseSchema,
   offchainProposalNonVotersQueryParamsSchema,
   offchainProposalNonVotersQueryResponseSchema,
@@ -143,7 +144,6 @@ import {
   offchainProposalsQueryResponseSchema,
   offchainSearchProposalsQueryParamsSchema,
   offchainSearchProposalsQueryResponseSchema,
-  proposalQueryParamsSchema,
   proposalQueryResponseSchema,
   proposalNonVotersQueryParamsSchema,
   proposalNonVotersQueryResponseSchema,
@@ -573,7 +573,7 @@ export function createMcpServer(): McpServer {
       outputSchema: { data: proposalsQueryResponseSchema },
       inputSchema: {
         dao: z.enum(DAO_NO_AAVE),
-        params: proposalsQueryParamsSchema,
+        params: proposalsQueryParamsSchema.omit({ lean: true }),
       },
     },
     async ({ dao, params }) =>
@@ -589,7 +589,7 @@ export function createMcpServer(): McpServer {
       outputSchema: { data: searchProposalsQueryResponseSchema },
       inputSchema: {
         dao: z.enum(DAO_NO_AAVE),
-        params: searchProposalsQueryParamsSchema,
+        params: searchProposalsQueryParamsSchema.omit({ lean: true }),
       },
     },
     async ({ dao, params }) =>
@@ -606,11 +606,9 @@ export function createMcpServer(): McpServer {
       inputSchema: {
         dao: z.enum(DAO_NO_AAVE),
         id: z.string(),
-        params: proposalQueryParamsSchema.optional(),
       },
     },
-    async ({ dao, id, params }) =>
-      proposalHandler({ dao, id, params: { ...params, lean: true } }),
+    async ({ dao, id }) => proposalHandler({ dao, id, params: { lean: true } }),
   );
 
   server.registerTool(
@@ -934,7 +932,7 @@ export function createMcpServer(): McpServer {
       outputSchema: { data: offchainProposalsQueryResponseSchema },
       inputSchema: {
         dao: z.enum(DAO_OFFCHAIN),
-        params: offchainProposalsQueryParamsSchema,
+        params: offchainProposalsQueryParamsSchema.omit({ lean: true }),
       },
     },
     async ({ dao, params }) =>
@@ -950,7 +948,7 @@ export function createMcpServer(): McpServer {
       outputSchema: { data: offchainSearchProposalsQueryResponseSchema },
       inputSchema: {
         dao: z.enum(DAO_OFFCHAIN),
-        params: offchainSearchProposalsQueryParamsSchema,
+        params: offchainSearchProposalsQueryParamsSchema.omit({ lean: true }),
       },
     },
     async ({ dao, params }) =>
@@ -970,15 +968,10 @@ export function createMcpServer(): McpServer {
       inputSchema: {
         dao: z.enum(DAO_OFFCHAIN),
         id: z.string(),
-        params: offchainProposalByIdQueryParamsSchema.optional(),
       },
     },
-    async ({ dao, id, params }) =>
-      offchainProposalByIdHandler({
-        dao,
-        id,
-        params: { ...params, lean: true },
-      }),
+    async ({ dao, id }) =>
+      offchainProposalByIdHandler({ dao, id, params: { lean: true } }),
   );
 
   server.registerTool(


### PR DESCRIPTION
Two related fixes to how `lean` is handled on the proposals endpoints.

### 1. `apps/api` — apply the lean projection in SQL

Only `GET /proposals` used `proposalSelectFields(lean)`. `/proposals/search` and `/proposals/{id}` fetched description/calldatas/values/targets and dropped them in the mapper — correct response, zero DB/wire savings.

- `getProposalById`: `findFirst` → `select(proposalSelectFields(lean)).limit(1)`
- `searchProposals`: same projection
- Service: `searchProposals` no longer `Omit`s `lean`; `getProposalById` takes an optional `lean`
- Response shape unchanged (`variant: "full" | "lean"`), so no client/gateful contract change

### 2. `@anticapture/client` — MCP proposal tools honor `lean` instead of forcing it

The MCP tools hardcoded `{ ...params, lean: true }` while still advertising `lean` with `default: false`, so a caller asking for the full payload was silently overridden — the source of the "MCP returns lean regardless of what you ask for" reports. Full proposals were only reachable by bypassing MCP and calling REST.

Now the six proposal tools re-declare `lean` with a **`true` default** (MCP responses stay small by default) and pass the caller's value through, so `lean: false` returns the full proposal — calldatas, values, targets, description/body.

- `proposals`, `searchProposals`, `offchainProposals`, `offchainSearchProposals`: `params: …QueryParamsSchema.extend({ lean: <onchain|offchain>LeanParam })`, handler passes `params` straight through
- `proposal`, `offchainProposalById`: `params: z.object({ lean }).optional()`, defaulting to lean when `params` is absent
- Titles dropped the `(lean)` suffix; descriptions now say "omitted by default; pass `lean: false` for the full payload"
- `outputSchema` was already the `full | lean` union, so full responses validate

### Verification

- `pnpm api typecheck` ✅ · `pnpm api lint` ✅ · `pnpm --filter=@anticapture/api test` ✅ 1074 passed
- `tsc --noEmit` + eslint in `packages/anticapture-client` ✅
- Confirmed the param semantics against the generated schema: `lean` absent → `true`, `lean: false` → `false`, `lean: "false"` → `false`
- Added unit coverage that `lean` reaches the repo on both the search and by-id paths

Note: `pnpm client codegen` fails locally with "Config failed loading" on `dev` too (pre-existing, unrelated to this branch), which is why client typecheck was run via `tsc` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)