### PR TITLE
fix: emit satisfiable MCP output schemas

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,6 +1,7 @@
 ---
 "@anticapture/api": patch
 "@anticapture/gateful": patch
+"@anticapture/client": minor
 ---
 
 Flatten `TokenPropertiesResponse` so the MCP `token` tool can validate its own
@@ -18,3 +19,9 @@ extended), so it is no longer registered as its own component and
 `TokenPropertiesResponse` is emitted as a flat object. The wire payload is
 unchanged — same twelve fields, all still required. The generated SDK loses the
 now-unused `TokenProperties` type.
+
+The SDK is bumped alongside it: `src/index.ts` re-exports every generated
+model, so dropping the component removes the public `TokenProperties` type.
+`TokenPropertiesResponse` is unaffected — twelve fields, `price` included —
+and neither consumer in the org (dashboard, notification-system) references
+the removed type.

--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,20 @@
+---
+"@anticapture/api": patch
+"@anticapture/gateful": patch
+---
+
+Flatten `TokenPropertiesResponse` so the MCP `token` tool can validate its own
+responses.
+
+`TokenPropertiesResponseSchema` extended the registered `TokenProperties`
+component, which zod-openapi emits as `allOf: [$ref TokenProperties, { price }]`.
+The MCP server projects output schemas with `io: "output"`, where Zod marks every
+object `additionalProperties: false` — so the `{ price }` member rejected the
+eleven properties carried by the sibling `$ref` and every `token` call failed
+with `Invalid structured content returned by tool token`.
+
+`TokenProperties` was referenced nowhere else in the spec (it existed only to be
+extended), so it is no longer registered as its own component and
+`TokenPropertiesResponse` is emitted as a flat object. The wire payload is
+unchanged — same twelve fields, all still required. The generated SDK loses the
+now-unused `TokenProperties` type.

--- a/.changeset/wild-months-invent.md
+++ b/.changeset/wild-months-invent.md
@@ -1,0 +1,20 @@
+---
+"@anticapture/client": patch
+---
+
+Fix the MCP server advertising an unsatisfiable output schema for every tool
+whose response is a discriminated union (`proposal`, `proposals`,
+`searchProposals`).
+
+Kubb's default `discriminator: "strict"` re-asserts each `oneOf` branch's
+discriminator as an intersection — `OnchainFullProposal AND { variant: "full" }`
+— even though every branch already declares its own `variant` literal.
+`registerTool` projects output schemas with `io: "output"`, where Zod marks
+objects `additionalProperties: false`, so the `allOf` member that declares only
+`variant` rejects the other 20+ real properties. Neither variant could validate,
+and every call failed client-side with `RuntimeError: Invalid structured content
+returned by tool proposal` — the data was always correct, only the advertised
+schema was impossible.
+
+Switching to `discriminator: "inherit"` emits a plain union of the mapped
+branches, which projects to a satisfiable `anyOf`.

--- a/apps/api/src/mappers/token/index.ts
+++ b/apps/api/src/mappers/token/index.ts
@@ -39,33 +39,37 @@ export type TokenHistoricalPriceResponse = z.infer<
   typeof TokenHistoricalPriceResponse
 >;
 
-export const TokenPropertiesSchema = z
-  .object({
-    id: z.string(),
-    name: z.string().nullable(),
-    decimals: z.number().int().openapi({
-      description: "Token decimals.",
-      example: 18,
-      type: "integer",
-    }),
-    totalSupply: z.string().openapi({ format: "bigint" }),
-    delegatedSupply: z.string().openapi({ format: "bigint" }),
-    cexSupply: z.string().openapi({ format: "bigint" }),
-    dexSupply: z.string().openapi({ format: "bigint" }),
-    lendingSupply: z.string().openapi({ format: "bigint" }),
-    circulatingSupply: z.string().openapi({ format: "bigint" }),
-    nonCirculatingSupply: z.string().openapi({ format: "bigint" }),
-    treasury: z.string().openapi({ format: "bigint" }),
-  })
-  .openapi("TokenProperties", {
-    description:
-      "Core token supply and treasury attributes for the active DAO token.",
-  });
+export const TokenPropertiesSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  decimals: z.number().int().openapi({
+    description: "Token decimals.",
+    example: 18,
+    type: "integer",
+  }),
+  totalSupply: z.string().openapi({ format: "bigint" }),
+  delegatedSupply: z.string().openapi({ format: "bigint" }),
+  cexSupply: z.string().openapi({ format: "bigint" }),
+  dexSupply: z.string().openapi({ format: "bigint" }),
+  lendingSupply: z.string().openapi({ format: "bigint" }),
+  circulatingSupply: z.string().openapi({ format: "bigint" }),
+  nonCirculatingSupply: z.string().openapi({ format: "bigint" }),
+  treasury: z.string().openapi({ format: "bigint" }),
+});
 
+// Deliberately NOT registered as its own OpenAPI component. Registering it made
+// `TokenPropertiesResponse` emit `allOf: [$ref TokenProperties, { price }]`, and
+// the MCP server projects output schemas with `io: "output"`, where Zod marks
+// every object `additionalProperties: false`. The `{ price }` member then
+// rejects the eleven properties carried by the sibling `$ref`, so no response
+// could satisfy the schema and the `token` tool failed every call with
+// "Invalid structured content". Nothing else referenced the component — it
+// existed only to be extended — so inlining it costs no expressiveness.
 export const TokenPropertiesResponseSchema = TokenPropertiesSchema.extend({
   price: z.string(),
 }).openapi("TokenPropertiesResponse", {
-  description: "Token properties enriched with the current token price.",
+  description:
+    "Core token supply and treasury attributes for the active DAO token, enriched with the current token price.",
 });
 
 export const TokenDistributionComparisonQuerySchema = z

--- a/infra/mcp-server/README.md
+++ b/infra/mcp-server/README.md
@@ -1,0 +1,26 @@
+# mcp-server
+
+Serves `@anticapture/client`'s generated MCP tools over HTTP.
+
+## The spec is baked at build time
+
+`Dockerfile` runs `pnpm --filter @anticapture/client codegen`, and that codegen
+fetches the OpenAPI document from a **running** Gateful
+(`src/gateful-openapi-spec.ts`) — the preview environment's own Gateful in a PR,
+`ANTICAPTURE_API_URL` on dev/production. The tool schemas are therefore frozen
+into the image at build time, not read at boot.
+
+Railway builds this service and `gateful` in parallel on the same commit, so a
+commit that changes the API contract produces an MCP image built against the
+**previous** Gateful. The symptom is a tool whose advertised schema does not
+match what the API now returns, with nothing wrong in the diff.
+
+When a change touches the spec, rebuild this service once more after Gateful is
+live. An empty commit will not do it — `watchPatterns` in `railway.json` filter
+on changed paths, and Railway marks a no-file commit `SKIPPED`. Touch something
+under one of the watched paths, or redeploy from the dashboard with a rebuild
+(the API's plain "redeploy" reuses the existing image, which is precisely the
+stale artifact).
+
+Making this ordering explicit — or having the server fetch its spec at boot
+instead of at build — would remove the hazard.

--- a/infra/mcp-server/README.md
+++ b/infra/mcp-server/README.md
@@ -2,25 +2,41 @@
 
 Serves `@anticapture/client`'s generated MCP tools over HTTP.
 
-## The spec is baked at build time
+## The OpenAPI spec is a hidden input to a cached build layer
 
 `Dockerfile` runs `pnpm --filter @anticapture/client codegen`, and that codegen
-fetches the OpenAPI document from a **running** Gateful
+fetches the OpenAPI document over the network from a **running** Gateful
 (`src/gateful-openapi-spec.ts`) — the preview environment's own Gateful in a PR,
-`ANTICAPTURE_API_URL` on dev/production. The tool schemas are therefore frozen
-into the image at build time, not read at boot.
+`ANTICAPTURE_API_URL` on dev/production. The tool schemas are frozen into the
+image at build time, not read at boot.
 
-Railway builds this service and `gateful` in parallel on the same commit, so a
-commit that changes the API contract produces an MCP image built against the
-**previous** Gateful. The symptom is a tool whose advertised schema does not
-match what the API now returns, with nothing wrong in the diff.
+BuildKit cannot see that input. The cache key for
 
-When a change touches the spec, rebuild this service once more after Gateful is
-live. An empty commit will not do it — `watchPatterns` in `railway.json` filter
-on changed paths, and Railway marks a no-file commit `SKIPPED`. Touch something
-under one of the watched paths, or redeploy from the dashboard with a rebuild
-(the API's plain "redeploy" reuses the existing image, which is precisely the
-stale artifact).
+```
+RUN pnpm --filter @anticapture/client codegen && pnpm --filter @anticapture/client build
+```
 
-Making this ordering explicit — or having the server fetch its spec at boot
-instead of at build — would remove the hazard.
+covers only the pruned `@anticapture/client` workspace and the lockfile. A change
+to `apps/api` alters the spec but touches neither, so the layer is **reused** and
+the image ships tool schemas generated against an older contract. The symptom is
+an MCP tool whose advertised schema does not match what the API returns, with
+nothing in the diff to explain it.
+
+Observed on this PR: `apps/api` flattened `TokenPropertiesResponse`, Gateful
+served the new shape immediately, and three consecutive MCP deploys kept
+advertising the old one — the build log shows
+`[installer 8/8] RUN pnpm … codegen … cached: true` every time.
+
+What does **not** clear it:
+
+- an empty commit — `watchPatterns` in `railway.json` filter on changed paths, so
+  Railway marks a no-file commit `SKIPPED`;
+- touching a file outside the pruned client workspace (this README, for one);
+- the API's plain redeploy, which reuses the existing image by design.
+
+What does: a no-cache rebuild, or any change inside
+`packages/anticapture-client/**`.
+
+The durable fixes are to make the spec a visible input (`ADD <spec-url>` before
+the codegen step, so BuildKit hashes the fetched document) or to resolve the spec
+at container start instead of at build. Neither is done here.

--- a/infra/mcp-server/railway.json
+++ b/infra/mcp-server/railway.json
@@ -12,18 +12,5 @@
   },
   "deploy": {
     "healthcheckPath": "/health"
-  },
-  "environments": {
-    "pr": {
-      "build": {
-        "builder": "DOCKERFILE",
-        "dockerfilePath": "infra/noop/Dockerfile"
-      },
-      "deploy": {
-        "startCommand": "echo 'NOOP'",
-        "healthcheckPath": null,
-        "preDeployCommand": null
-      }
-    }
   }
 }

--- a/packages/anticapture-client/kubb.config.ts
+++ b/packages/anticapture-client/kubb.config.ts
@@ -60,6 +60,17 @@ export default defineConfig(({ watch }) => ({
   plugins: [
     pluginOas({
       collisionDetection: false,
+      // `strict` (the default) re-asserts each `oneOf` branch's discriminator as
+      // an intersection: `OnchainFullProposal AND { variant: "full" }`. That is
+      // redundant — every branch already declares its own `variant` literal —
+      // and it is fatal for the MCP server. `registerTool` projects the output
+      // schema with `io: "output"`, where Zod marks every object
+      // `additionalProperties: false`; an `allOf` member that declares only
+      // `variant` then rejects the other 20+ real properties, so no response of
+      // either variant can validate and the tool fails with "Invalid structured
+      // content" on every call. `inherit` emits a plain union of the mapped
+      // branches, which projects to a satisfiable `anyOf`.
+      discriminator: "inherit",
     }),
     pluginTs(pluginTsOptions),
     pluginClient({


### PR DESCRIPTION
## What

Two one-place fixes for the same class of defect — an MCP `outputSchema` that no response can satisfy.

1. `packages/anticapture-client/kubb.config.ts` — `discriminator: "inherit"` on `pluginOas`. Fixes `proposal`, `proposals`, `searchProposals`.
2. `apps/api/src/mappers/token/index.ts` — stop registering `TokenProperties` as its own component so `TokenPropertiesResponse` is emitted flat. Fixes `token`.

## Why

Four tools failed on **every** call:

```
MCP call failed: RuntimeError: Invalid structured content returned by tool proposal:
{'id': '603', 'daoId': 'COMP', 'txHash': '0xbcf35d76…', …}
```

The data was always correct and complete. The advertised schema was impossible.

`registerTool` projects output schemas with `io: "output"` (`@modelcontextprotocol/sdk`, `zod-json-schema-compat.ts`), where Zod marks every object `additionalProperties: false`. `additionalProperties` only sees `properties` in its **own** schema object — so any `allOf` member that declares a subset of the fields rejects all the rest, and the composition becomes unsatisfiable. Input schemas are unaffected: they project with `io: "input"`, which emits no `additionalProperties`.

Both fixes remove an `allOf` that never needed to exist.

**Unions.** Kubb's default `discriminator: "strict"` re-asserts each `oneOf` branch's discriminator as an intersection, though every branch already declares its own `variant` literal:

```ts
z.union([
  z.lazy(() => onchainFullProposalSchema).and(z.object({ variant: z.literal("full") })),
  z.lazy(() => onchainLeanProposalSchema).and(z.object({ variant: z.literal("lean") })),
])
```

```
branch 0: allOf[0] 25 props, addProps=false, variant ['full']
          allOf[1]  1 prop  (variant), addProps=false   ← rejects the other 25
branch 1: allOf[0] 21 props, addProps=false, variant ['lean']
          allOf[1]  1 prop  (variant), addProps=false
```

A `lean` response failed the branch demanding `full`; a `full` response was rejected as `additionalProperties` by the branch demanding `lean`. `inherit` emits a plain union of the mapped branches → satisfiable `anyOf`.

The OpenAPI spec was correct all along (`oneOf` + `discriminator.mapping`), and so is the Zod source (`onchainProposals.ts:181`, a proper `discriminatedUnion`). Only the codegen projection was wrong.

**Token.** `TokenPropertiesResponseSchema` extended the registered `TokenProperties` component, which zod-openapi emits as `allOf: [$ref TokenProperties, { price }]` — same strict-object collision. `TokenProperties` was referenced nowhere else in the spec (it existed only to be extended), so it is no longer registered on its own. The wire payload is unchanged: twelve fields, all still required. The generated SDK loses the now-unused `TokenProperties` type.

## Verification

**Against the PR preview** (`mcp-anticapture-pr-2156.up.railway.app`), before the token commit:

```
tools: 56 | unsatisfiable outputSchema: 1  (was 4)
proposal   lean=true   variant=lean  errors=0
proposal   lean=false  variant=full  errors=0
proposals                            errors=0
searchProposals                      errors=0
token                                errors=2   ← fixed by the second commit
```

The full `COMP/603` payload is genuinely reviewable, not just schema-valid — `targets` n=2 (Arbitrum Delayed Inbox), `values` n=2, `calldatas` n=2 (`0x679b6ded`, `createRetryableTicket`), 1549-byte description.

**Token fix**, by rendering the OpenAPI document locally:

| | before | after |
|---|---|---|
| `TokenPropertiesResponse` | `allOf: [$ref, {price}]` | `type: object`, 12 properties, 12 required, no `allOf` |
| components emitted | `TokenPropertiesResponse`, `TokenProperties` | `TokenPropertiesResponse` |

**Checks:** `pnpm client typecheck`, `pnpm client lint`, `pnpm api typecheck`, `pnpm api lint` all pass; `pnpm api test:unit` 789/789.

`packages/anticapture-client/generated/` is gitignored, so the regenerated output isn't in the diff — it follows from the next build.

## Open question for review

`3bc6430` (not mine) drops the `environments.pr` noop override from `infra/mcp-server/railway.json`, which is what allowed this preview to deploy a real MCP server. Merging it as-is makes **every** PR preview build and run the MCP server instead of a noop. Intended, or should it be reverted before merge?

## Impact

Found when an unattended calldata-review agent hit the RuntimeError on `proposal` and re-escalated every 15 minutes for five days. Any MCP client that enforces `outputSchema` sees these tools as permanently broken; clients that skip validation never noticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
