### PR TITLE
fix(gateful): forward the relayer's structured errors instead of a generic 500

### DIFF
--- a/.changeset/gateful-relayer-structured-errors.md
+++ b/.changeset/gateful-relayer-structured-errors.md
@@ -1,0 +1,6 @@
+---
+"@anticapture/gateful": patch
+---
+
+Forward the relayer's own error responses (e.g. `503 RELAYER_LOW_BALANCE`, `{ code, message }`) to clients instead of
+replacing them with a generic 500, and stop counting them as circuit-breaker failures: the relayer answered, it is not down.

--- a/apps/gateful/src/proxy/relayer.test.ts
+++ b/apps/gateful/src/proxy/relayer.test.ts
@@ -76,6 +76,46 @@ describe("relayer proxy route", () => {
     ]);
   });
 
+  it("passes a structured relayer error through and does not count it as a failure", async () => {
+    // The relayer answered 503 RELAYER_LOW_BALANCE on purpose: nothing was
+    // broadcast and the relayer is up. The client needs that code to offer
+    // the wallet fallback, and the breaker must not treat it as an outage.
+    const relayerBody = {
+      code: "RELAYER_LOW_BALANCE",
+      message: "Relayer wallet balance is too low to submit transactions",
+    };
+    const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(
+      async () =>
+        new Response(JSON.stringify(relayerBody), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    for (let i = 0; i < 6; i++) {
+      const res = await app.request("/uni/relay/queue", {
+        method: "POST",
+        body: JSON.stringify({ proposalId: "1" }),
+      });
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual(relayerBody);
+    }
+    expect(fetchSpy).toHaveBeenCalledTimes(6);
+    expect(registry.get("relayer:uni").state).toBe("CLOSED");
+  });
+
+  it("still treats a 5xx without a relayer error code as an upstream failure", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response("Bad Gateway", {
+        status: 502,
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+
+    const res = await app.request("/uni/relay/queue", { method: "POST" });
+    expect(res.status).toBe(500);
+  });
+
   it("should open the relayer circuit and short-circuit after repeated upstream failures", async () => {
     const fetchSpy = vi
       .spyOn(global, "fetch")

--- a/apps/gateful/src/proxy/relayer.test.ts
+++ b/apps/gateful/src/proxy/relayer.test.ts
@@ -104,6 +104,28 @@ describe("relayer proxy route", () => {
     expect(registry.get("relayer:uni").state).toBe("CLOSED");
   });
 
+  it("counts the relayer's own crash response (500 INTERNAL) as an upstream failure", async () => {
+    // The relayer's global error handler wraps unhandled exceptions with the
+    // error contract; a nonempty code alone must not exempt it.
+    const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: "Internal server error",
+            code: "INTERNAL",
+          }),
+          { status: 500, headers: { "content-type": "application/json" } },
+        ),
+    );
+
+    for (let i = 0; i < 5; i++) {
+      const res = await app.request("/uni/relay/queue", { method: "POST" });
+      expect(res.status).toBe(500);
+    }
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+    expect(registry.get("relayer:uni").state).toBe("OPEN");
+  });
+
   it("still treats a 5xx without a relayer error code as an upstream failure", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue(
       new Response("Bad Gateway", {

--- a/apps/gateful/src/proxy/relayer.ts
+++ b/apps/gateful/src/proxy/relayer.ts
@@ -8,11 +8,19 @@ import { stripAuthorization } from "./strip-authorization.js";
 const PROXY_TIMEOUT_MS = 30000;
 
 /**
+ * The relayer's global error handler wraps unhandled exceptions as
+ * `500 { code: "INTERNAL" }`. That is a crash wearing the error contract,
+ * not a deliberate answer, and must keep counting against the breaker.
+ */
+const RELAYER_CRASH_CODE = "INTERNAL";
+
+/**
  * A 5xx the relayer answered deliberately, with its own error contract
  * (`{ code, message }`, e.g. `503 RELAYER_LOW_BALANCE`). The relayer is up
  * and talking, so the response goes to the client verbatim and the circuit
- * breaker does not count it as a failure. A 5xx without a `code` is the
- * platform or a crash talking, not the relayer, and stays an upstream error.
+ * breaker does not count it as a failure. A 5xx without a `code`, or with
+ * the crash code, is the platform or a failure talking, not the relayer, and
+ * stays an upstream error.
  */
 async function isStructuredRelayerError(res: Response): Promise<boolean> {
   if (!res.headers.get("content-type")?.includes("application/json")) {
@@ -20,7 +28,11 @@ async function isStructuredRelayerError(res: Response): Promise<boolean> {
   }
   try {
     const body = (await res.clone().json()) as { code?: unknown };
-    return typeof body?.code === "string" && body.code.length > 0;
+    return (
+      typeof body?.code === "string" &&
+      body.code.length > 0 &&
+      body.code !== RELAYER_CRASH_CODE
+    );
   } catch {
     return false;
   }

--- a/apps/gateful/src/proxy/relayer.ts
+++ b/apps/gateful/src/proxy/relayer.ts
@@ -8,6 +8,25 @@ import { stripAuthorization } from "./strip-authorization.js";
 const PROXY_TIMEOUT_MS = 30000;
 
 /**
+ * A 5xx the relayer answered deliberately, with its own error contract
+ * (`{ code, message }`, e.g. `503 RELAYER_LOW_BALANCE`). The relayer is up
+ * and talking, so the response goes to the client verbatim and the circuit
+ * breaker does not count it as a failure. A 5xx without a `code` is the
+ * platform or a crash talking, not the relayer, and stays an upstream error.
+ */
+async function isStructuredRelayerError(res: Response): Promise<boolean> {
+  if (!res.headers.get("content-type")?.includes("application/json")) {
+    return false;
+  }
+  try {
+    const body = (await res.clone().json()) as { code?: unknown };
+    return typeof body?.code === "string" && body.code.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Forwards /:dao/relay/*, /:dao/config and /:dao/rate-limit/* to the
  * per-DAO relayer configured via DAO_RELAYER_<NAME>. Must be registered
  * before the catch-all DAO API proxy so relay traffic isn't swallowed by it.
@@ -43,7 +62,7 @@ export function relayerProxy(
         headers: stripAuthorization(c.req.raw.headers),
         signal: AbortSignal.timeout(PROXY_TIMEOUT_MS),
       });
-      if (res.status >= 500) {
+      if (res.status >= 500 && !(await isStructuredRelayerError(res))) {
         throw new Error(`Upstream relayer:${dao} returned ${res.status}`);
       }
       return res;


### PR DESCRIPTION
## Contexto

Comentário do Codex na #2155 (deferido como DEV-1184): quando o relayer perde saldo entre o probe de `/relay/balance` e o `POST /relay/queue|execute`, ele responde `503 { code: "RELAYER_LOW_BALANCE" }` **antes de transmitir qualquer transação**. O proxy do Gateful lançava erro para todo 5xx e o `app.onError` devolvia `500 Internal server error`, então o dashboard nunca via o código, classificava como `unknown` e segurava o fallback pela carteira mesmo sem nada ter sido enviado. O mesmo vale para o voto e a delegação gasless.

## Mudança

- `apps/gateful/src/proxy/relayer.ts`: um 5xx cujo corpo JSON traz o `code` do contrato de erro do relayer passa **verbatim** para o cliente e **não conta como falha** no circuit breaker (o relayer respondeu; ele não está fora). Um 5xx sem `code` (502 da plataforma, crash, timeout) continua sendo tratado como falha do upstream.
- Testes: estrutura 503 repassada 6× sem abrir o circuito; 502 sem código continua virando 500.
- Changeset `@anticapture/gateful` patch.

## Verificação

- `tsc --noEmit`, `eslint`, `vitest run src/proxy/relayer.test.ts` (6/6) no Gateful.

Par com a #2155, onde o modal passa a oferecer "Use my wallet anyway" também no estado `unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
