### PR TITLE
feat(relayer): webhook receiver for automatic queue/execute (DEV-1158)

### DIFF
--- a/.changeset/relayer-webhook-receiver.md
+++ b/.changeset/relayer-webhook-receiver.md
@@ -2,9 +2,12 @@
 "@anticapture/relayer": minor
 ---
 
-Add POST /relay/webhook, a private-network receiver for notification-system
-events. When the body carries `metadata.proposalId`, the relayer reads the
+Add POST /internal/webhook, a receiver for notification-system events. The
+route lives under /internal/ so gateful's /:dao/relay/\* proxy cannot reach
+it — only Railway's private network can. When the body carries
+`metadata.proposalId` for this relayer's own DAO, the relayer reads the
 proposal's on-chain state and sponsors queue() (Succeeded) or execute()
-(Queued, eta passed) through the existing enactment service. The route is not
-part of the public OpenAPI spec. The server now binds to `::` so Railway
-private networking can reach it.
+(Queued, eta passed) through the existing enactment service; events for
+other DAOs (`metadata.daoId`) are ignored. The route is not part of the
+public OpenAPI spec. The server now binds to `::` so Railway private
+networking can reach it.

--- a/.changeset/relayer-webhook-receiver.md
+++ b/.changeset/relayer-webhook-receiver.md
@@ -1,0 +1,10 @@
+---
+"@anticapture/relayer": minor
+---
+
+Add POST /relay/webhook, a private-network receiver for notification-system
+events. When the body carries `metadata.proposalId`, the relayer reads the
+proposal's on-chain state and sponsors queue() (Succeeded) or execute()
+(Queued, eta passed) through the existing enactment service. The route is not
+part of the public OpenAPI spec. The server now binds to `::` so Railway
+private networking can reach it.

--- a/apps/relayer/src/controllers/relay-webhook.test.ts
+++ b/apps/relayer/src/controllers/relay-webhook.test.ts
@@ -12,7 +12,10 @@ silentLogger.level = "silent";
 
 const TX_HASH = `0x${"ab".repeat(32)}` as const;
 
-function createApp(enact: (proposalId: string) => Promise<EnactOutcome>) {
+function createApp(
+  enact: (proposalId: string) => Promise<EnactOutcome>,
+  extraOptions: { daoId?: string } = {},
+) {
   const app = new Hono();
   const calls: string[] = [];
   const outcomes: WebhookOutcome[] = [];
@@ -24,13 +27,17 @@ function createApp(enact: (proposalId: string) => Promise<EnactOutcome>) {
         return enact(id);
       },
     },
-    { onOutcome: (o) => outcomes.push(o), logger: silentLogger },
+    {
+      onOutcome: (o) => outcomes.push(o),
+      logger: silentLogger,
+      ...extraOptions,
+    },
   );
   return { app, calls, outcomes };
 }
 
 const post = (app: Hono, body: unknown) =>
-  app.request("/relay/webhook", {
+  app.request("/internal/webhook", {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
@@ -46,7 +53,7 @@ const webhookBody = (metadata: Record<string, unknown>) => ({
   metadata,
 });
 
-describe("POST /relay/webhook", () => {
+describe("POST /internal/webhook", () => {
   it("accepts a proposal id and enacts it asynchronously", async () => {
     const { app, calls, outcomes } = createApp(async () => ({
       action: "execute",
@@ -107,12 +114,12 @@ describe("POST /relay/webhook", () => {
   });
 
   it("ignores a non-JSON body", async () => {
-    const { app, calls } = createApp(async () => ({
+    const { app, calls, outcomes } = createApp(async () => ({
       action: "skipped",
       state: "Executed",
     }));
 
-    const res = await app.request("/relay/webhook", {
+    const res = await app.request("/internal/webhook", {
       method: "POST",
       body: "nope",
     });
@@ -120,6 +127,7 @@ describe("POST /relay/webhook", () => {
     expect(res.status).toBe(202);
     await settle();
     expect(calls).toEqual([]);
+    expect(outcomes).toEqual(["ignored"]);
   });
 
   it("reports skipped when the proposal is not actionable", async () => {
@@ -150,5 +158,93 @@ describe("POST /relay/webhook", () => {
     expect(res.status).toBe(202);
     await settle();
     expect(outcomes).toEqual(["failed"]);
+  });
+
+  it("reports failed on TRANSACTION_REVERTED (gas was spent on a mined revert)", async () => {
+    const { app, outcomes } = createApp(async () => {
+      throw Errors.TRANSACTION_REVERTED(TX_HASH);
+    });
+    const res = await post(app, webhookBody({ proposalId: "42" }));
+    expect(res.status).toBe(202);
+    await settle();
+    expect(outcomes).toEqual(["failed"]);
+  });
+
+  it.each([
+    ["PROPOSAL_NOT_FOUND (404)", () => Errors.PROPOSAL_NOT_FOUND("42")],
+    ["RELAYER_LOW_BALANCE (503)", () => Errors.RELAYER_LOW_BALANCE()],
+  ])("reports failed on %s", async (_name, makeError) => {
+    const { app, outcomes } = createApp(async () => {
+      throw makeError();
+    });
+    const res = await post(app, webhookBody({ proposalId: "42" }));
+    expect(res.status).toBe(202);
+    await settle();
+    expect(outcomes).toEqual(["failed"]);
+  });
+
+  it("returns 202 before enact settles", async () => {
+    let resolveEnact: (value: EnactOutcome) => void;
+    const enacted = new Promise<EnactOutcome>((resolve) => {
+      resolveEnact = resolve;
+    });
+    const { app, outcomes } = createApp(() => enacted);
+
+    const res = await post(app, webhookBody({ proposalId: "42" }));
+
+    expect(res.status).toBe(202);
+    expect(outcomes).toEqual([]);
+
+    resolveEnact!({ action: "execute", txHash: TX_HASH });
+    await settle();
+    expect(outcomes).toEqual(["executed"]);
+  });
+
+  it("ignores events for another DAO", async () => {
+    const { app, calls, outcomes } = createApp(
+      async () => ({ action: "execute", txHash: TX_HASH }),
+      { daoId: "ENS" },
+    );
+
+    const res = await post(
+      app,
+      webhookBody({ proposalId: "42", daoId: "UNI" }),
+    );
+
+    expect(res.status).toBe(202);
+    await settle();
+    expect(calls).toEqual([]);
+    expect(outcomes).toEqual(["ignored"]);
+  });
+
+  it("accepts a matching DAO regardless of case", async () => {
+    const { app, calls, outcomes } = createApp(
+      async () => ({ action: "execute", txHash: TX_HASH }),
+      { daoId: "ENS" },
+    );
+
+    await post(app, webhookBody({ proposalId: "42", daoId: "ens" }));
+
+    await settle();
+    expect(calls).toEqual(["42"]);
+    expect(outcomes).toEqual(["executed"]);
+  });
+
+  it("does not break when onOutcome throws", async () => {
+    const app = new Hono();
+    relayWebhook(
+      app,
+      { enact: async () => ({ action: "execute", txHash: TX_HASH }) },
+      {
+        onOutcome: () => {
+          throw new Error("boom");
+        },
+        logger: silentLogger,
+      },
+    );
+
+    const res = await post(app, webhookBody({ proposalId: "42" }));
+    expect(res.status).toBe(202);
+    await settle();
   });
 });

--- a/apps/relayer/src/controllers/relay-webhook.test.ts
+++ b/apps/relayer/src/controllers/relay-webhook.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { OpenAPIHono as Hono } from "@hono/zod-openapi";
+import { createLogger } from "@anticapture/observability";
+
+import { Errors } from "@/errors";
+import type { EnactOutcome } from "@/services/proposals/proposal-enactment";
+
+import { relayWebhook, type WebhookOutcome } from "./relay-webhook";
+
+const silentLogger = createLogger("relay-webhook-test");
+silentLogger.level = "silent";
+
+const TX_HASH = `0x${"ab".repeat(32)}` as const;
+
+function createApp(enact: (proposalId: string) => Promise<EnactOutcome>) {
+  const app = new Hono();
+  const calls: string[] = [];
+  const outcomes: WebhookOutcome[] = [];
+  relayWebhook(
+    app,
+    {
+      enact: async (id) => {
+        calls.push(id);
+        return enact(id);
+      },
+    },
+    { onOutcome: (o) => outcomes.push(o), logger: silentLogger },
+  );
+  return { app, calls, outcomes };
+}
+
+const post = (app: Hono, body: unknown) =>
+  app.request("/relay/webhook", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+// The route answers before enact() settles; give the microtask queue a turn.
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+const webhookBody = (metadata: Record<string, unknown>) => ({
+  event: "proposalExecutable",
+  message: "Proposal 42 on ENS is ready to execute",
+  timestamp: new Date().toISOString(),
+  metadata,
+});
+
+describe("POST /relay/webhook", () => {
+  it("accepts a proposal id and enacts it asynchronously", async () => {
+    const { app, calls, outcomes } = createApp(async () => ({
+      action: "execute",
+      txHash: TX_HASH,
+    }));
+
+    const res = await post(
+      app,
+      webhookBody({ proposalId: "42", status: "PENDING_EXECUTION" }),
+    );
+
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({ accepted: true });
+    await settle();
+    expect(calls).toEqual(["42"]);
+    expect(outcomes).toEqual(["executed"]);
+  });
+
+  it("reports queued when enact queued", async () => {
+    const { app, outcomes } = createApp(async () => ({
+      action: "queue",
+      txHash: TX_HASH,
+    }));
+    await post(app, webhookBody({ proposalId: "42" }));
+    await settle();
+    expect(outcomes).toEqual(["queued"]);
+  });
+
+  it("ignores events without a proposal id and never calls enact", async () => {
+    const { app, calls, outcomes } = createApp(async () => ({
+      action: "skipped",
+      state: "Executed",
+    }));
+
+    const res = await post(
+      app,
+      webhookBody({ triggerType: "newProposal", daoId: "ens" }),
+    );
+
+    expect(res.status).toBe(202);
+    await settle();
+    expect(calls).toEqual([]);
+    expect(outcomes).toEqual(["ignored"]);
+  });
+
+  it("ignores a malformed proposal id", async () => {
+    const { app, calls, outcomes } = createApp(async () => ({
+      action: "skipped",
+      state: "Executed",
+    }));
+
+    const res = await post(app, webhookBody({ proposalId: "not-a-number" }));
+
+    expect(res.status).toBe(202);
+    await settle();
+    expect(calls).toEqual([]);
+    expect(outcomes).toEqual(["ignored"]);
+  });
+
+  it("ignores a non-JSON body", async () => {
+    const { app, calls } = createApp(async () => ({
+      action: "skipped",
+      state: "Executed",
+    }));
+
+    const res = await app.request("/relay/webhook", {
+      method: "POST",
+      body: "nope",
+    });
+
+    expect(res.status).toBe(202);
+    await settle();
+    expect(calls).toEqual([]);
+  });
+
+  it("reports skipped when the proposal is not actionable", async () => {
+    const { app, outcomes } = createApp(async () => ({
+      action: "skipped",
+      state: "Executed",
+    }));
+    await post(app, webhookBody({ proposalId: "42" }));
+    await settle();
+    expect(outcomes).toEqual(["skipped"]);
+  });
+
+  it("reports skipped on a 409 from enact (timelock, simulation)", async () => {
+    const { app, outcomes } = createApp(async () => {
+      throw Errors.TIMELOCK_NOT_READY(1n);
+    });
+    const res = await post(app, webhookBody({ proposalId: "42" }));
+    expect(res.status).toBe(202);
+    await settle();
+    expect(outcomes).toEqual(["skipped"]);
+  });
+
+  it("reports failed on any other error and still answered 202", async () => {
+    const { app, outcomes } = createApp(async () => {
+      throw new Error("rpc down");
+    });
+    const res = await post(app, webhookBody({ proposalId: "42" }));
+    expect(res.status).toBe(202);
+    await settle();
+    expect(outcomes).toEqual(["failed"]);
+  });
+});

--- a/apps/relayer/src/controllers/relay-webhook.ts
+++ b/apps/relayer/src/controllers/relay-webhook.ts
@@ -59,10 +59,16 @@ export function relayWebhook(
     const parsed = RelayWebhookBodySchema.safeParse(
       await c.req.json().catch(() => null),
     );
-    const proposalId = parsed.success
-      ? parsed.data.metadata?.proposalId
-      : undefined;
 
+    if (!parsed.success) {
+      report("ignored", {
+        reason: "body did not match the webhook envelope",
+        issues: parsed.error.issues.map((issue) => issue.path.join(".")),
+      });
+      return c.json({ accepted: true }, 202);
+    }
+
+    const proposalId = parsed.data.metadata?.proposalId;
     if (proposalId === undefined) {
       report("ignored", { reason: "no proposalId in metadata" });
       return c.json({ accepted: true }, 202);

--- a/apps/relayer/src/controllers/relay-webhook.ts
+++ b/apps/relayer/src/controllers/relay-webhook.ts
@@ -26,6 +26,8 @@ export interface RelayWebhookOptions {
   /** Called once per webhook with the final outcome; index.ts feeds a Prometheus counter. */
   onOutcome?: (outcome: WebhookOutcome) => void;
   logger?: Logger;
+  /** DAO this relayer serves. Events whose metadata.daoId doesn't match (case-insensitive) are ignored. */
+  daoId?: string;
 }
 
 /**
@@ -64,6 +66,19 @@ export function relayWebhook(
       report("ignored", {
         reason: "body did not match the webhook envelope",
         issues: parsed.error.issues.map((issue) => issue.path.join(".")),
+      });
+      return c.json({ accepted: true }, 202);
+    }
+
+    const eventDaoId = parsed.data.metadata?.daoId;
+    if (
+      options.daoId !== undefined &&
+      typeof eventDaoId === "string" &&
+      eventDaoId.toLowerCase() !== options.daoId.toLowerCase()
+    ) {
+      report("ignored", {
+        reason: "event for another DAO",
+        daoId: eventDaoId,
       });
       return c.json({ accepted: true }, 202);
     }

--- a/apps/relayer/src/controllers/relay-webhook.ts
+++ b/apps/relayer/src/controllers/relay-webhook.ts
@@ -31,9 +31,10 @@ export interface RelayWebhookOptions {
 /**
  * Receiver for notification-system webhooks (ProposalFinished / ProposalExecutable).
  *
- * Plain route on purpose: it is reached over Railway's private network only, so
- * it carries no auth, and it is kept out of the OpenAPI spec so the generated
- * SDK does not grow a method nobody outside the relayer should call.
+ * Served under /internal/ so gateful's /:dao/relay/* proxy cannot reach it;
+ * only Railway private networking can. It carries no auth, and it is kept
+ * out of the OpenAPI spec so the generated SDK does not grow a method nobody
+ * outside the relayer should call.
  *
  * Always answers 202 right away: the sender times out at 30s and a mainnet
  * receipt wait can take longer. The outcome goes to logs and metrics instead.
@@ -54,7 +55,7 @@ export function relayWebhook(
     }
   };
 
-  app.post("/relay/webhook", async (c) => {
+  app.post("/internal/webhook", async (c) => {
     const parsed = RelayWebhookBodySchema.safeParse(
       await c.req.json().catch(() => null),
     );

--- a/apps/relayer/src/controllers/relay-webhook.ts
+++ b/apps/relayer/src/controllers/relay-webhook.ts
@@ -12,6 +12,16 @@ export type WebhookOutcome =
   | "ignored"
   | "failed";
 
+// Only these RelayError codes mean "nothing to do right now" (not ready,
+// would revert): expected in normal operation, not failures. Everything
+// else — including TRANSACTION_REVERTED (gas was spent on a mined revert),
+// other RelayErrors (404/503), and plain errors — is a failure.
+const SKIPPED_CODES = new Set([
+  "INVALID_PROPOSAL_STATE",
+  "TIMELOCK_NOT_READY",
+  "SIMULATION_FAILED",
+]);
+
 export interface RelayWebhookOptions {
   /** Called once per webhook with the final outcome; index.ts feeds a Prometheus counter. */
   onOutcome?: (outcome: WebhookOutcome) => void;
@@ -35,9 +45,13 @@ export function relayWebhook(
 ) {
   const logger = options.logger ?? createLogger("relayer-webhook");
   const report = (outcome: WebhookOutcome, fields: Record<string, unknown>) => {
-    options.onOutcome?.(outcome);
-    const level = outcome === "failed" ? "error" : "info";
-    logger[level]({ outcome, ...fields }, `webhook ${outcome}`);
+    try {
+      options.onOutcome?.(outcome);
+      const level = outcome === "failed" ? "error" : "info";
+      logger[level]({ outcome, ...fields }, `webhook ${outcome}`);
+    } catch {
+      // reporting must never break the webhook
+    }
   };
 
   app.post("/relay/webhook", async (c) => {
@@ -70,13 +84,17 @@ export function relayWebhook(
         }
       })
       .catch((err: unknown) => {
-        // 409s are "nothing to do right now" (not ready, already done, would
-        // revert): expected in normal operation, not failures.
-        if (err instanceof RelayError && err.status === 409) {
+        if (err instanceof RelayError && SKIPPED_CODES.has(err.code)) {
           report("skipped", {
             proposalId: proposalId.toString(),
             code: err.code,
             reason: err.message,
+          });
+        } else if (err instanceof RelayError) {
+          report("failed", {
+            proposalId: proposalId.toString(),
+            code: err.code,
+            err,
           });
         } else {
           report("failed", { proposalId: proposalId.toString(), err });

--- a/apps/relayer/src/controllers/relay-webhook.ts
+++ b/apps/relayer/src/controllers/relay-webhook.ts
@@ -1,0 +1,88 @@
+import type { OpenAPIHono as Hono } from "@hono/zod-openapi";
+import { createLogger, type Logger } from "@anticapture/observability";
+
+import { RelayError } from "@/errors";
+import { RelayWebhookBodySchema } from "@/schemas/relay-webhook";
+import type { ProposalEnactmentService } from "@/services/proposals/proposal-enactment";
+
+export type WebhookOutcome =
+  | "queued"
+  | "executed"
+  | "skipped"
+  | "ignored"
+  | "failed";
+
+export interface RelayWebhookOptions {
+  /** Called once per webhook with the final outcome; index.ts feeds a Prometheus counter. */
+  onOutcome?: (outcome: WebhookOutcome) => void;
+  logger?: Logger;
+}
+
+/**
+ * Receiver for notification-system webhooks (ProposalFinished / ProposalExecutable).
+ *
+ * Plain route on purpose: it is reached over Railway's private network only, so
+ * it carries no auth, and it is kept out of the OpenAPI spec so the generated
+ * SDK does not grow a method nobody outside the relayer should call.
+ *
+ * Always answers 202 right away: the sender times out at 30s and a mainnet
+ * receipt wait can take longer. The outcome goes to logs and metrics instead.
+ */
+export function relayWebhook(
+  app: Hono,
+  enactment: Pick<ProposalEnactmentService, "enact">,
+  options: RelayWebhookOptions = {},
+) {
+  const logger = options.logger ?? createLogger("relayer-webhook");
+  const report = (outcome: WebhookOutcome, fields: Record<string, unknown>) => {
+    options.onOutcome?.(outcome);
+    const level = outcome === "failed" ? "error" : "info";
+    logger[level]({ outcome, ...fields }, `webhook ${outcome}`);
+  };
+
+  app.post("/relay/webhook", async (c) => {
+    const parsed = RelayWebhookBodySchema.safeParse(
+      await c.req.json().catch(() => null),
+    );
+    const proposalId = parsed.success
+      ? parsed.data.metadata?.proposalId
+      : undefined;
+
+    if (proposalId === undefined) {
+      report("ignored", { reason: "no proposalId in metadata" });
+      return c.json({ accepted: true }, 202);
+    }
+
+    // Fire-and-forget: the response must not wait for the broadcast.
+    void enactment
+      .enact(proposalId.toString())
+      .then((result) => {
+        if (result.action === "skipped") {
+          report("skipped", {
+            proposalId: proposalId.toString(),
+            state: result.state,
+          });
+        } else {
+          report(result.action === "queue" ? "queued" : "executed", {
+            proposalId: proposalId.toString(),
+            txHash: result.txHash,
+          });
+        }
+      })
+      .catch((err: unknown) => {
+        // 409s are "nothing to do right now" (not ready, already done, would
+        // revert): expected in normal operation, not failures.
+        if (err instanceof RelayError && err.status === 409) {
+          report("skipped", {
+            proposalId: proposalId.toString(),
+            code: err.code,
+            reason: err.message,
+          });
+        } else {
+          report("failed", { proposalId: proposalId.toString(), err });
+        }
+      });
+
+    return c.json({ accepted: true }, 202);
+  });
+}

--- a/apps/relayer/src/index.ts
+++ b/apps/relayer/src/index.ts
@@ -189,6 +189,7 @@ async function main() {
   relayProposal(app, proposalEnactment);
   relayWebhook(app, proposalEnactment, {
     onOutcome: (outcome) => webhookOutcomes.add(1, { outcome }),
+    daoId: env.DAO_NAME,
   });
   health(app);
   config(app, {

--- a/apps/relayer/src/index.ts
+++ b/apps/relayer/src/index.ts
@@ -19,6 +19,7 @@ import { rateLimit } from "@/controllers/rate-limit";
 import { relayDelegate } from "@/controllers/relay-delegate";
 import { relayProposal } from "@/controllers/relay-proposal";
 import { relayVote } from "@/controllers/relay-vote";
+import { relayWebhook } from "@/controllers/relay-webhook";
 import { env } from "@/env";
 import { RelayError } from "@/errors";
 import { createClient } from "redis";
@@ -34,9 +35,16 @@ import { AnticaptureProposalSource } from "@/services/proposals/proposal-source"
 import { RelayService } from "@/services/relay";
 import { SignatureVerifier } from "@/services/guards/signature-verifier";
 import { createLocalSigner } from "@/signer/local-signer";
-import { exporter } from "@/instrumentation";
+import { exporter, meterProvider } from "@/instrumentation";
 
 const logger = createLogger("anticapture-relayer");
+
+const webhookOutcomes = meterProvider
+  .getMeter("anticapture-relayer")
+  .createCounter("relayer_webhook_outcomes_total", {
+    description:
+      "Outcomes of notification-system webhooks received by the relayer",
+  });
 
 async function main() {
   const chain = mainnet;
@@ -160,26 +168,28 @@ async function main() {
     return c.json({ error: "Internal server error", code: "INTERNAL" }, 500);
   });
 
+  const proposalEnactment = wrapWithTracing(
+    new ProposalEnactmentService(
+      wrapWithTracing(new ViemGovernorGateway(publicClient, governorAddress)),
+      signer,
+      wrapWithTracing(
+        new AnticaptureProposalSource(
+          env.ANTICAPTURE_API_URL,
+          env.DAO_NAME,
+          env.ANTICAPTURE_API_KEY,
+        ),
+      ),
+      { minBalanceWei: BigInt(env.MIN_RELAYER_BALANCE_WEI) },
+    ),
+  );
+
   // --- Routes ---
   relayVote(app, relayService);
   relayDelegate(app, relayService);
-  relayProposal(
-    app,
-    wrapWithTracing(
-      new ProposalEnactmentService(
-        wrapWithTracing(new ViemGovernorGateway(publicClient, governorAddress)),
-        signer,
-        wrapWithTracing(
-          new AnticaptureProposalSource(
-            env.ANTICAPTURE_API_URL,
-            env.DAO_NAME,
-            env.ANTICAPTURE_API_KEY,
-          ),
-        ),
-        { minBalanceWei: BigInt(env.MIN_RELAYER_BALANCE_WEI) },
-      ),
-    ),
-  );
+  relayProposal(app, proposalEnactment);
+  relayWebhook(app, proposalEnactment, {
+    onOutcome: (outcome) => webhookOutcomes.add(1, { outcome }),
+  });
   health(app);
   config(app, {
     minVotingPower: env.MIN_VOTING_POWER,
@@ -217,7 +227,7 @@ async function main() {
     "Relayer starting",
   );
 
-  serve({ fetch: app.fetch, port: env.PORT });
+  serve({ fetch: app.fetch, port: env.PORT, hostname: "::" });
 }
 
 main().catch((err) => {

--- a/apps/relayer/src/schemas/relay-webhook.ts
+++ b/apps/relayer/src/schemas/relay-webhook.ts
@@ -1,0 +1,17 @@
+import { z } from "@hono/zod-openapi";
+
+import { DecimalUint256Schema } from "./evm-primitives";
+
+/**
+ * Envelope posted by notification-system's webhook channel. Only
+ * `metadata.proposalId` matters; everything else is accepted and ignored so
+ * events from other triggers (new proposal, vote cast, ...) are harmless.
+ */
+export const RelayWebhookBodySchema = z
+  .object({
+    metadata: z
+      .object({ proposalId: DecimalUint256Schema.optional() })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();

--- a/apps/relayer/src/schemas/relay-webhook.ts
+++ b/apps/relayer/src/schemas/relay-webhook.ts
@@ -10,7 +10,10 @@ import { DecimalUint256Schema } from "./evm-primitives";
 export const RelayWebhookBodySchema = z
   .object({
     metadata: z
-      .object({ proposalId: DecimalUint256Schema.optional() })
+      .object({
+        proposalId: DecimalUint256Schema.optional(),
+        daoId: z.string().optional(),
+      })
       .passthrough()
       .optional(),
   })

--- a/apps/relayer/src/services/proposals/proposal-enactment.test.ts
+++ b/apps/relayer/src/services/proposals/proposal-enactment.test.ts
@@ -568,3 +568,73 @@ describe("ProposalEnactmentService in-flight dedup", () => {
     await expectRelayError(executed, "INVALID_PROPOSAL_STATE", 409);
   });
 });
+
+describe("ProposalEnactmentService.enact", () => {
+  it("queues when the proposal is Succeeded", async () => {
+    const { service, simulated } = createService({
+      governor: { state: async () => ProposalState.Succeeded },
+    });
+
+    const outcome = await service.enact(PROPOSAL_ID.toString());
+
+    expect(outcome).toEqual({ action: "queue", txHash: TX_HASH });
+    expect(simulated).toEqual([{ functionName: "queue" }]);
+  });
+
+  it("executes when the proposal is Queued and the eta has passed", async () => {
+    const { service, simulated } = createService({
+      governor: {
+        state: async () => ProposalState.Queued,
+        proposalEta: async () => NOW - 1n,
+      },
+    });
+
+    const outcome = await service.enact(PROPOSAL_ID.toString());
+
+    expect(outcome).toEqual({ action: "execute", txHash: TX_HASH });
+    expect(simulated).toEqual([{ functionName: "execute" }]);
+  });
+
+  it("propagates TIMELOCK_NOT_READY when Queued but the eta is in the future", async () => {
+    const { service, sent } = createService({
+      governor: {
+        state: async () => ProposalState.Queued,
+        proposalEta: async () => NOW + 100n,
+      },
+    });
+
+    await expectRelayError(
+      service.enact(PROPOSAL_ID.toString()),
+      "TIMELOCK_NOT_READY",
+      409,
+    );
+    expect(sent).toEqual([]);
+  });
+
+  it.each([
+    ProposalState.Pending,
+    ProposalState.Active,
+    ProposalState.Canceled,
+    ProposalState.Defeated,
+    ProposalState.Expired,
+    ProposalState.Executed,
+  ])("skips without broadcasting when state is %s", async (state) => {
+    const { service, sent, simulated } = createService({
+      governor: { state: async () => state },
+    });
+
+    const outcome = await service.enact(PROPOSAL_ID.toString());
+
+    expect(outcome).toEqual({ action: "skipped", state: ProposalState[state] });
+    expect(sent).toEqual([]);
+    expect(simulated).toEqual([]);
+  });
+
+  it("throws PROPOSAL_NOT_FOUND for an unknown proposal", async () => {
+    const { service } = createService({
+      governor: { state: async () => null },
+    });
+
+    await expectRelayError(service.enact("999"), "PROPOSAL_NOT_FOUND", 404);
+  });
+});

--- a/apps/relayer/src/services/proposals/proposal-enactment.ts
+++ b/apps/relayer/src/services/proposals/proposal-enactment.ts
@@ -244,7 +244,7 @@ export class ProposalEnactmentService {
     } catch (err) {
       // The transaction is already broadcast, so a failed receipt poll only
       // leaves its status unknown. Rejecting here would release the in-flight
-      // lock through enact()'s error path and reopen the duplicate-broadcast
+      // lock through dispatch()'s error path and reopen the duplicate-broadcast
       // window, so report it as unsettled and let the settlement hold decide.
       this.logger.warn(
         { proposalId, action: functionName, txHash, err },

--- a/apps/relayer/src/services/proposals/proposal-enactment.ts
+++ b/apps/relayer/src/services/proposals/proposal-enactment.ts
@@ -28,6 +28,10 @@ export interface ProposalEnactmentConfig {
 
 type EnactmentAction = "queue" | "execute";
 
+export type EnactOutcome =
+  | { action: EnactmentAction; txHash: Hash }
+  | { action: "skipped"; state: string };
+
 // After an unsettled broadcast (receipt timeout or failed poll) the in-flight
 // lock is held through this many extra receipt waits before giving up, so a
 // transaction dropped from the mempool cannot lock its proposal out of
@@ -61,14 +65,36 @@ export class ProposalEnactmentService {
   ) {}
 
   async queue(proposalId: string): Promise<{ txHash: Hash }> {
-    return this.enact("queue", proposalId);
+    return this.dispatch("queue", proposalId);
   }
 
   async execute(proposalId: string): Promise<{ txHash: Hash }> {
-    return this.enact("execute", proposalId);
+    return this.dispatch("execute", proposalId);
   }
 
-  private enact(
+  /**
+   * Picks the lifecycle step from on-chain state and runs it: Succeeded →
+   * queue, Queued → execute, anything else is a no-op. Callers that only
+   * know a proposal id (the notification-system webhook) use this instead
+   * of choosing queue/execute themselves, so the payload is never trusted.
+   * queue()/execute() re-run their own guards, so a state change between
+   * the two reads still ends in a 409 rather than a wasted broadcast.
+   */
+  async enact(proposalId: string): Promise<EnactOutcome> {
+    const state = await this.governor.state(BigInt(proposalId));
+    if (state === null) {
+      throw Errors.PROPOSAL_NOT_FOUND(proposalId);
+    }
+    if (state === ProposalState.Succeeded) {
+      return { action: "queue", ...(await this.queue(proposalId)) };
+    }
+    if (state === ProposalState.Queued) {
+      return { action: "execute", ...(await this.execute(proposalId)) };
+    }
+    return { action: "skipped", state: ProposalState[state] };
+  }
+
+  private dispatch(
     action: EnactmentAction,
     proposalId: string,
   ): Promise<{ txHash: Hash }> {


### PR DESCRIPTION
## Context

[DEV-1158](https://app.clickup.com/t/86ak1zk6u): ENS proposals should be queued and executed without a human. [DEV-700](https://app.clickup.com/t/86ahgvag1) shipped `POST /relay/queue` and `POST /relay/execute`; nothing calls them. The notification-system now emits a webhook when a proposal succeeds (`ProposalFinished`) and when its timelock eta has passed (new `ProposalExecutable`, see companion PR [blockful/notification-system#273](https://github.com/blockful/notification-system/pull/273)). This PR makes the relayer receive those webhooks and act on them.

## What changed (`apps/relayer` only)

- **`ProposalEnactmentService.enact(proposalId)`**: reads on-chain `state()` and dispatches to the existing `queue()` (Succeeded) or `execute()` (Queued); anything else is `skipped`; unknown id → 404. All existing guards (state/eta re-check, `hashProposal` verification, balance, simulation, in-flight lock per action+proposal) are reused as-is. The pre-existing private lock wrapper was renamed `enact` → `dispatch` to free the name.
- **`POST /internal/webhook`**: plain Hono route (not in the OpenAPI spec, not in the SDK). Reads `metadata.proposalId` from the notification-system envelope, answers `202 { accepted: true }` immediately and runs `enact()` asynchronously. Outcomes are logged and counted in Prometheus `relayer_webhook_outcomes_total{outcome}`:
  - `queued` / `executed`: broadcast sent (`txHash` logged)
  - `skipped`: nothing to do (`INVALID_PROPOSAL_STATE`, `TIMELOCK_NOT_READY`, `SIMULATION_FAILED`), no gas
  - `ignored`: no `proposalId`, envelope mismatch, or `metadata.daoId` is another DAO (compared case-insensitively with `DAO_NAME`)
  - `failed`: everything else, including `TRANSACTION_REVERTED`, low balance, RPC errors (error level)
- **Server binds `::`** (dual-stack) so Railway private networking can reach it; IPv4 keeps working.
- `/relay/queue` and `/relay/execute` now share the same `ProposalEnactmentService` instance as the webhook, so the in-flight lock covers manual and automatic calls together. No behaviour change for those routes.
- Changeset: `@anticapture/relayer` minor.

## Why no auth, and why `/internal/`

The route is east-west traffic inside the `anticapture-infra` Railway project. It lives under `/internal/` because gateful proxies `/{dao}/relay/*` verbatim to this service; a `/relay/webhook` path would have been publicly reachable through the gateway. Nothing under `/internal/` is proxied, so the route is only reachable as `http://<relayer-service>.railway.internal:<PORT>/internal/webhook`. The payload is never trusted for anything but the proposal id; the chain decides whether there is anything to do, so the worst a caller can trigger is a legitimate queue/execute the DAO already voted for.

## Rollout

1. Deploy this and the notification-system PR to dev.
2. On the consumers service: set `WEBHOOK_ALLOWED_PRIVATE_HOSTS=<relayer-service>.railway.internal`, then `POST /webhooks { "url": "http://<relayer-service>.railway.internal:<PORT>/internal/webhook" }`. Store the returned secret. Registration subscribes all DAOs; deactivate the non-ENS ones for that URL (the relayer also ignores them by `daoId`).
3. Smoke on dev without gas: post the envelope with EP 6.34's id (`69304512515872868228453463730257567312488838925636819022683533220991373699419`, a dead Queued proposal) and expect `outcome=skipped code=SIMULATION_FAILED` in the logs.
4. Repeat on production.

Known limits (accepted in the spec): delivery is emit-once, so a webhook lost while the relayer is down or redeploying falls back to the manual dashboard button (DEV-1168); retries are DEV-1182. A proposal queued more than 1h after voting ended will hit `TIMELOCK_NOT_READY` once and needs the manual path.

## Tests

- Unit: `enact()` (10 cases: queue/execute/skipped states/404/timelock), route (15 cases: 202 before `enact` settles, outcome classification incl. `TRANSACTION_REVERTED`/404/503 → `failed`, ignored reasons, DAO filter, `onOutcome` throwing). `pnpm --filter @anticapture/relayer test`: 92/92. Typecheck, lint, build green.
- Local smoke on an anvil mainnet fork with the anvil test key: route, `::` bind and the counter verified (`ignored` and `failed` outcomes). The `skipped` leg could not be reached from the sandbox because the public API host's TLS certificate did not match; re-run step 3 above on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
